### PR TITLE
Smart run type defaulting + normalize run type terminology to eliminate tech debt

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -16,7 +16,8 @@
       "Bash(dir:*)",
       "Bash(npm run type-check:*)",
       "Read(/C:\\Source\\TowerOfTracking/**)",
-      "Bash(npm run integration-precheck:*)"
+      "Bash(npm run integration-precheck:*)",
+      "Bash(npm run dev:build:*)"
     ],
     "defaultMode": "acceptEdits"
   },

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -60,11 +60,15 @@ function Button({
   const Comp = asChild ? Slot : "button"
 
   const finalVariant = selected && variant === 'outline' ? 'outline-selected' : variant
-  
+
+  // Add aria-pressed for selection buttons to improve screen reader support
+  const ariaProps = selected !== undefined ? { 'aria-pressed': selected } : {}
+
   return (
     <Comp
       data-slot="button"
       className={cn(buttonVariants({ variant: finalVariant, size, fullWidthOnMobile, className }))}
+      {...ariaProps}
       {...props}
     />
   )

--- a/src/components/ui/selection-button-group.tsx
+++ b/src/components/ui/selection-button-group.tsx
@@ -19,6 +19,7 @@ interface SelectionButtonGroupProps<T = string> {
   vertical?: boolean
   spacing?: 'tight' | 'normal' | 'loose'
   equalWidth?: boolean
+  ariaLabel?: string
 }
 
 export function SelectionButtonGroup<T = string>({
@@ -31,7 +32,8 @@ export function SelectionButtonGroup<T = string>({
   fullWidthOnMobile = true,
   vertical = false,
   spacing = 'tight',
-  equalWidth = false
+  equalWidth = false,
+  ariaLabel
 }: SelectionButtonGroupProps<T>) {
   const spacingClasses = {
     tight: 'gap-1',
@@ -39,13 +41,17 @@ export function SelectionButtonGroup<T = string>({
     loose: 'gap-3'
   };
   return (
-    <div className={cn(
-      "flex",
-      spacingClasses[spacing],
-      vertical ? "flex-col" : "flex-wrap",
-      equalWidth && "w-full",
-      className
-    )}>
+    <div
+      className={cn(
+        "flex",
+        spacingClasses[spacing],
+        vertical ? "flex-col" : "flex-wrap",
+        equalWidth && "w-full",
+        className
+      )}
+      role="group"
+      aria-label={ariaLabel}
+    >
       {options.map((option) => (
         <Button
           key={String(option.value)}
@@ -62,7 +68,6 @@ export function SelectionButtonGroup<T = string>({
           style={option.color && selectedValue === option.value ? {
             backgroundColor: `${option.color}20`,
             borderColor: `${option.color}70`,
-            color: '#f1f5f9'
           } : undefined}
         >
           {option.color && option.icon && (

--- a/src/features/data-tracking/components/data-input.tsx
+++ b/src/features/data-tracking/components/data-input.tsx
@@ -80,7 +80,8 @@ const DataInputComponent = function DataInput({ className }: DataInputProps) {
               
               <RunTypeSelector
                 selectedType={form.selectedRunType as RunTypeFilter}
-                onTypeChange={(type) => form.setSelectedRunType(type === 'all' ? 'farm' : type as RunType)}
+                onTypeChange={(type) => form.setSelectedRunType(type === 'all' ? RunType.FARM : type)}
+                mode="selection"
               />
               <FormField>
                 <FormLabel required>

--- a/src/features/data-tracking/components/run-type-selector.tsx
+++ b/src/features/data-tracking/components/run-type-selector.tsx
@@ -1,29 +1,27 @@
-import { FormControl, SelectionButtonGroup, SelectionOption } from '../../../components/ui'
-import { RunTypeFilter, getRunTypeDisplayLabel } from '../utils/run-type-filter'
-import { RunType } from '../types/game-run.types'
+import { FormControl, SelectionButtonGroup } from '../../../components/ui'
+import { RunTypeFilter } from '../utils/run-type-filter'
+import { getOptionsForMode, RunTypeSelectorMode } from '../utils/run-type-selector-options'
 
 interface RunTypeSelectorProps {
   selectedType: RunTypeFilter
   onTypeChange: (type: RunTypeFilter) => void
   className?: string
+  mode?: RunTypeSelectorMode
 }
 
-const RUN_TYPE_OPTIONS: Array<SelectionOption<RunTypeFilter>> = [
-  { value: 'farming', label: getRunTypeDisplayLabel(RunType.FARM), color: '#10b981', icon: true },
-  { value: 'tournament', label: getRunTypeDisplayLabel(RunType.TOURNAMENT), color: '#f59e0b', icon: true },
-  { value: 'milestone', label: getRunTypeDisplayLabel(RunType.MILESTONE), color: '#8b5cf6', icon: true },
-  { value: 'all', label: 'All Types', color: '#6b7280', icon: true },
-] as const
+export function RunTypeSelector({ selectedType, onTypeChange, className = '', mode = 'filter' }: RunTypeSelectorProps) {
+  const options = getOptionsForMode(mode)
+  const ariaLabel = mode === 'selection' ? 'Select run type for new game run' : 'Filter runs by type'
 
-export function RunTypeSelector({ selectedType, onTypeChange, className = '' }: RunTypeSelectorProps) {
   return (
     <FormControl label="Run Type" className={className}>
       <SelectionButtonGroup<RunTypeFilter>
-        options={RUN_TYPE_OPTIONS}
+        options={options}
         selectedValue={selectedType}
         onSelectionChange={onTypeChange}
         size="sm"
         fullWidthOnMobile={false}
+        ariaLabel={ariaLabel}
       />
     </FormControl>
   )

--- a/src/features/data-tracking/components/runs-table/tabbed-runs-table.tsx
+++ b/src/features/data-tracking/components/runs-table/tabbed-runs-table.tsx
@@ -31,32 +31,32 @@ export function TabbedRunsTable() {
   return (
     <Tabs value={activeTab} onValueChange={handleTabChange}>
       <TabsList className="mb-6 w-full sm:w-auto">
-        <TabsTrigger value="farming" className="flex-1 sm:flex-initial">
-          <span className="hidden sm:inline">Farming Runs</span>
-          <span className="sm:hidden">Farming</span>
+        <TabsTrigger value={RunType.FARM} className="flex-1 sm:flex-initial">
+          <span className="hidden sm:inline">Farm Runs</span>
+          <span className="sm:hidden">Farm</span>
           <span className="ml-1">({farmingRuns.length})</span>
         </TabsTrigger>
-        <TabsTrigger value="tournament" className="flex-1 sm:flex-initial">
+        <TabsTrigger value={RunType.TOURNAMENT} className="flex-1 sm:flex-initial">
           <span className="hidden sm:inline">Tournament Runs</span>
           <span className="sm:hidden">Tournament</span>
           <span className="ml-1">({tournamentRuns.length})</span>
         </TabsTrigger>
-        <TabsTrigger value="milestone" className="flex-1 sm:flex-initial">
+        <TabsTrigger value={RunType.MILESTONE} className="flex-1 sm:flex-initial">
           <span className="hidden sm:inline">Milestone Runs</span>
           <span className="sm:hidden">Milestone</span>
           <span className="ml-1">({milestoneRuns.length})</span>
         </TabsTrigger>
       </TabsList>
 
-      <TabsContent value="farming">
+      <TabsContent value={RunType.FARM}>
         <FarmingRunsTable runs={farmingRuns} removeRun={removeRun} />
       </TabsContent>
 
-      <TabsContent value="tournament">
+      <TabsContent value={RunType.TOURNAMENT}>
         <TournamentRunsTable runs={tournamentRuns} removeRun={removeRun} />
       </TabsContent>
 
-      <TabsContent value="milestone">
+      <TabsContent value={RunType.MILESTONE}>
         <MilestoneRunsTable runs={milestoneRuns} removeRun={removeRun} />
       </TabsContent>
     </Tabs>

--- a/src/features/data-tracking/components/tier-stats-table.tsx
+++ b/src/features/data-tracking/components/tier-stats-table.tsx
@@ -3,14 +3,15 @@ import { useData } from '../hooks/use-data'
 import { prepareTierStatsData, formatLargeNumber, TierStatsData } from '../utils/chart-data'
 import { formatDuration } from '../utils/data-parser'
 import { FarmingOnlyIndicator } from './farming-only-indicator'
+import { RunType } from '../types/game-run.types'
 
 type SortField = keyof TierStatsData
 type SortDirection = 'asc' | 'desc'
 
 export function TierStatsTable() {
   const { runs } = useData()
-  
-  const baseTierStats = useMemo(() => prepareTierStatsData(runs, 'farming'), [runs])
+
+  const baseTierStats = useMemo(() => prepareTierStatsData(runs, RunType.FARM), [runs])
   const [sortField, setSortField] = useState<SortField>('tier')
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc')
   

--- a/src/features/data-tracking/components/tier-trends-analysis.tsx
+++ b/src/features/data-tracking/components/tier-trends-analysis.tsx
@@ -1,9 +1,10 @@
 import { useState, useMemo, useEffect } from 'react'
 import { useData } from '../hooks/use-data'
-import { 
-  calculateTierTrends, 
+import {
+  calculateTierTrends,
   getAvailableTiersForTrends
 } from '../utils/tier-trends'
+import { RunType } from '../types/game-run.types'
 import { RunTypeFilter } from '../utils/run-type-filter'
 import { TierTrendsSummary } from './tier-trends-summary'
 import { TierTrendsFilters as TierTrendsFiltersComponent } from './tier-trends-filters'
@@ -17,8 +18,8 @@ type SortDirection = 'asc' | 'desc'
 
 export function TierTrendsAnalysis() {
   const { runs } = useData()
-  
-  const [runTypeFilter, setRunTypeFilter] = useState<RunTypeFilter>('farming')
+
+  const [runTypeFilter, setRunTypeFilter] = useState<RunTypeFilter>(RunType.FARM)
   
   const availableTiers = useMemo(() => getAvailableTiersForTrends(runs, runTypeFilter), [runs, runTypeFilter])
   
@@ -99,7 +100,7 @@ export function TierTrendsAnalysis() {
         <div className="text-center">
           <p>No tier data available for trends analysis.</p>
           <p className="text-sm mt-2">
-            You need at least 2 {runTypeFilter === 'farming' ? 'farming' : runTypeFilter === 'tournament' ? 'tournament' : ''} runs in the same tier to see trends.
+            You need at least 2 {runTypeFilter === RunType.FARM ? 'farm' : runTypeFilter === RunType.TOURNAMENT ? 'tournament' : runTypeFilter === RunType.MILESTONE ? 'milestone' : ''} runs in the same tier to see trends.
           </p>
         </div>
       </div>
@@ -123,11 +124,11 @@ export function TierTrendsAnalysis() {
             <div className="w-2 h-8 bg-gradient-to-b from-orange-400 to-orange-600 rounded-full shadow-lg shadow-orange-500/30"></div>
 {filters.tier === 0 ? 'All Tiers' : `Tier ${filters.tier}`} Trends Analysis
             <span className="text-sm font-normal text-slate-400 ml-auto">
-              Last {trendsData.periodCount} {filters.duration === 'per-run' ? 'Runs' : filters.duration === 'daily' ? 'Days' : filters.duration === 'weekly' ? 'Weeks' : 'Months'} - {runTypeFilter === 'farming' ? 'Farming' : runTypeFilter === 'tournament' ? 'Tournament' : ''} Mode
+              Last {trendsData.periodCount} {filters.duration === 'per-run' ? 'Runs' : filters.duration === 'daily' ? 'Days' : filters.duration === 'weekly' ? 'Weeks' : 'Months'} - {runTypeFilter === RunType.FARM ? 'Farm' : runTypeFilter === RunType.TOURNAMENT ? 'Tournament' : runTypeFilter === RunType.MILESTONE ? 'Milestone' : ''} Mode
             </span>
           </h3>
           <p className="text-slate-400 text-sm">
-            Statistical changes across your recent {runTypeFilter === 'farming' ? 'farming' : runTypeFilter === 'tournament' ? 'tournament' : ''} runs. Showing fields with ≥{filters.changeThresholdPercent}% change.
+            Statistical changes across your recent {runTypeFilter === RunType.FARM ? 'farm' : runTypeFilter === RunType.TOURNAMENT ? 'tournament' : runTypeFilter === RunType.MILESTONE ? 'milestone' : ''} runs. Showing fields with ≥{filters.changeThresholdPercent}% change.
           </p>
         </div>
         

--- a/src/features/data-tracking/hooks/use-run-type-context.test.tsx
+++ b/src/features/data-tracking/hooks/use-run-type-context.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useRunTypeContext } from './use-run-type-context'
+import { RunTypeValue } from '../types/game-run.types'
+import * as TanStackRouter from '@tanstack/react-router'
+
+// Mock TanStack Router hooks
+vi.mock('@tanstack/react-router', async () => {
+  const actual = await vi.importActual('@tanstack/react-router')
+  return {
+    ...actual,
+    useLocation: vi.fn(),
+  }
+})
+
+describe('useRunTypeContext', () => {
+  const mockUseLocation = vi.mocked(TanStackRouter.useLocation)
+
+  it('should return "tournament" when on /runs page with type=tournament', () => {
+    mockUseLocation.mockReturnValue({
+      pathname: '/runs',
+      search: { type: 'tournament' },
+    } as ReturnType<typeof TanStackRouter.useLocation>)
+
+    const { result } = renderHook(() => useRunTypeContext())
+
+    expect(result.current).toBe('tournament')
+  })
+
+  it('should return "milestone" when on /runs page with type=milestone', () => {
+    mockUseLocation.mockReturnValue({
+      pathname: '/runs',
+      search: { type: 'milestone' },
+    } as ReturnType<typeof TanStackRouter.useLocation>)
+
+    const { result } = renderHook(() => useRunTypeContext())
+
+    expect(result.current).toBe('milestone')
+  })
+
+  it('should return RunType.FARM when on /runs page with type=farm', () => {
+    mockUseLocation.mockReturnValue({
+      pathname: '/runs',
+      search: { type: 'farm' },
+    } as ReturnType<typeof TanStackRouter.useLocation>)
+
+    const { result } = renderHook(() => useRunTypeContext())
+
+    expect(result.current).toBe('farm')
+  })
+
+  it('should return "farm" when on /runs page without type parameter', () => {
+    mockUseLocation.mockReturnValue({
+      pathname: '/runs',
+      search: {},
+    } as ReturnType<typeof TanStackRouter.useLocation>)
+
+    const { result } = renderHook(() => useRunTypeContext())
+
+    expect(result.current).toBe('farm')
+  })
+
+  it('should return "farm" when on /runs page with invalid type parameter', () => {
+    mockUseLocation.mockReturnValue({
+      pathname: '/runs',
+      search: { type: 'invalid' as unknown as RunTypeValue },
+    } as ReturnType<typeof TanStackRouter.useLocation>)
+
+    const { result } = renderHook(() => useRunTypeContext())
+
+    expect(result.current).toBe('farm')
+  })
+
+  it('should return "farm" when not on /runs page', () => {
+    mockUseLocation.mockReturnValue({
+      pathname: '/dashboard',
+      search: {},
+    } as ReturnType<typeof TanStackRouter.useLocation>)
+
+    const { result } = renderHook(() => useRunTypeContext())
+
+    expect(result.current).toBe('farm')
+  })
+
+  it('should return "farm" when on home page', () => {
+    mockUseLocation.mockReturnValue({
+      pathname: '/',
+      search: {},
+    } as ReturnType<typeof TanStackRouter.useLocation>)
+
+    const { result } = renderHook(() => useRunTypeContext())
+
+    expect(result.current).toBe('farm')
+  })
+
+  it('should ignore type parameter when not on /runs page', () => {
+    mockUseLocation.mockReturnValue({
+      pathname: '/dashboard',
+      search: { type: 'tournament' },
+    } as ReturnType<typeof TanStackRouter.useLocation>)
+
+    const { result } = renderHook(() => useRunTypeContext())
+
+    expect(result.current).toBe('farm')
+  })
+})

--- a/src/features/data-tracking/hooks/use-run-type-context.ts
+++ b/src/features/data-tracking/hooks/use-run-type-context.ts
@@ -1,0 +1,26 @@
+import { useLocation } from '@tanstack/react-router'
+import { mapUrlTypeToRunType } from '../utils/run-type-defaults'
+import { RunType, RunTypeValue } from '../types/game-run.types'
+
+interface RunsSearchParams {
+  type?: RunTypeValue
+}
+
+/**
+ * Hook to determine the default run type based on current URL context
+ * Reads the type parameter from /runs route if available, otherwise defaults to RunType.FARM
+ */
+export function useRunTypeContext(): RunTypeValue {
+  const location = useLocation()
+
+  // Check if we're on the runs page and extract type parameter
+  const isRunsPage = location.pathname === '/runs'
+
+  if (isRunsPage) {
+    const searchParams = location.search as RunsSearchParams
+    return mapUrlTypeToRunType(searchParams.type)
+  }
+
+  // Default to farm for all other pages
+  return RunType.FARM
+}

--- a/src/features/data-tracking/hooks/use-runs-navigation.ts
+++ b/src/features/data-tracking/hooks/use-runs-navigation.ts
@@ -1,6 +1,7 @@
 import { useUrlSearchParam } from '../../navigation/hooks/use-url-search-param'
+import { RunType, RunTypeValue } from '../types/game-run.types'
 
-export type RunsTabType = 'farming' | 'tournament' | 'milestone'
+export type RunsTabType = RunTypeValue
 
 interface RunsSearchParams extends Record<string, unknown> {
   type?: RunsTabType
@@ -11,11 +12,11 @@ interface RunsSearchParams extends Record<string, unknown> {
  */
 export function useRunsNavigation() {
   const { search, updateSearch } = useUrlSearchParam<RunsSearchParams>(
-    '/runs', 
-    { type: 'farming' }
+    '/runs',
+    { type: RunType.FARM }
   )
 
-  const activeTab = search.type || 'farming'
+  const activeTab = search.type || RunType.FARM
 
   const setActiveTab = (type: RunsTabType) => {
     updateSearch({ type })

--- a/src/features/data-tracking/utils/data-input-state.test.ts
+++ b/src/features/data-tracking/utils/data-input-state.test.ts
@@ -5,6 +5,7 @@ import {
   formatTimeFromDate,
   createDateTimeFromComponents,
 } from './data-input-state';
+import { RunType } from '../types/game-run.types';
 
 describe('data-input-state utilities', () => {
   let mockDate: Date;
@@ -21,16 +22,38 @@ describe('data-input-state utilities', () => {
   });
 
   describe('createInitialFormState', () => {
-    it('should return consistent initial state', () => {
+    it('should return consistent initial state with default farm type', () => {
       const state = createInitialFormState();
 
       expect(state).toEqual({
         inputData: '',
         notes: '',
-        selectedRunType: 'farm',
+        selectedRunType: RunType.FARM,
         duplicateResult: null,
         resolution: 'new-only',
       });
+    });
+
+    it('should accept tournament as default run type', () => {
+      const state = createInitialFormState(RunType.TOURNAMENT);
+
+      expect(state.selectedRunType).toBe(RunType.TOURNAMENT);
+      expect(state.inputData).toBe('');
+      expect(state.notes).toBe('');
+      expect(state.duplicateResult).toBeNull();
+      expect(state.resolution).toBe('new-only');
+    });
+
+    it('should accept milestone as default run type', () => {
+      const state = createInitialFormState(RunType.MILESTONE);
+
+      expect(state.selectedRunType).toBe(RunType.MILESTONE);
+    });
+
+    it('should default to farm when provided undefined', () => {
+      const state = createInitialFormState(undefined);
+
+      expect(state.selectedRunType).toBe(RunType.FARM);
     });
 
     it('should return new objects on each call', () => {

--- a/src/features/data-tracking/utils/data-input-state.ts
+++ b/src/features/data-tracking/utils/data-input-state.ts
@@ -1,10 +1,11 @@
 import type { DuplicateDetectionResult } from '../utils/duplicate-detection';
 import type { DuplicateResolution } from '../components/duplicate-info';
+import { RunType, RunTypeValue } from '../types/game-run.types';
 
 export interface DataInputFormInitialState {
   inputData: string;
   notes: string;
-  selectedRunType: 'farm' | 'tournament' | 'milestone';
+  selectedRunType: RunTypeValue;
   duplicateResult: DuplicateDetectionResult | null;
   resolution: DuplicateResolution;
 }
@@ -15,13 +16,14 @@ export interface DateTimeState {
 }
 
 /**
- * Creates the initial form state with default values
+ * Creates the initial form state with optional context-aware default run type
+ * @param defaultRunType - Optional default run type from URL context or other sources
  */
-export function createInitialFormState(): DataInputFormInitialState {
+export function createInitialFormState(defaultRunType?: RunTypeValue): DataInputFormInitialState {
   return {
     inputData: '',
     notes: '',
-    selectedRunType: 'farm',
+    selectedRunType: defaultRunType || RunType.FARM,
     duplicateResult: null,
     resolution: 'new-only',
   };

--- a/src/features/data-tracking/utils/run-type-defaults.test.ts
+++ b/src/features/data-tracking/utils/run-type-defaults.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import {
+  mapUrlTypeToRunType,
+  normalizeRunTypeFilter
+} from './run-type-defaults'
+import { RunType } from '../types/game-run.types'
+import { RunTypeFilter } from './run-type-filter'
+
+describe('mapUrlTypeToRunType', () => {
+  it('should map RunType.FARM to RunType.FARM', () => {
+    expect(mapUrlTypeToRunType(RunType.FARM)).toBe(RunType.FARM)
+  })
+
+  it('should map RunType.TOURNAMENT to RunType.TOURNAMENT', () => {
+    expect(mapUrlTypeToRunType(RunType.TOURNAMENT)).toBe(RunType.TOURNAMENT)
+  })
+
+  it('should map RunType.MILESTONE to RunType.MILESTONE', () => {
+    expect(mapUrlTypeToRunType(RunType.MILESTONE)).toBe(RunType.MILESTONE)
+  })
+
+  it('should default to RunType.FARM for undefined', () => {
+    expect(mapUrlTypeToRunType(undefined)).toBe(RunType.FARM)
+  })
+
+  it('should default to RunType.FARM for invalid values', () => {
+    expect(mapUrlTypeToRunType('invalid')).toBe(RunType.FARM)
+    expect(mapUrlTypeToRunType('')).toBe(RunType.FARM)
+    expect(mapUrlTypeToRunType('all')).toBe(RunType.FARM)
+    expect(mapUrlTypeToRunType('farming')).toBe(RunType.FARM) // old 'farming' value now invalid
+  })
+})
+
+describe('normalizeRunTypeFilter', () => {
+  it('should convert RunType.FARM to RunType.FARM', () => {
+    expect(normalizeRunTypeFilter(RunType.FARM)).toBe(RunType.FARM)
+  })
+
+  it('should convert RunType.TOURNAMENT to RunType.TOURNAMENT', () => {
+    expect(normalizeRunTypeFilter(RunType.TOURNAMENT)).toBe(RunType.TOURNAMENT)
+  })
+
+  it('should convert RunType.MILESTONE to RunType.MILESTONE', () => {
+    expect(normalizeRunTypeFilter(RunType.MILESTONE)).toBe(RunType.MILESTONE)
+  })
+
+  it('should convert "all" to RunType.FARM as fallback', () => {
+    expect(normalizeRunTypeFilter('all')).toBe(RunType.FARM)
+  })
+
+  it('should delegate to mapUrlTypeToRunType for consistent mapping', () => {
+    // Test that normalizeRunTypeFilter uses the same mapping logic as mapUrlTypeToRunType
+    expect(normalizeRunTypeFilter(RunType.FARM)).toBe(mapUrlTypeToRunType(RunType.FARM))
+    expect(normalizeRunTypeFilter(RunType.TOURNAMENT)).toBe(mapUrlTypeToRunType(RunType.TOURNAMENT))
+    expect(normalizeRunTypeFilter(RunType.MILESTONE)).toBe(mapUrlTypeToRunType(RunType.MILESTONE))
+  })
+
+  it('should handle invalid filter values by delegating to mapUrlTypeToRunType', () => {
+    // After handling 'all', invalid values are delegated to mapUrlTypeToRunType
+    // which returns FARM as fallback
+    expect(normalizeRunTypeFilter('invalid' as unknown as RunTypeFilter)).toBe(RunType.FARM)
+  })
+})

--- a/src/features/data-tracking/utils/run-type-defaults.ts
+++ b/src/features/data-tracking/utils/run-type-defaults.ts
@@ -1,0 +1,33 @@
+import { RunType, RunTypeValue } from '../types/game-run.types'
+import { RunTypeFilter } from './run-type-filter'
+
+/**
+ * Maps URL parameter values to internal run type values
+ * Normalizes URL params to match RunType enum values
+ */
+export function mapUrlTypeToRunType(urlType: string | undefined): RunTypeValue {
+  switch (urlType) {
+    case RunType.FARM:
+      return RunType.FARM
+    case RunType.TOURNAMENT:
+      return RunType.TOURNAMENT
+    case RunType.MILESTONE:
+      return RunType.MILESTONE
+    default:
+      return RunType.FARM // Default fallback
+  }
+}
+
+/**
+ * Validates and normalizes run type filter values to internal run type values
+ * Delegates to mapUrlTypeToRunType for consistent mapping logic
+ * Returns 'farm' for invalid or 'all' values
+ */
+export function normalizeRunTypeFilter(filterValue: RunTypeFilter): RunTypeValue {
+  if (filterValue === 'all') {
+    return RunType.FARM
+  }
+
+  // Delegate to the canonical URL-to-RunType mapper for consistency
+  return mapUrlTypeToRunType(filterValue)
+}

--- a/src/features/data-tracking/utils/run-type-filter.test.ts
+++ b/src/features/data-tracking/utils/run-type-filter.test.ts
@@ -57,20 +57,20 @@ describe('filterRunsByType', () => {
     expect(result).toEqual(mockRuns)
   })
 
-  it('returns only farming runs when filter is "farming"', () => {
-    const result = filterRunsByType(mockRuns, 'farming')
+  it('returns only farming runs when filter is RunType.FARM', () => {
+    const result = filterRunsByType(mockRuns, RunType.FARM)
     expect(result).toHaveLength(2)
     expect(result.every(run => run.runType === RunType.FARM)).toBe(true)
   })
 
-  it('returns only tournament runs when filter is "tournament"', () => {
-    const result = filterRunsByType(mockRuns, 'tournament')
+  it('returns only tournament runs when filter is RunType.TOURNAMENT', () => {
+    const result = filterRunsByType(mockRuns, RunType.TOURNAMENT)
     expect(result).toHaveLength(1)
     expect(result[0].runType).toBe(RunType.TOURNAMENT)
   })
 
-  it('returns only milestone runs when filter is "milestone"', () => {
-    const result = filterRunsByType(mockRuns, 'milestone')
+  it('returns only milestone runs when filter is RunType.MILESTONE', () => {
+    const result = filterRunsByType(mockRuns, RunType.MILESTONE)
     expect(result).toHaveLength(1)
     expect(result[0].runType).toBe(RunType.MILESTONE)
   })

--- a/src/features/data-tracking/utils/run-type-filter.ts
+++ b/src/features/data-tracking/utils/run-type-filter.ts
@@ -1,6 +1,6 @@
 import { ParsedGameRun, RunType, RunTypeValue } from '../types/game-run.types'
 
-export type RunTypeFilter = 'farming' | 'tournament' | 'milestone' | 'all'
+export type RunTypeFilter = RunTypeValue | 'all'
 
 /**
  * Centralized function to determine run type from tier string
@@ -34,24 +34,7 @@ export function filterRunsByType(runs: ParsedGameRun[], runType: RunTypeFilter):
     return runs
   }
   
-  return runs.filter(run => {
-    // Map filter values to run type enum values
-    let targetRunType: RunTypeValue
-    switch (runType) {
-      case 'farming':
-        targetRunType = RunType.FARM
-        break
-      case 'tournament':
-        targetRunType = RunType.TOURNAMENT
-        break
-      case 'milestone':
-        targetRunType = RunType.MILESTONE
-        break
-      default:
-        return false
-    }
-    return run.runType === targetRunType
-  })
+  return runs.filter(run => run.runType === runType)
 }
 
 /**

--- a/src/features/data-tracking/utils/run-type-selector-options.test.ts
+++ b/src/features/data-tracking/utils/run-type-selector-options.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { getOptionsForMode } from './run-type-selector-options'
+import { RunType } from '../types/game-run.types'
+
+describe('getOptionsForMode', () => {
+  it('should return all options including "all" in filter mode', () => {
+    const options = getOptionsForMode('filter')
+
+    expect(options).toHaveLength(4)
+    expect(options.map(o => o.value)).toEqual([RunType.FARM, RunType.TOURNAMENT, RunType.MILESTONE, 'all'])
+  })
+
+  it('should exclude "all" option in selection mode', () => {
+    const options = getOptionsForMode('selection')
+
+    expect(options).toHaveLength(3)
+    expect(options.map(o => o.value)).toEqual([RunType.FARM, RunType.TOURNAMENT, RunType.MILESTONE])
+  })
+
+  it('should return options with correct labels in filter mode', () => {
+    const options = getOptionsForMode('filter')
+
+    expect(options[0].label).toBe('Farm')
+    expect(options[1].label).toBe('Tournament')
+    expect(options[2].label).toBe('Milestone')
+    expect(options[3].label).toBe('All Types')
+  })
+
+  it('should return options with correct labels in selection mode', () => {
+    const options = getOptionsForMode('selection')
+
+    expect(options[0].label).toBe('Farm')
+    expect(options[1].label).toBe('Tournament')
+    expect(options[2].label).toBe('Milestone')
+  })
+
+  it('should return options with correct colors', () => {
+    const options = getOptionsForMode('selection')
+
+    expect(options[0].color).toBe('#10b981') // farming - green
+    expect(options[1].color).toBe('#f59e0b') // tournament - orange
+    expect(options[2].color).toBe('#8b5cf6') // milestone - purple
+  })
+
+  it('should return options with icon property set to true', () => {
+    const options = getOptionsForMode('selection')
+
+    options.forEach(option => {
+      expect(option.icon).toBe(true)
+    })
+  })
+})

--- a/src/features/data-tracking/utils/run-type-selector-options.ts
+++ b/src/features/data-tracking/utils/run-type-selector-options.ts
@@ -1,0 +1,24 @@
+import type { SelectionOption } from '../../../components/ui'
+import { RunType } from '../types/game-run.types'
+import { RunTypeFilter, getRunTypeDisplayLabel } from './run-type-filter'
+
+export type RunTypeSelectorMode = 'filter' | 'selection'
+
+const ALL_RUN_TYPE_OPTIONS: Array<SelectionOption<RunTypeFilter>> = [
+  { value: RunType.FARM, label: getRunTypeDisplayLabel(RunType.FARM), color: '#10b981', icon: true },
+  { value: RunType.TOURNAMENT, label: getRunTypeDisplayLabel(RunType.TOURNAMENT), color: '#f59e0b', icon: true },
+  { value: RunType.MILESTONE, label: getRunTypeDisplayLabel(RunType.MILESTONE), color: '#8b5cf6', icon: true },
+  { value: 'all', label: 'All Types', color: '#6b7280', icon: true },
+] as const
+
+/**
+ * Gets the appropriate run type options based on the selector mode
+ * - 'selection' mode: Excludes 'all' option (for creation forms)
+ * - 'filter' mode: Includes all options (for filtering)
+ */
+export function getOptionsForMode(mode: RunTypeSelectorMode): Array<SelectionOption<RunTypeFilter>> {
+  if (mode === 'selection') {
+    return ALL_RUN_TYPE_OPTIONS.filter(option => option.value !== 'all')
+  }
+  return ALL_RUN_TYPE_OPTIONS
+}

--- a/src/features/data-tracking/utils/tier-trends.test.ts
+++ b/src/features/data-tracking/utils/tier-trends.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { calculateTierTrends, getAvailableTiersForTrends } from './tier-trends';
 import type { ParsedGameRun, TierTrendsFilters, GameRunField } from '../types/game-run.types';
+import { RunType } from '../types/game-run.types';
 
 // Helper function to create a mock field
 function createMockField(
@@ -88,7 +89,7 @@ describe('tier-trends', () => {
         createMockRun({}, undefined, 3),
       ];
 
-      const result = getAvailableTiersForTrends(runs, 'farming');
+      const result = getAvailableTiersForTrends(runs, RunType.FARM);
       expect(result).toEqual([3, 1]); // Sorted descending
     });
 
@@ -100,7 +101,7 @@ describe('tier-trends', () => {
         createMockRun({ runType: 'tournament' }, undefined, 2),
       ];
 
-      const farmingResult = getAvailableTiersForTrends(runs, 'farming');
+      const farmingResult = getAvailableTiersForTrends(runs, RunType.FARM);
       const tournamentResult = getAvailableTiersForTrends(runs, 'tournament');
       
       expect(farmingResult).toEqual([1]);
@@ -114,7 +115,7 @@ describe('tier-trends', () => {
         createMockRun({}, undefined, 3),
       ];
 
-      const result = getAvailableTiersForTrends(runs, 'farming');
+      const result = getAvailableTiersForTrends(runs, RunType.FARM);
       expect(result).toEqual([]);
     });
   });
@@ -130,7 +131,7 @@ describe('tier-trends', () => {
           quantity: 3,
         };
 
-        const result = calculateTierTrends(runs, filters, 'farming');
+        const result = calculateTierTrends(runs, filters, RunType.FARM);
 
         expect(result.periodCount).toBe(3);
         expect(result.comparisonColumns).toHaveLength(3);
@@ -160,7 +161,7 @@ describe('tier-trends', () => {
           quantity: 2,
         };
 
-        const result = calculateTierTrends(runs, filters, 'farming');
+        const result = calculateTierTrends(runs, filters, RunType.FARM);
 
         expect(result.comparisonColumns).toHaveLength(2);
         
@@ -184,7 +185,7 @@ describe('tier-trends', () => {
           aggregationType: 'sum',
         };
 
-        const result = calculateTierTrends(runs, filters, 'farming');
+        const result = calculateTierTrends(runs, filters, RunType.FARM);
 
         expect(result.periodCount).toBe(3);
         expect(result.comparisonColumns).toHaveLength(3);
@@ -241,7 +242,7 @@ describe('tier-trends', () => {
           aggregationType: 'sum',
         };
 
-        const sumResult = calculateTierTrends(runs, sumFilters, 'farming');
+        const sumResult = calculateTierTrends(runs, sumFilters, RunType.FARM);
         expect(sumResult.comparisonColumns.length).toBe(2);
         expect(sumResult.comparisonColumns[0].values.coinsEarned).toBe(300); // Day2: 300
         expect(sumResult.comparisonColumns[1].values.coinsEarned).toBe(300); // Day1: 100+200=300
@@ -255,7 +256,7 @@ describe('tier-trends', () => {
           aggregationType: 'average',
         };
 
-        const avgResult = calculateTierTrends(runs, avgFilters, 'farming');
+        const avgResult = calculateTierTrends(runs, avgFilters, RunType.FARM);
         expect(avgResult.comparisonColumns[0].values.coinsEarned).toBe(300); // Day2: 300/1 = 300
         expect(avgResult.comparisonColumns[1].values.coinsEarned).toBe(150); // Day1: (100+200)/2 = 150
 
@@ -268,7 +269,7 @@ describe('tier-trends', () => {
           aggregationType: 'min',
         };
 
-        const minResult = calculateTierTrends(runs, minFilters, 'farming');
+        const minResult = calculateTierTrends(runs, minFilters, RunType.FARM);
         expect(minResult.comparisonColumns[0].values.coinsEarned).toBe(300); // Day2: min(300) = 300
         expect(minResult.comparisonColumns[1].values.coinsEarned).toBe(100); // Day1: min(100,200) = 100
 
@@ -281,7 +282,7 @@ describe('tier-trends', () => {
           aggregationType: 'max',
         };
 
-        const maxResult = calculateTierTrends(runs, maxFilters, 'farming');
+        const maxResult = calculateTierTrends(runs, maxFilters, RunType.FARM);
         expect(maxResult.comparisonColumns[0].values.coinsEarned).toBe(300); // Day2: max(300) = 300
         expect(maxResult.comparisonColumns[1].values.coinsEarned).toBe(200); // Day1: max(100,200) = 200
       });
@@ -311,7 +312,7 @@ describe('tier-trends', () => {
           quantity: 2,
         };
 
-        const result = calculateTierTrends(runs, filters, 'farming');
+        const result = calculateTierTrends(runs, filters, RunType.FARM);
         const coinsField = result.fieldTrends.find(f => f.fieldName === 'coinsEarned');
 
         expect(coinsField).toBeDefined();
@@ -331,7 +332,7 @@ describe('tier-trends', () => {
           quantity: 3,
         };
 
-        const lowResult = calculateTierTrends(runs, lowThreshold, 'farming');
+        const lowResult = calculateTierTrends(runs, lowThreshold, RunType.FARM);
         const lowFieldCount = lowResult.fieldTrends.length;
 
         // With high threshold, should include fewer fields
@@ -342,7 +343,7 @@ describe('tier-trends', () => {
           quantity: 3,
         };
 
-        const highResult = calculateTierTrends(runs, highThreshold, 'farming');
+        const highResult = calculateTierTrends(runs, highThreshold, RunType.FARM);
         const highFieldCount = highResult.fieldTrends.length;
 
         expect(lowFieldCount).toBeGreaterThan(highFieldCount);
@@ -359,7 +360,7 @@ describe('tier-trends', () => {
           quantity: 3,
         };
 
-        const result = calculateTierTrends(runs, filters, 'farming');
+        const result = calculateTierTrends(runs, filters, RunType.FARM);
 
         expect(result.summary.totalFields).toBeGreaterThan(0);
         expect(result.summary.fieldsChanged).toBeGreaterThanOrEqual(0);
@@ -382,7 +383,7 @@ describe('tier-trends', () => {
           quantity: 3,
         };
 
-        const result = calculateTierTrends(runs, filters, 'farming');
+        const result = calculateTierTrends(runs, filters, RunType.FARM);
 
         expect(result.periodCount).toBe(1);
         expect(result.fieldTrends).toHaveLength(0);
@@ -406,7 +407,7 @@ describe('tier-trends', () => {
           quantity: 2,
         };
 
-        const result = calculateTierTrends(runs, filters, 'farming');
+        const result = calculateTierTrends(runs, filters, RunType.FARM);
         
         // Should not crash and should handle missing values as 0
         expect(result.fieldTrends.length).toBeGreaterThanOrEqual(0);
@@ -432,7 +433,7 @@ describe('tier-trends', () => {
           quantity: 2,
         };
 
-        const result = calculateTierTrends(runs, filters, 'farming');
+        const result = calculateTierTrends(runs, filters, RunType.FARM);
         const coinsField = result.fieldTrends.find(f => f.fieldName === 'coinsEarned');
 
         expect(coinsField).toBeDefined();

--- a/src/features/data-tracking/utils/tier-trends.ts
+++ b/src/features/data-tracking/utils/tier-trends.ts
@@ -1,10 +1,11 @@
-import type { 
-  ParsedGameRun, 
-  TierTrendsFilters, 
-  TierTrendsData, 
+import type {
+  ParsedGameRun,
+  TierTrendsFilters,
+  TierTrendsData,
   FieldTrendData,
   GameRunField,
 } from '../types/game-run.types';
+import { RunType } from '../types/game-run.types';
 import { RunTypeFilter, filterRunsByType } from './run-type-filter';
 import { createEnhancedRunHeader } from './run-header-formatting';
 
@@ -20,9 +21,9 @@ interface PeriodData {
  * Calculate tier trends analysis for the specified duration and quantity
  */
 export function calculateTierTrends(
-  runs: ParsedGameRun[], 
+  runs: ParsedGameRun[],
   filters: TierTrendsFilters,
-  runTypeFilter: RunTypeFilter = 'farming'
+  runTypeFilter: RunTypeFilter = RunType.FARM
 ): TierTrendsData {
   // Filter runs by type and tier, sorted by timestamp (newest first)
   const filteredRuns = filterRunsByType(runs, runTypeFilter);
@@ -127,9 +128,9 @@ function analyzeTrendType(values: number[]): FieldTrendData['trendType'] {
 }
 
 /**
- * Get available tiers for trend analysis (tiers with at least 2 farming runs)
+ * Get available tiers for trend analysis (tiers with at least 2 runs of the specified type)
  */
-export function getAvailableTiersForTrends(runs: ParsedGameRun[], runTypeFilter: RunTypeFilter = 'farming'): number[] {
+export function getAvailableTiersForTrends(runs: ParsedGameRun[], runTypeFilter: RunTypeFilter = RunType.FARM): number[] {
   const tierCounts = new Map<number, number>();
   
   const filteredRuns = filterRunsByType(runs, runTypeFilter);

--- a/src/features/navigation/config/navigation-config.ts
+++ b/src/features/navigation/config/navigation-config.ts
@@ -6,9 +6,9 @@ export const NAVIGATION_SECTIONS: NavigationSection[] = [
     label: 'Game Runs',
     items: [
       {
-        id: 'farming-runs',
-        label: 'Farming Runs',
-        href: '/runs?type=farming',
+        id: 'farm-runs',
+        label: 'Farm Runs',
+        href: '/runs?type=farm',
         icon: 'farming'
       },
       {

--- a/src/routes/charts/cells.tsx
+++ b/src/routes/charts/cells.tsx
@@ -18,7 +18,7 @@ function CellsChartPage() {
             <div className="absolute -inset-1 bg-gradient-to-r from-pink-600/20 to-rose-600/20 blur-lg -z-10 rounded-lg"></div>
           </div>
           <p className="text-muted-foreground text-lg">
-            Track your cell earnings from farming runs over different time periods
+            Track your cell earnings from farm runs over different time periods
           </p>
         </div>
 
@@ -28,10 +28,10 @@ function CellsChartPage() {
           </CardHeader>
           <CardContent className="p-0">
             <div className="p-8 w-full">
-              <TimeSeriesChart 
+              <TimeSeriesChart
                 metric="cells"
                 title="Cells Earned"
-                subtitle="Track your cell earnings from farming runs over different time periods"
+                subtitle="Track your cell earnings from farm runs over different time periods"
                 defaultPeriod="hourly"
                 showFarmingOnly={true}
               />

--- a/src/routes/charts/coins.tsx
+++ b/src/routes/charts/coins.tsx
@@ -18,7 +18,7 @@ function CoinsChartPage() {
             <div className="absolute -inset-1 bg-gradient-to-r from-emerald-600/20 to-green-600/20 blur-lg -z-10 rounded-lg"></div>
           </div>
           <p className="text-muted-foreground text-lg">
-            Track your coin earnings from farming runs over different time periods
+            Track your coin earnings from farm runs over different time periods
           </p>
         </div>
 
@@ -28,10 +28,10 @@ function CoinsChartPage() {
           </CardHeader>
           <CardContent className="p-0">
             <div className="p-8 w-full">
-              <TimeSeriesChart 
+              <TimeSeriesChart
                 metric="coins"
                 title="Coins Earned"
-                subtitle="Track your coin earnings from farming runs over different time periods"
+                subtitle="Track your coin earnings from farm runs over different time periods"
                 defaultPeriod="hourly"
                 showFarmingOnly={true}
               />

--- a/src/routes/charts/tier-trends.tsx
+++ b/src/routes/charts/tier-trends.tsx
@@ -18,7 +18,7 @@ function TierTrendsPage() {
             <div className="absolute -inset-1 bg-gradient-to-r from-orange-600/20 to-yellow-600/20 blur-lg -z-10 rounded-lg"></div>
           </div>
           <p className="text-muted-foreground text-lg">
-            Compare statistical changes across your recent farming runs for the same tier. Identify performance improvements and upgrade impacts.
+            Compare statistical changes across your recent farm runs for the same tier. Identify performance improvements and upgrade impacts.
           </p>
         </div>
 

--- a/src/routes/runs.tsx
+++ b/src/routes/runs.tsx
@@ -1,15 +1,16 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { TabbedRunsTable } from '../features/data-tracking'
+import { RunTypeValue } from '../features/data-tracking/types/game-run.types'
 
 interface RunsSearchParams {
-  type?: 'farming' | 'tournament' | 'milestone'
+  type?: RunTypeValue
 }
 
 export const Route = createFileRoute('/runs')({
   component: RunsPage,
   validateSearch: (search): RunsSearchParams => {
     return {
-      type: search.type as 'farming' | 'tournament' | 'milestone' | undefined,
+      type: search.type as RunTypeValue | undefined,
     }
   },
 })

--- a/todos.md
+++ b/todos.md
@@ -1,16 +1,11 @@
 # Bugs
 - fix issues with warning about invalid values in notes filed and then not doing anything about it
-- runtype import has issues, default paste has type set to Farm, when you select run type button it changes type to Farming
 
 # Periodic
 - Ask the architecture-review or the frontend-design-reviewer to
     Make one area of the code more beautiful without changing functionality
 
 # Features
-
-## For v0.1.0
-- Add versioning
-
 ## For v0.2.0
 - Add google drive api integration
 - Make app a PWA so that it can be installed to native devices


### PR DESCRIPTION
**Problem:** Users had to manually re-select run type every time they clicked "Add Game Run", even when viewing a filtered tab (e.g., on Tournament tab → still had to select Tournament manually).

**Solution:** Run type now intelligently defaults based on current context:
- On `/runs?type=tournament` → defaults to Tournament
- On `/runs?type=milestone` → defaults to Milestone  
- On `/runs?type=farm` → defaults to Farm
- Anywhere else → defaults to Farm

**User Impact:**
- ✅ Fewer clicks when creating runs from filtered views
- ✅ Default matches user intent based on current context
- ✅ Form resets maintain context awareness

---

## Tech Debt: Run Type Terminology Normalization

**While implementing this feature, we discovered inconsistent run type terminology:**
- URLs used `?type=farming` but internal `RunType` enum stored `'farm'`
- String literals scattered throughout codebase (`'farming'`, `'farm'`, hardcoded strings)
- **This caused tier stats and tier trends to show NO DATA** because filters couldn't match runs

**Why we fixed it now:**
- New defaulting feature required reading URL params reliably
- Inconsistency would cause silent bugs in new code
- No compile-time safety for run type values

**Normalization approach:**
- Chose `'farm'` over `'farming'` (matches existing enum, less breaking changes)
- Replaced all string literals with `RunType.FARM/TOURNAMENT/MILESTONE` 
- Single source of truth prevents future mismatches
- Type safety catches mistakes at compile time

**Fixes from normalization:**
- ✅ Tier stats now loads data correctly
- ✅ Tier trends now loads data correctly
- ✅ All UI updated: "Farming Runs" → "Farm Runs" (consistent naming)

---

## Breaking Changes
⚠️ **URL parameter:** Old `?type=farming` links now use `?type=farm` (graceful fallback to farm type)
