### PR TITLE
Fix auto-tag major version bump detection

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -53,9 +53,10 @@ jobs:
           echo "Commit message: $COMMIT_MSG"
 
           # Determine version bump based on commit message
-          # Recognize: [major]/[MAJOR], [minor]/[MINOR], MAJOR/major at start, MINOR/minor at start, or BREAKING CHANGE
-          # Case-insensitive to support various styles
-          if echo "$COMMIT_MSG" | grep -qiE '\[major\]|^major\b|^BREAKING CHANGE:'; then
+          # Major bump ONLY if first line starts with: [major], [MAJOR], major, MAJOR, BREAKING CHANGE:, or BREAKING:
+          # Extract first line to prevent "BREAKING CHANGE:" appearing mid-message from triggering major bump
+          FIRST_LINE=$(echo "$COMMIT_MSG" | head -n 1)
+          if echo "$FIRST_LINE" | grep -qiE '^\[major\]|^major\b|^BREAKING CHANGE:|^BREAKING:'; then
             MAJOR=$((MAJOR + 1))
             MINOR=0
             PATCH=0


### PR DESCRIPTION
## Summary
- Prevents unintended major version bumps when "BREAKING CHANGE:" appears in commit message body
- Major bumps now only trigger when explicit keywords appear at the start of the first line

## Problem
The v1.0.0 tag was incorrectly created because "BREAKING CHANGE:" appeared in the body of commit ca8f2c6, even though it wasn't intended as a breaking change announcement.

## Solution
Extract and check only the first line of commit messages for major bump triggers, preventing mid-message mentions from affecting version detection.