### PR TITLE
MINOR Fix version bump keyword detection and add PAT validation

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -53,14 +53,14 @@ jobs:
           echo "Commit message: $COMMIT_MSG"
 
           # Determine version bump based on commit message
-          # Use stricter patterns to avoid false positives (e.g., "Fix major bug" should not trigger major bump)
-          # Only recognize explicit markers: [major], [minor], or BREAKING CHANGE (case-insensitive)
-          if echo "$COMMIT_MSG" | grep -qiE '\[major\]|^BREAKING CHANGE:'; then
+          # Recognize: [major]/[MAJOR], [minor]/[MINOR], MAJOR/major at start, MINOR/minor at start, or BREAKING CHANGE
+          # Case-insensitive to support various styles
+          if echo "$COMMIT_MSG" | grep -qiE '\[major\]|^major\b|^BREAKING CHANGE:'; then
             MAJOR=$((MAJOR + 1))
             MINOR=0
             PATCH=0
             BUMP_TYPE="major"
-          elif echo "$COMMIT_MSG" | grep -qiE '\[minor\]'; then
+          elif echo "$COMMIT_MSG" | grep -qiE '\[minor\]|^minor\b'; then
             MINOR=$((MINOR + 1))
             PATCH=0
             BUMP_TYPE="minor"
@@ -81,8 +81,16 @@ jobs:
       - name: Create and push tag
         env:
           # Use PAT to trigger deploy workflow (default GITHUB_TOKEN doesn't trigger workflows)
+          # PAT must have Workflows: Read and write permission
           GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |
+          # Verify PAT is set (will show empty if missing, but won't expose the token)
+          if [ -z "$GITHUB_TOKEN" ]; then
+            echo "ERROR: PAT_TOKEN secret is not set. Deploy workflow will not trigger."
+            echo "Please set PAT_TOKEN in repository secrets with Workflows: Read and write permission."
+            exit 1
+          fi
+
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag -a "${{ steps.parse_version.outputs.new_tag }}" -m "Auto-tagged version ${{ steps.parse_version.outputs.new_version }} (${{ steps.parse_version.outputs.bump_type }} bump)"


### PR DESCRIPTION
### What Changed

**Support MINOR/MAJOR at start of commit message:**
- Updated regex to match `MINOR` or `MAJOR` as first word (not just `[minor]`/`[major]` with brackets)
- Pattern now matches: `[minor]`, `MINOR`, `minor`, at start of message
- Prevents false positives like "Fix major bug" (major must be at start)
- Uses word boundary check to avoid matching "minority"

**Add PAT token validation:**
- Workflow now fails immediately if `PAT_TOKEN` secret is missing
- Clear error message explains that Workflows permission is required
- Prevents silent failures where tags get created but deploy doesn't trigger
