### PR TITLE
MINOR Make tier stats table columns customizable with persistent configuration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-popover": "^1.1.15",
         "@radix-ui/react-slot": "^1.2.3",
+        "@radix-ui/react-tooltip": "^1.2.8",
         "@tailwindcss/vite": "^4.0.6",
         "@tanstack/react-router": "^1.130.2",
         "@tanstack/react-start": "^1.131.7",
@@ -3354,6 +3355,40 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz",
+      "integrity": "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-use-callback-ref": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
@@ -3471,6 +3506,29 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
+      "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-slot": "^1.2.3",
+    "@radix-ui/react-tooltip": "^1.2.8",
     "@tailwindcss/vite": "^4.0.6",
     "@tanstack/react-router": "^1.130.2",
     "@tanstack/react-start": "^1.131.7",

--- a/src/components/ui/add-item-button.tsx
+++ b/src/components/ui/add-item-button.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react'
+import { Plus } from 'lucide-react'
+import { cn } from '../../shared/lib/utils'
+
+export interface AddItemButtonProps extends React.ComponentProps<'button'> {
+  children: React.ReactNode
+  icon?: React.ReactNode
+}
+
+export function AddItemButton({
+  children,
+  icon = <Plus className="w-4 h-4" />,
+  className,
+  ...props
+}: AddItemButtonProps) {
+  return (
+    <button
+      type="button"
+      className={cn(
+        'group flex items-center gap-2 rounded-lg border px-3 py-2 text-left transition-all duration-200',
+        'bg-slate-700/30 border-slate-600/30',
+        'hover:bg-slate-700/50 hover:border-slate-500/50 hover:shadow-sm',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-400/50 focus-visible:border-orange-500/50',
+        'disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-slate-700/30 disabled:hover:border-slate-600/30',
+        className
+      )}
+      {...props}
+    >
+      <span className="shrink-0 text-slate-400 group-hover:text-orange-400 transition-colors">
+        {icon}
+      </span>
+      <span className="text-sm text-slate-300 group-hover:text-slate-100 transition-colors truncate">
+        {children}
+      </span>
+    </button>
+  )
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,3 +1,4 @@
+export * from "./add-item-button";
 export * from "./alert";
 export * from "./button";
 export * from "./button-group";
@@ -13,7 +14,9 @@ export * from "./nav-collapse-button";
 export * from "./nav-link";
 export * from "./nav-section";
 export * from "./popover";
+export * from "./removable-badge";
 export * from "./responsive-dialog";
 export * from "./selection-button-group";
 export * from "./tabs";
 export * from "./textarea";
+export * from "./toggle-switch";

--- a/src/components/ui/removable-badge.tsx
+++ b/src/components/ui/removable-badge.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react'
+import { X } from 'lucide-react'
+import { cn } from '../../shared/lib/utils'
+
+export interface RemovableBadgeProps {
+  children: React.ReactNode
+  onRemove: () => void
+  subtitle?: string
+  className?: string
+  'aria-label'?: string
+}
+
+export function RemovableBadge({
+  children,
+  onRemove,
+  subtitle,
+  className,
+  'aria-label': ariaLabel,
+}: RemovableBadgeProps) {
+  return (
+    <div
+      className={cn(
+        'group flex items-center gap-2 rounded-lg border px-3 py-2 transition-all duration-200',
+        'bg-slate-700/50 border-slate-600/50',
+        'hover:border-slate-500 hover:bg-slate-700/70 hover:shadow-sm',
+        className
+      )}
+    >
+      <div className="flex items-center gap-2 flex-1 min-w-0">
+        <span className="text-sm text-slate-200 truncate">{children}</span>
+        {subtitle && (
+          <span className="text-xs text-slate-400 shrink-0">{subtitle}</span>
+        )}
+      </div>
+      <button
+        onClick={onRemove}
+        aria-label={ariaLabel || `Remove ${children}`}
+        className={cn(
+          'shrink-0 rounded p-0.5 transition-all duration-200',
+          'text-slate-400 hover:text-red-400 hover:bg-red-400/10',
+          'opacity-0 group-hover:opacity-100',
+          'focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400/50'
+        )}
+      >
+        <X className="w-4 h-4" />
+      </button>
+    </div>
+  )
+}

--- a/src/components/ui/toggle-switch.tsx
+++ b/src/components/ui/toggle-switch.tsx
@@ -1,0 +1,45 @@
+import { cn } from '../../shared/lib/utils'
+
+export interface ToggleSwitchProps {
+  checked: boolean
+  onCheckedChange: (checked: boolean) => void
+  disabled?: boolean
+  'aria-label'?: string
+  'aria-labelledby'?: string
+  className?: string
+}
+
+export function ToggleSwitch({
+  checked,
+  onCheckedChange,
+  disabled = false,
+  className,
+  ...ariaProps
+}: ToggleSwitchProps) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      disabled={disabled}
+      onClick={() => onCheckedChange(!checked)}
+      className={cn(
+        'relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-all duration-200',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+        'disabled:cursor-not-allowed disabled:opacity-50',
+        checked
+          ? 'bg-orange-500 hover:bg-orange-600'
+          : 'bg-slate-600 hover:bg-slate-500',
+        className
+      )}
+      {...ariaProps}
+    >
+      <span
+        className={cn(
+          'inline-block h-4 w-4 transform rounded-full bg-white shadow-sm transition-transform duration-200',
+          checked ? 'translate-x-6' : 'translate-x-1'
+        )}
+      />
+    </button>
+  )
+}

--- a/src/features/data-tracking/components/tier-stats-cell-tooltip.tsx
+++ b/src/features/data-tracking/components/tier-stats-cell-tooltip.tsx
@@ -1,0 +1,78 @@
+import { format } from 'date-fns'
+import type { CellTooltipData } from '../types/tier-stats-config.types'
+import { formatDuration } from '../utils/data-parser'
+import { formatLargeNumber } from '../utils/chart-data'
+
+interface TierStatsCellTooltipProps {
+  data: CellTooltipData
+}
+
+export function TierStatsCellTooltip({ data }: TierStatsCellTooltipProps) {
+  return (
+    <div className="bg-slate-950 border border-slate-600/80 rounded-lg p-4 shadow-2xl backdrop-blur-md min-w-[220px]">
+      <div className="space-y-3">
+        {/* Field Name */}
+        <div className="font-semibold text-white text-sm border-b border-slate-700/80 pb-2.5">
+          {data.displayName}
+          {data.isHourlyRate && <span className="text-slate-300 font-normal"> (Per Hour)</span>}
+        </div>
+
+        {/* Value */}
+        <div className="flex justify-between items-center gap-4">
+          <span className="text-xs text-slate-300 font-medium">Value:</span>
+          <span className="text-sm font-mono text-white font-semibold">
+            {formatLargeNumber(Math.round(data.value))}
+            {data.isHourlyRate && '/h'}
+          </span>
+        </div>
+
+        {/* Hourly Rate Context */}
+        {data.isHourlyRate && data.hourlyRateContext && (
+          <div className="bg-orange-500/10 border border-orange-500/30 rounded-md p-2.5 space-y-1.5">
+            <div className="flex justify-between items-center gap-4">
+              <span className="text-xs text-orange-200">Base Value:</span>
+              <span className="font-mono text-xs text-orange-100 font-semibold">
+                {formatLargeNumber(Math.round(data.hourlyRateContext.baseValue))}
+              </span>
+            </div>
+            <div className="flex justify-between items-center gap-4">
+              <span className="text-xs text-orange-200">Run Duration:</span>
+              <span className="font-mono text-xs text-orange-100 font-semibold">
+                {formatDuration(data.hourlyRateContext.runDuration)}
+              </span>
+            </div>
+          </div>
+        )}
+
+        {/* Divider */}
+        <div className="border-t border-slate-700/80 pt-3 space-y-2">
+          <div className="text-xs text-slate-300 font-medium mb-2">From Run:</div>
+
+          {/* Wave */}
+          <div className="flex justify-between items-center gap-4">
+            <span className="text-xs text-slate-300">Wave:</span>
+            <span className="text-sm font-mono text-white font-medium">
+              {data.wave.toLocaleString()}
+            </span>
+          </div>
+
+          {/* Duration */}
+          <div className="flex justify-between items-center gap-4">
+            <span className="text-xs text-slate-300">Duration:</span>
+            <span className="text-sm font-mono text-white font-medium">
+              {formatDuration(data.duration)}
+            </span>
+          </div>
+
+          {/* Timestamp */}
+          <div className="flex justify-between items-center gap-4">
+            <span className="text-xs text-slate-300">Date:</span>
+            <span className="text-sm font-mono text-white font-medium">
+              {format(data.timestamp, 'MM/dd \'at\' h:mm a')}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/features/data-tracking/components/tier-stats-config-panel.tsx
+++ b/src/features/data-tracking/components/tier-stats-config-panel.tsx
@@ -1,0 +1,148 @@
+import { ChevronDown, ChevronUp, RotateCcw, X } from 'lucide-react'
+import type { UseTierStatsConfigReturn } from '../hooks/use-tier-stats-config'
+import { getFieldDisplayName, canFieldHaveHourlyRate } from '../utils/tier-stats-config'
+import { ToggleSwitch } from '../../../components/ui/toggle-switch'
+import { AddItemButton } from '../../../components/ui/add-item-button'
+import { Button } from '../../../components/ui/button'
+
+interface TierStatsConfigPanelProps {
+  config: UseTierStatsConfigReturn
+}
+
+export function TierStatsConfigPanel({ config }: TierStatsConfigPanelProps) {
+  return (
+    <div className="space-y-4">
+      {/* Toggle Button */}
+      <div className="flex items-center justify-between gap-4">
+        <Button
+          variant="ghost"
+          onClick={config.toggleConfigSection}
+          className="gap-2 text-slate-300 hover:text-slate-100 transition-colors text-sm font-medium px-0 hover:bg-transparent h-auto min-h-0"
+        >
+          {config.configSectionCollapsed ? (
+            <>
+              <ChevronDown className="w-4 h-4" />
+              Customize Table Columns
+            </>
+          ) : (
+            <>
+              <ChevronUp className="w-4 h-4" />
+              Hide Configuration
+            </>
+          )}
+        </Button>
+
+        {!config.configSectionCollapsed && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={config.resetToDefaults}
+            className="gap-1.5 text-slate-400 hover:text-orange-400 transition-colors h-auto min-h-0 px-2"
+          >
+            <RotateCcw className="w-3.5 h-3.5" />
+            Reset to Defaults
+          </Button>
+        )}
+      </div>
+
+      {/* Configuration Section */}
+      {!config.configSectionCollapsed && (
+        <div className="bg-slate-800/30 border border-slate-700/50 rounded-lg p-8 space-y-8">
+          {/* Selected Columns */}
+          <div>
+            <h4 className="text-sm font-semibold text-slate-100 mb-4">
+              Selected Columns ({config.selectedColumns.length})
+            </h4>
+
+            {config.selectedColumns.length === 0 ? (
+              <div className="bg-slate-700/30 border border-slate-600/30 rounded-lg p-4">
+                <p className="text-sm text-slate-400 text-center">
+                  No columns selected. Add columns below to customize your table.
+                </p>
+              </div>
+            ) : (
+              <div className="space-y-3">
+                {config.selectedColumns.map(column => {
+                  const canHaveHourly = canFieldHaveHourlyRate(column.fieldName, config.availableFields)
+                  const displayName = getFieldDisplayName(column.fieldName, config.availableFields)
+
+                  return (
+                    <div
+                      key={column.fieldName}
+                      className="flex items-center justify-between gap-4 bg-slate-700/30 border border-slate-600/40 rounded-lg px-4 py-3 group hover:border-slate-500/60 transition-all"
+                    >
+                      <div className="flex items-center gap-3 flex-1 min-w-0">
+                        <span className="text-sm text-slate-200 font-medium truncate">{displayName}</span>
+                        {column.showHourlyRate && (
+                          <span className="text-xs text-orange-400 bg-orange-500/10 px-2 py-0.5 rounded border border-orange-500/30 whitespace-nowrap">
+                            + /hour
+                          </span>
+                        )}
+                      </div>
+
+                      <div className="flex items-center gap-2 shrink-0">
+                        {canHaveHourly && (
+                          <div className="flex items-center gap-2">
+                            <span className="text-xs text-slate-400">Show /hour:</span>
+                            <ToggleSwitch
+                              checked={column.showHourlyRate}
+                              onCheckedChange={() => config.toggleColumnHourlyRate(column.fieldName)}
+                              aria-label={`Toggle hourly rate for ${displayName}`}
+                            />
+                          </div>
+                        )}
+                        <button
+                          onClick={() => config.removeColumn(column.fieldName)}
+                          className="text-slate-400 hover:text-red-400 transition-colors p-1 rounded hover:bg-red-500/10"
+                          aria-label={`Remove ${displayName} column`}
+                        >
+                          <X className="w-4 h-4" />
+                        </button>
+                      </div>
+                    </div>
+                  )
+                })}
+              </div>
+            )}
+          </div>
+
+          {/* Add Column Section */}
+          <div>
+            <h4 className="text-sm font-semibold text-slate-100 mb-4">
+              Add Column
+            </h4>
+
+            {config.unselectedFields.length === 0 ? (
+              <div className="bg-emerald-500/10 border border-emerald-500/30 rounded-lg p-4">
+                <p className="text-sm text-emerald-400 text-center font-medium">
+                  All available columns are already selected
+                </p>
+              </div>
+            ) : (
+              <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-2.5">
+                {config.unselectedFields.map(field => (
+                  <AddItemButton
+                    key={field.fieldName}
+                    onClick={() => config.addColumn(field.fieldName)}
+                  >
+                    {field.displayName}
+                  </AddItemButton>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Help Text */}
+          <div className="pt-6 border-t border-slate-700/50">
+            <div className="bg-blue-500/10 border border-blue-500/30 rounded-lg p-4">
+              <p className="text-xs text-blue-300 leading-relaxed">
+                <span className="font-semibold text-blue-200">Tip:</span> Column values show the maximum achieved for each tier.
+                Hourly rates are calculated from the specific run that achieved the maximum value.
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/features/data-tracking/components/tier-stats-table.tsx
+++ b/src/features/data-tracking/components/tier-stats-table.tsx
@@ -1,41 +1,27 @@
-import { useMemo, useState } from 'react'
 import { useData } from '../hooks/use-data'
-import { prepareTierStatsData, formatLargeNumber, TierStatsData } from '../utils/chart-data'
-import { formatDuration } from '../utils/data-parser'
 import { FarmingOnlyIndicator } from './farming-only-indicator'
 import { RunType } from '../types/game-run.types'
-
-type SortField = keyof TierStatsData
-type SortDirection = 'asc' | 'desc'
+import { TierStatsConfigPanel } from './tier-stats-config-panel'
+import { TierStatsCellTooltip } from './tier-stats-cell-tooltip'
+import { useTierStatsConfig } from '../hooks/use-tier-stats-config'
+import { useDynamicTierStatsTable } from '../hooks/use-dynamic-tier-stats-table'
+import { filterRunsByType } from '../utils/run-type-filter'
+import { getTierStatsCellClassName } from '../utils/tier-stats-cell-styles'
+import * as Tooltip from '@radix-ui/react-tooltip'
 
 export function TierStatsTable() {
   const { runs } = useData()
 
-  const baseTierStats = useMemo(() => prepareTierStatsData(runs, RunType.FARM), [runs])
-  const [sortField, setSortField] = useState<SortField>('tier')
-  const [sortDirection, setSortDirection] = useState<SortDirection>('desc')
-  
-  const tierStats = useMemo(() => {
-    return [...baseTierStats].sort((a, b) => {
-      const aValue = a[sortField]
-      const bValue = b[sortField]
-      
-      if (aValue < bValue) return sortDirection === 'asc' ? -1 : 1
-      if (aValue > bValue) return sortDirection === 'asc' ? 1 : -1
-      return 0
-    })
-  }, [baseTierStats, sortField, sortDirection])
-  
-  const handleSort = (field: SortField) => {
-    if (sortField === field) {
-      setSortDirection(sortDirection === 'asc' ? 'desc' : 'asc')
-    } else {
-      setSortField(field)
-      setSortDirection('desc')
-    }
-  }
+  // Filter to farm runs only
+  const farmRuns = filterRunsByType(runs, RunType.FARM)
 
-  if (tierStats.length === 0) {
+  // Configuration hook
+  const config = useTierStatsConfig(farmRuns)
+
+  // Dynamic table hook
+  const table = useDynamicTierStatsTable(farmRuns, config, RunType.FARM)
+
+  if (farmRuns.length === 0) {
     return (
       <div className="h-[400px] flex items-center justify-center text-muted-foreground">
         No tier data available. Import some game runs to see the analysis.
@@ -43,178 +29,168 @@ export function TierStatsTable() {
     )
   }
 
+  if (table.tierStats.length === 0) {
+    return (
+      <div className="h-[400px] flex items-center justify-center text-muted-foreground">
+        No tier statistics calculated. Ensure you have valid tier data.
+      </div>
+    )
+  }
+
   return (
-    <div className="space-y-6">
-      <div className="space-y-2">
-        <div className="flex items-center justify-between">
-          <h3 className="text-lg font-semibold text-slate-100">Performance by Tier</h3>
-          <FarmingOnlyIndicator />
+    <Tooltip.Provider delayDuration={300}>
+      <div className="space-y-6">
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <h3 className="text-lg font-semibold text-slate-100">Performance by Tier</h3>
+            <FarmingOnlyIndicator />
+          </div>
+          <p className="text-slate-400 text-sm">
+            Maximum values achieved across farming runs for each tier. Customize columns to track any resource.
+          </p>
         </div>
-        <p className="text-slate-400 text-sm">
-          Maximum values achieved across farming runs for each tier. Rates calculated as per-hour metrics.
-        </p>
-      </div>
 
-      {/* Summary Stats */}
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <div className="bg-gradient-to-br from-slate-800/50 to-slate-700/30 border border-slate-600/50 rounded-lg p-4 backdrop-blur-sm">
-          <div className="text-sm text-slate-400 mb-1">Total Tiers</div>
-          <div className="text-2xl font-bold text-slate-100">{tierStats.length}</div>
-        </div>
-        <div className="bg-gradient-to-br from-emerald-800/20 to-emerald-700/10 border border-emerald-600/30 rounded-lg p-4 backdrop-blur-sm">
-          <div className="text-sm text-emerald-400 mb-1">Highest Coins</div>
-          <div className="text-2xl font-bold text-emerald-300">
-            {tierStats.length > 0 ? formatLargeNumber(Math.max(...tierStats.map(t => t.maxCoins))) : '0'}
+        {/* Configuration Panel */}
+        <TierStatsConfigPanel config={config} />
+
+        {/* Summary Stats */}
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <div className="bg-gradient-to-br from-slate-800/50 to-slate-700/30 border border-slate-600/50 rounded-lg p-5 backdrop-blur-sm transition-all duration-200 hover:border-slate-500/60 hover:shadow-md">
+            <div className="text-sm text-slate-300 font-medium mb-2">Total Tiers</div>
+            <div className="text-3xl font-bold text-slate-100">{table.summary.totalTiers}</div>
+          </div>
+          <div className="bg-gradient-to-br from-emerald-800/20 to-emerald-700/10 border border-emerald-600/30 rounded-lg p-5 backdrop-blur-sm transition-all duration-200 hover:border-emerald-500/40 hover:shadow-md hover:shadow-emerald-500/10">
+            <div className="text-sm text-emerald-300 font-medium mb-2">Total Runs</div>
+            <div className="text-3xl font-bold text-emerald-200">
+              {table.summary.totalRuns}
+            </div>
+          </div>
+          <div className="bg-gradient-to-br from-purple-800/20 to-purple-700/10 border border-purple-600/30 rounded-lg p-5 backdrop-blur-sm transition-all duration-200 hover:border-purple-500/40 hover:shadow-md hover:shadow-purple-500/10">
+            <div className="text-sm text-purple-300 font-medium mb-2">Columns Displayed</div>
+            <div className="text-3xl font-bold text-purple-200">
+              {table.columns.length}
+            </div>
           </div>
         </div>
-        <div className="bg-gradient-to-br from-pink-800/20 to-pink-700/10 border border-pink-600/30 rounded-lg p-4 backdrop-blur-sm">
-          <div className="text-sm text-pink-400 mb-1">Highest Cells</div>
-          <div className="text-2xl font-bold text-pink-300">
-            {tierStats.length > 0 ? formatLargeNumber(Math.max(...tierStats.map(t => t.maxCells))) : '0'}
+
+        {/* Table */}
+        <div className="overflow-hidden rounded-lg border border-slate-700/50 bg-slate-800/30 backdrop-blur-sm">
+          <div className="overflow-x-auto">
+            <table className="w-full">
+              <thead>
+                <tr className="border-b border-slate-700/50 bg-gradient-to-r from-slate-700/20 via-slate-600/10 to-slate-700/20">
+                  {/* Tier Column */}
+                  <th
+                    className="px-6 py-4 text-left text-sm font-semibold text-slate-200"
+                    aria-sort={table.sortField === 'tier' ? (table.sortDirection === 'asc' ? 'ascending' : 'descending') : 'none'}
+                  >
+                    <button
+                      onClick={() => table.handleSort('tier')}
+                      className="flex items-center gap-2 hover:text-slate-100 transition-colors focus-visible:outline-none focus-visible:text-orange-400"
+                    >
+                      Tier
+                      {table.sortField === 'tier' && (
+                        <span className="text-xs text-orange-400">{table.sortDirection === 'asc' ? '↑' : '↓'}</span>
+                      )}
+                    </button>
+                  </th>
+
+                  {/* Dynamic Columns */}
+                  {table.columns.map(column => (
+                    <th
+                      key={column.id}
+                      className="px-6 py-4 text-right text-sm font-semibold text-slate-200"
+                      aria-sort={table.sortField === column.id ? (table.sortDirection === 'asc' ? 'ascending' : 'descending') : 'none'}
+                    >
+                      <button
+                        onClick={() => table.handleSort(column.id)}
+                        className="flex items-center gap-2 hover:text-slate-100 transition-colors ml-auto focus-visible:outline-none focus-visible:text-orange-400"
+                      >
+                        {column.displayName}
+                        {table.sortField === column.id && (
+                          <span className="text-xs text-orange-400">{table.sortDirection === 'asc' ? '↑' : '↓'}</span>
+                        )}
+                      </button>
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {table.tierStats.map((tierStats, index) => {
+                  const isEven = index % 2 === 0
+                  const rowBg = isEven
+                    ? 'bg-gradient-to-r from-slate-800/20 via-slate-700/10 to-slate-800/20'
+                    : 'bg-gradient-to-r from-slate-700/20 via-slate-600/10 to-slate-700/20'
+
+                  return (
+                    <tr
+                      key={tierStats.tier}
+                      className={`border-b border-slate-700/30 transition-all duration-200 hover:bg-gradient-to-r hover:from-purple-500/8 hover:via-pink-500/4 hover:to-purple-500/8 hover:border-purple-500/20 ${rowBg}`}
+                    >
+                      {/* Tier Cell */}
+                      <td className="px-6 py-3.5">
+                        <div className="flex items-center gap-3">
+                          <div className="w-2 h-7 bg-gradient-to-b from-purple-400 to-purple-600 rounded-full shadow-sm"></div>
+                          <span className="font-semibold text-slate-100">Tier {tierStats.tier}</span>
+                        </div>
+                      </td>
+
+                      {/* Dynamic Cells */}
+                      {table.columns.map(column => {
+                        const tooltipData = table.getCellTooltipData(tierStats, column)
+                        const displayValue = table.getCellDisplayValue(tierStats, column)
+
+                        const cellClassName = getTierStatsCellClassName({
+                          isHourlyRate: column.showHourlyRate,
+                          dataType: column.dataType
+                        })
+
+                        return (
+                          <td key={column.id} className="px-6 py-3.5 text-right">
+                            {tooltipData ? (
+                              <Tooltip.Root>
+                                <Tooltip.Trigger asChild>
+                                  <button className={cellClassName}>
+                                    <div className="flex flex-col items-end gap-0.5">
+                                      <div className="font-semibold">{displayValue.main}</div>
+                                      {displayValue.hourly && (
+                                        <div className="text-xs text-orange-300 opacity-90">{displayValue.hourly}</div>
+                                      )}
+                                    </div>
+                                  </button>
+                                </Tooltip.Trigger>
+                                <Tooltip.Portal>
+                                  <Tooltip.Content
+                                    side="top"
+                                    sideOffset={8}
+                                    className="z-50"
+                                  >
+                                    <TierStatsCellTooltip data={tooltipData} />
+                                    <Tooltip.Arrow className="fill-slate-950" />
+                                  </Tooltip.Content>
+                                </Tooltip.Portal>
+                              </Tooltip.Root>
+                            ) : (
+                              <span className={cellClassName}>
+                                <div className="flex flex-col items-end gap-0.5">
+                                  <div className="font-semibold">{displayValue.main}</div>
+                                  {displayValue.hourly && (
+                                    <div className="text-xs text-orange-300 opacity-90">{displayValue.hourly}</div>
+                                  )}
+                                </div>
+                              </span>
+                            )}
+                          </td>
+                        )
+                      })}
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
           </div>
         </div>
       </div>
-
-      <div className="overflow-hidden rounded-lg border border-slate-700/50 bg-slate-800/30 backdrop-blur-sm">
-        <div className="overflow-x-auto">
-          <table className="w-full">
-            <thead>
-              <tr className="border-b border-slate-700/50 bg-gradient-to-r from-slate-700/20 via-slate-600/10 to-slate-700/20">
-                <th className="px-6 py-4 text-left text-sm font-semibold text-slate-200">
-                  <button 
-                    onClick={() => handleSort('tier')}
-                    className="flex items-center gap-1 hover:text-slate-100 transition-colors"
-                  >
-                    Tier
-                    {sortField === 'tier' && (
-                      <span className="text-xs">{sortDirection === 'asc' ? '↑' : '↓'}</span>
-                    )}
-                  </button>
-                </th>
-                <th className="px-6 py-4 text-right text-sm font-semibold text-slate-200">
-                  <button 
-                    onClick={() => handleSort('maxWave')}
-                    className="flex items-center gap-1 hover:text-slate-100 transition-colors ml-auto"
-                  >
-                    Wave
-                    {sortField === 'maxWave' && (
-                      <span className="text-xs">{sortDirection === 'asc' ? '↑' : '↓'}</span>
-                    )}
-                  </button>
-                </th>
-                <th className="px-6 py-4 text-right text-sm font-semibold text-slate-200">
-                  <button 
-                    onClick={() => handleSort('maxDuration')}
-                    className="flex items-center gap-1 hover:text-slate-100 transition-colors ml-auto"
-                  >
-                    Duration
-                    {sortField === 'maxDuration' && (
-                      <span className="text-xs">{sortDirection === 'asc' ? '↑' : '↓'}</span>
-                    )}
-                  </button>
-                </th>
-                <th className="px-6 py-4 text-right text-sm font-semibold text-slate-200">
-                  <button 
-                    onClick={() => handleSort('maxCoins')}
-                    className="flex items-center gap-1 hover:text-slate-100 transition-colors ml-auto"
-                  >
-                    Coins
-                    {sortField === 'maxCoins' && (
-                      <span className="text-xs">{sortDirection === 'asc' ? '↑' : '↓'}</span>
-                    )}
-                  </button>
-                </th>
-                <th className="px-6 py-4 text-right text-sm font-semibold text-slate-200">
-                  <button 
-                    onClick={() => handleSort('maxCoinsPerHour')}
-                    className="flex items-center gap-1 hover:text-slate-100 transition-colors ml-auto"
-                  >
-                    Coins/Hour
-                    {sortField === 'maxCoinsPerHour' && (
-                      <span className="text-xs">{sortDirection === 'asc' ? '↑' : '↓'}</span>
-                    )}
-                  </button>
-                </th>
-                <th className="px-6 py-4 text-right text-sm font-semibold text-slate-200">
-                  <button 
-                    onClick={() => handleSort('maxCells')}
-                    className="flex items-center gap-1 hover:text-slate-100 transition-colors ml-auto"
-                  >
-                    Cells
-                    {sortField === 'maxCells' && (
-                      <span className="text-xs">{sortDirection === 'asc' ? '↑' : '↓'}</span>
-                    )}
-                  </button>
-                </th>
-                <th className="px-6 py-4 text-right text-sm font-semibold text-slate-200">
-                  <button 
-                    onClick={() => handleSort('maxCellsPerHour')}
-                    className="flex items-center gap-1 hover:text-slate-100 transition-colors ml-auto"
-                  >
-                    Cells/Hour
-                    {sortField === 'maxCellsPerHour' && (
-                      <span className="text-xs">{sortDirection === 'asc' ? '↑' : '↓'}</span>
-                    )}
-                  </button>
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {tierStats.map((tier, index) => {
-                // Alternate row colors with subtle gradients
-                const isEven = index % 2 === 0
-                const rowBg = isEven 
-                  ? 'bg-gradient-to-r from-slate-800/20 via-slate-700/10 to-slate-800/20' 
-                  : 'bg-gradient-to-r from-slate-700/20 via-slate-600/10 to-slate-700/20'
-                
-                return (
-                  <tr 
-                    key={tier.tier} 
-                    className={`border-b border-slate-700/30 transition-all duration-200 hover:bg-gradient-to-r hover:from-purple-500/10 hover:via-pink-500/5 hover:to-purple-500/10 ${rowBg}`}
-                  >
-                    <td className="px-6 py-4">
-                      <div className="flex items-center gap-2">
-                        <div className="w-2 h-6 bg-gradient-to-b from-purple-400 to-purple-600 rounded-full shadow-sm"></div>
-                        <span className="font-medium text-slate-100">Tier {tier.tier}</span>
-                      </div>
-                    </td>
-                    <td className="px-6 py-4 text-right">
-                      <span className="font-mono text-slate-200 bg-slate-700/30 px-2 py-1 rounded">
-                        {tier.maxWave.toLocaleString()}
-                      </span>
-                    </td>
-                    <td className="px-6 py-4 text-right">
-                      <span className="font-mono text-slate-200 bg-slate-700/30 px-2 py-1 rounded">
-                        {formatDuration(tier.maxDuration)}
-                      </span>
-                    </td>
-                    <td className="px-6 py-4 text-right">
-                      <span className="font-mono text-emerald-300 bg-emerald-500/10 px-2 py-1 rounded border border-emerald-500/20">
-                        {formatLargeNumber(tier.maxCoins)}
-                      </span>
-                    </td>
-                    <td className="px-6 py-4 text-right">
-                      <span className="font-mono text-emerald-300 bg-emerald-500/10 px-2 py-1 rounded border border-emerald-500/20">
-                        {formatLargeNumber(Math.round(tier.maxCoinsPerHour))}/h
-                      </span>
-                    </td>
-                    <td className="px-6 py-4 text-right">
-                      <span className="font-mono text-pink-300 bg-pink-500/10 px-2 py-1 rounded border border-pink-500/20">
-                        {formatLargeNumber(tier.maxCells)}
-                      </span>
-                    </td>
-                    <td className="px-6 py-4 text-right">
-                      <span className="font-mono text-pink-300 bg-pink-500/10 px-2 py-1 rounded border border-pink-500/20">
-                        {formatLargeNumber(Math.round(tier.maxCellsPerHour))}/h
-                      </span>
-                    </td>
-                  </tr>
-                )
-              })}
-            </tbody>
-          </table>
-        </div>
-      </div>
-    </div>
+    </Tooltip.Provider>
   )
 }

--- a/src/features/data-tracking/hooks/use-dynamic-tier-stats-table.ts
+++ b/src/features/data-tracking/hooks/use-dynamic-tier-stats-table.ts
@@ -1,0 +1,172 @@
+import { useMemo, useState, useCallback } from 'react'
+import type { ParsedGameRun } from '../types/game-run.types'
+import type { UseTierStatsConfigReturn } from './use-tier-stats-config'
+import type { DynamicTierStats, TierStatsColumn, CellTooltipData } from '../types/tier-stats-config.types'
+import {
+  calculateDynamicTierStats,
+  buildColumnDefinitions,
+  getCellValue,
+  calculateSummaryStats,
+  type TierStatsSummary
+} from '../utils/tier-stats-calculator'
+import { filterRunsByType, RunTypeFilter } from '../utils/run-type-filter'
+import { getFieldValue } from '../utils/field-utils'
+import { formatLargeNumber } from '../utils/chart-data'
+import { formatDuration } from '../utils/data-parser'
+
+export interface UseDynamicTierStatsTableReturn {
+  tierStats: DynamicTierStats[]
+  columns: TierStatsColumn[]
+  summary: TierStatsSummary
+  sortField: string
+  sortDirection: 'asc' | 'desc'
+  handleSort: (columnId: string) => void
+  getCellDisplayValue: (tierStats: DynamicTierStats, column: TierStatsColumn) => { main: string; hourly?: string }
+  getCellTooltipData: (tierStats: DynamicTierStats, column: TierStatsColumn) => CellTooltipData | null
+}
+
+export function useDynamicTierStatsTable(
+  runs: ParsedGameRun[],
+  config: UseTierStatsConfigReturn,
+  runTypeFilter: RunTypeFilter = 'farm'
+): UseDynamicTierStatsTableReturn {
+  // Filter runs by type
+  const filteredRuns = useMemo(
+    () => filterRunsByType(runs, runTypeFilter),
+    [runs, runTypeFilter]
+  )
+
+  // Calculate dynamic tier stats
+  const baseTierStats = useMemo(
+    () => calculateDynamicTierStats(filteredRuns, config.selectedColumns),
+    [filteredRuns, config.selectedColumns]
+  )
+
+  // Build column definitions
+  const columns = useMemo(
+    () => buildColumnDefinitions(
+      config.selectedColumns,
+      config.availableFields
+    ),
+    [config.selectedColumns, config.availableFields]
+  )
+
+  // Calculate summary stats
+  const summary = useMemo(
+    () => calculateSummaryStats(baseTierStats, config.selectedColumns),
+    [baseTierStats, config.selectedColumns]
+  )
+
+  // Sorting state
+  const [sortField, setSortField] = useState<string>('tier')
+  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('desc')
+
+  // Apply sorting
+  const tierStats = useMemo(() => {
+    return [...baseTierStats].sort((a, b) => {
+      // Special case: tier always sorts by tier number
+      if (sortField === 'tier') {
+        return sortDirection === 'asc' ? a.tier - b.tier : b.tier - a.tier
+      }
+
+      // Find the column to sort by
+      const column = columns.find(col => col.id === sortField)
+      if (!column) return 0
+
+      // Always sort by base value (not hourly rate)
+      const aValue = getCellValue(a, column.fieldName, false) ?? -Infinity
+      const bValue = getCellValue(b, column.fieldName, false) ?? -Infinity
+
+      if (aValue < bValue) return sortDirection === 'asc' ? -1 : 1
+      if (aValue > bValue) return sortDirection === 'asc' ? 1 : -1
+      return 0
+    })
+  }, [baseTierStats, sortField, sortDirection, columns])
+
+  // Sort handler
+  const handleSort = useCallback((columnId: string) => {
+    if (sortField === columnId) {
+      setSortDirection(sortDirection === 'asc' ? 'desc' : 'asc')
+    } else {
+      setSortField(columnId)
+      setSortDirection('desc')
+    }
+  }, [sortField, sortDirection])
+
+  // Get cell display value - returns object with main value and optional hourly rate
+  const getCellDisplayValue = useCallback((tierStats: DynamicTierStats, column: TierStatsColumn): { main: string; hourly?: string } => {
+    if (column.id === 'tier') {
+      return { main: `Tier ${tierStats.tier}` }
+    }
+
+    const value = getCellValue(tierStats, column.fieldName, false)
+    if (value === null) return { main: '-' }
+
+    const formattedMain = formatCellValue(value, column.dataType)
+
+    // Add hourly rate if enabled for this column
+    if (column.showHourlyRate) {
+      const hourlyValue = getCellValue(tierStats, column.fieldName, true)
+      if (hourlyValue !== null) {
+        const formattedHourly = formatCellValue(hourlyValue, column.dataType)
+        return { main: formattedMain, hourly: `${formattedHourly}/h` }
+      }
+    }
+
+    return { main: formattedMain }
+  }, [])
+
+  // Get tooltip data for a cell
+  const getCellTooltipData = useCallback((tierStats: DynamicTierStats, column: TierStatsColumn): CellTooltipData | null => {
+    if (column.id === 'tier') return null
+
+    const fieldStats = tierStats.fields[column.fieldName]
+    if (!fieldStats) return null
+
+    const run = fieldStats.maxValueRun
+    const wave = getFieldValue<number>(run, 'wave') ?? 0
+    const duration = run.realTime
+
+    const value = fieldStats.maxValue
+
+    const tooltipData: CellTooltipData = {
+      fieldName: column.fieldName,
+      displayName: column.displayName,
+      value,
+      run,
+      wave,
+      duration,
+      timestamp: run.timestamp,
+      isHourlyRate: false
+    }
+
+    // Add hourly rate context if this column shows hourly rates
+    if (column.showHourlyRate && fieldStats.hourlyRate) {
+      tooltipData.hourlyRateContext = {
+        baseValue: fieldStats.maxValue,
+        runDuration: duration
+      }
+    }
+
+    return tooltipData
+  }, [])
+
+  return {
+    tierStats,
+    columns,
+    summary,
+    sortField,
+    sortDirection,
+    handleSort,
+    getCellDisplayValue,
+    getCellTooltipData
+  }
+}
+
+// Helper function to format cell values based on data type
+function formatCellValue(value: number, dataType: 'number' | 'duration' | 'string' | 'date'): string {
+  if (dataType === 'duration') {
+    return formatDuration(Math.round(value))
+  }
+  return formatLargeNumber(Math.round(value))
+}

--- a/src/features/data-tracking/hooks/use-tier-stats-config.test.tsx
+++ b/src/features/data-tracking/hooks/use-tier-stats-config.test.tsx
@@ -1,0 +1,332 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useTierStatsConfig } from './use-tier-stats-config'
+import type { ParsedGameRun } from '../types/game-run.types'
+import { createGameRunField } from '../utils/field-utils'
+import { clearTierStatsConfig } from '../utils/tier-stats-persistence'
+
+describe('useTierStatsConfig', () => {
+  const createMockRun = (tier: number): ParsedGameRun => ({
+    id: `run-${tier}`,
+    timestamp: new Date('2024-01-01'),
+    fields: {
+      tier: createGameRunField('Tier', tier.toString()),
+      wave: createGameRunField('Wave', '1000'),
+      realTime: createGameRunField('Real Time', '2h 30m 0s'),
+      coinsEarned: createGameRunField('Coins Earned', '100M'),
+      cellsEarned: createGameRunField('Cells Earned', '50K'),
+      shards: createGameRunField('Shards', '1000'),
+      metals: createGameRunField('Metals', '500')
+    },
+    tier,
+    wave: 1000,
+    coinsEarned: 100000000,
+    cellsEarned: 50000,
+    realTime: 9000,
+    runType: 'farm'
+  })
+
+  beforeEach(() => {
+    localStorage.clear()
+    clearTierStatsConfig()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  describe('initialization', () => {
+    it('should load default configuration on first use', () => {
+      const runs = [createMockRun(5)]
+      const { result } = renderHook(() => useTierStatsConfig(runs))
+
+      expect(result.current.selectedColumns).toHaveLength(4)
+      expect(result.current.configSectionCollapsed).toBe(true)
+    })
+
+    it('should discover available fields from runs', () => {
+      const runs = [createMockRun(5)]
+      const { result } = renderHook(() => useTierStatsConfig(runs))
+
+      const fieldNames = result.current.availableFields.map(f => f.fieldName)
+      expect(fieldNames).toContain('wave')
+      expect(fieldNames).toContain('coinsEarned')
+      expect(fieldNames).toContain('cellsEarned')
+      expect(fieldNames).toContain('shards')
+      expect(fieldNames).toContain('metals')
+    })
+
+    it('should calculate unselected fields correctly', () => {
+      const runs = [createMockRun(5)]
+      const { result } = renderHook(() => useTierStatsConfig(runs))
+
+      const unselectedFieldNames = result.current.unselectedFields.map(f => f.fieldName)
+      expect(unselectedFieldNames).toContain('shards')
+      expect(unselectedFieldNames).toContain('metals')
+      expect(unselectedFieldNames).not.toContain('wave')
+      expect(unselectedFieldNames).not.toContain('coinsEarned')
+    })
+  })
+
+  describe('addColumn', () => {
+    it('should add a column to selected columns', () => {
+      const runs = [createMockRun(5)]
+      const { result } = renderHook(() => useTierStatsConfig(runs))
+
+      const initialCount = result.current.selectedColumns.length
+
+      act(() => {
+        result.current.addColumn('shards')
+      })
+
+      expect(result.current.selectedColumns).toHaveLength(initialCount + 1)
+      const added = result.current.selectedColumns.find(col => col.fieldName === 'shards')
+      expect(added).toBeDefined()
+      expect(added?.showHourlyRate).toBe(false)
+    })
+
+    it('should not add duplicate columns', () => {
+      const runs = [createMockRun(5)]
+      const { result } = renderHook(() => useTierStatsConfig(runs))
+
+      act(() => {
+        result.current.addColumn('wave')
+      })
+
+      const waveColumns = result.current.selectedColumns.filter(col => col.fieldName === 'wave')
+      expect(waveColumns).toHaveLength(1)
+    })
+
+    it('should update unselected fields after adding', () => {
+      const runs = [createMockRun(5)]
+      const { result } = renderHook(() => useTierStatsConfig(runs))
+
+      expect(result.current.unselectedFields.some(f => f.fieldName === 'shards')).toBe(true)
+
+      act(() => {
+        result.current.addColumn('shards')
+      })
+
+      expect(result.current.unselectedFields.some(f => f.fieldName === 'shards')).toBe(false)
+    })
+  })
+
+  describe('removeColumn', () => {
+    it('should remove a column from selected columns', () => {
+      const runs = [createMockRun(5)]
+      const { result } = renderHook(() => useTierStatsConfig(runs))
+
+      const initialCount = result.current.selectedColumns.length
+
+      act(() => {
+        result.current.removeColumn('wave')
+      })
+
+      expect(result.current.selectedColumns).toHaveLength(initialCount - 1)
+      expect(result.current.selectedColumns.some(col => col.fieldName === 'wave')).toBe(false)
+    })
+
+    it('should update unselected fields after removing', () => {
+      const runs = [createMockRun(5)]
+      const { result } = renderHook(() => useTierStatsConfig(runs))
+
+      expect(result.current.unselectedFields.some(f => f.fieldName === 'wave')).toBe(false)
+
+      act(() => {
+        result.current.removeColumn('wave')
+      })
+
+      expect(result.current.unselectedFields.some(f => f.fieldName === 'wave')).toBe(true)
+    })
+
+    it('should handle removing non-existent column gracefully', () => {
+      const runs = [createMockRun(5)]
+      const { result } = renderHook(() => useTierStatsConfig(runs))
+
+      const initialCount = result.current.selectedColumns.length
+
+      act(() => {
+        result.current.removeColumn('nonExistentField')
+      })
+
+      expect(result.current.selectedColumns).toHaveLength(initialCount)
+    })
+  })
+
+  describe('toggleColumnHourlyRate', () => {
+    it('should toggle hourly rate for a specific column', () => {
+      const runs = [createMockRun(5)]
+      const { result } = renderHook(() => useTierStatsConfig(runs))
+
+      // Find coins column (default has showHourlyRate: true)
+      const coinsCol = result.current.selectedColumns.find(col => col.fieldName === 'coinsEarned')
+      expect(coinsCol?.showHourlyRate).toBe(true)
+
+      act(() => {
+        result.current.toggleColumnHourlyRate('coinsEarned')
+      })
+
+      const coinsColAfter = result.current.selectedColumns.find(col => col.fieldName === 'coinsEarned')
+      expect(coinsColAfter?.showHourlyRate).toBe(false)
+
+      act(() => {
+        result.current.toggleColumnHourlyRate('coinsEarned')
+      })
+
+      const coinsColFinal = result.current.selectedColumns.find(col => col.fieldName === 'coinsEarned')
+      expect(coinsColFinal?.showHourlyRate).toBe(true)
+    })
+
+    it('should only affect the specified column', () => {
+      const runs = [createMockRun(5)]
+      const { result } = renderHook(() => useTierStatsConfig(runs))
+
+      const cellsInitial = result.current.selectedColumns.find(col => col.fieldName === 'cellsEarned')
+      const coinsInitial = result.current.selectedColumns.find(col => col.fieldName === 'coinsEarned')
+
+      act(() => {
+        result.current.toggleColumnHourlyRate('cellsEarned')
+      })
+
+      const cellsAfter = result.current.selectedColumns.find(col => col.fieldName === 'cellsEarned')
+      const coinsAfter = result.current.selectedColumns.find(col => col.fieldName === 'coinsEarned')
+
+      expect(cellsAfter?.showHourlyRate).toBe(!cellsInitial?.showHourlyRate)
+      expect(coinsAfter?.showHourlyRate).toBe(coinsInitial?.showHourlyRate)
+    })
+  })
+
+  describe('toggleConfigSection', () => {
+    it('should toggle config section collapsed state', () => {
+      const runs = [createMockRun(5)]
+      const { result } = renderHook(() => useTierStatsConfig(runs))
+
+      const initial = result.current.configSectionCollapsed
+
+      act(() => {
+        result.current.toggleConfigSection()
+      })
+
+      expect(result.current.configSectionCollapsed).toBe(!initial)
+
+      act(() => {
+        result.current.toggleConfigSection()
+      })
+
+      expect(result.current.configSectionCollapsed).toBe(initial)
+    })
+  })
+
+  describe('resetToDefaults', () => {
+    it('should reset configuration to defaults', () => {
+      const runs = [createMockRun(5)]
+      const { result } = renderHook(() => useTierStatsConfig(runs))
+
+      // Modify configuration
+      act(() => {
+        result.current.addColumn('shards')
+        result.current.toggleColumnHourlyRate('coinsEarned')
+        result.current.toggleConfigSection()
+      })
+
+      // Verify it changed
+      expect(result.current.selectedColumns.some(col => col.fieldName === 'shards')).toBe(true)
+      const coinsCol = result.current.selectedColumns.find(col => col.fieldName === 'coinsEarned')
+      expect(coinsCol?.showHourlyRate).toBe(false) // Was toggled off
+
+      // Reset
+      act(() => {
+        result.current.resetToDefaults()
+      })
+
+      // Verify defaults restored
+      expect(result.current.selectedColumns).toHaveLength(4)
+      expect(result.current.configSectionCollapsed).toBe(true)
+      expect(result.current.selectedColumns.some(col => col.fieldName === 'shards')).toBe(false)
+      const coinsColAfter = result.current.selectedColumns.find(col => col.fieldName === 'coinsEarned')
+      expect(coinsColAfter?.showHourlyRate).toBe(true) // Back to default
+    })
+  })
+
+  describe('localStorage persistence', () => {
+    it('should persist configuration changes to localStorage', () => {
+      const runs = [createMockRun(5)]
+      const { result } = renderHook(() => useTierStatsConfig(runs))
+
+      act(() => {
+        result.current.addColumn('shards')
+      })
+
+      // Create new hook instance to test loading from storage
+      const { result: result2 } = renderHook(() => useTierStatsConfig(runs))
+
+      expect(result2.current.selectedColumns.some(col => col.fieldName === 'shards')).toBe(true)
+    })
+
+    it('should persist column hourly rate toggle to localStorage', () => {
+      const runs = [createMockRun(5)]
+      const { result } = renderHook(() => useTierStatsConfig(runs))
+
+      act(() => {
+        result.current.toggleColumnHourlyRate('coinsEarned')
+      })
+
+      const { result: result2 } = renderHook(() => useTierStatsConfig(runs))
+
+      const coinsCol = result2.current.selectedColumns.find(col => col.fieldName === 'coinsEarned')
+      expect(coinsCol?.showHourlyRate).toBe(false)
+    })
+
+    it('should persist config section state to localStorage', () => {
+      const runs = [createMockRun(5)]
+      const { result } = renderHook(() => useTierStatsConfig(runs))
+
+      act(() => {
+        result.current.toggleConfigSection()
+      })
+
+      const { result: result2 } = renderHook(() => useTierStatsConfig(runs))
+
+      expect(result2.current.configSectionCollapsed).toBe(false)
+    })
+  })
+
+  describe('field validation', () => {
+    it('should remove invalid columns when available fields change', () => {
+      const runsWithShards = [createMockRun(5)]
+      const { result, rerender } = renderHook(
+        ({ runs }) => useTierStatsConfig(runs),
+        { initialProps: { runs: runsWithShards } }
+      )
+
+      act(() => {
+        result.current.addColumn('shards')
+      })
+
+      expect(result.current.selectedColumns.some(col => col.fieldName === 'shards')).toBe(true)
+
+      // Create runs without shards field
+      const runsWithoutShards: ParsedGameRun[] = [{
+        id: 'run-6',
+        timestamp: new Date('2024-01-01'),
+        fields: {
+          tier: createGameRunField('Tier', '6'),
+          wave: createGameRunField('Wave', '1000'),
+          realTime: createGameRunField('Real Time', '2h 30m 0s'),
+          coinsEarned: createGameRunField('Coins Earned', '100M'),
+          cellsEarned: createGameRunField('Cells Earned', '50K')
+        },
+        tier: 6,
+        wave: 1000,
+        coinsEarned: 100000000,
+        cellsEarned: 50000,
+        realTime: 9000,
+        runType: 'farm'
+      }]
+
+      rerender({ runs: runsWithoutShards })
+
+      expect(result.current.selectedColumns.some(col => col.fieldName === 'shards')).toBe(false)
+    })
+  })
+})

--- a/src/features/data-tracking/hooks/use-tier-stats-config.tsx
+++ b/src/features/data-tracking/hooks/use-tier-stats-config.tsx
@@ -1,0 +1,138 @@
+import { useState, useEffect, useMemo, useCallback } from 'react'
+import type { ParsedGameRun } from '../types/game-run.types'
+import type {
+  TierStatsConfig,
+  TierStatsColumnConfig,
+  AvailableField
+} from '../types/tier-stats-config.types'
+import {
+  discoverAvailableFields,
+  getUnselectedFields,
+  validateColumnConfig,
+  getDefaultConfig
+} from '../utils/tier-stats-config'
+import {
+  loadTierStatsConfig,
+  saveTierStatsConfig
+} from '../utils/tier-stats-persistence'
+
+export interface UseTierStatsConfigReturn {
+  // Configuration state
+  selectedColumns: TierStatsColumnConfig[]
+  configSectionCollapsed: boolean
+
+  // Available fields
+  availableFields: AvailableField[]
+  unselectedFields: AvailableField[]
+
+  // Actions
+  addColumn: (fieldName: string) => void
+  removeColumn: (fieldName: string) => void
+  toggleColumnHourlyRate: (fieldName: string) => void
+  toggleConfigSection: () => void
+  resetToDefaults: () => void
+}
+
+/**
+ * Hook for managing tier stats configuration state with localStorage persistence
+ */
+export function useTierStatsConfig(runs: ParsedGameRun[]): UseTierStatsConfigReturn {
+  // Discover available fields from runs data
+  const availableFields = useMemo(() => discoverAvailableFields(runs), [runs])
+
+  // Load initial configuration from localStorage
+  const [config, setConfig] = useState<TierStatsConfig>(() => {
+    const loaded = loadTierStatsConfig()
+    // Validate against current data
+    return {
+      ...loaded,
+      selectedColumns: validateColumnConfig(loaded.selectedColumns, availableFields)
+    }
+  })
+
+  // Persist to localStorage whenever config changes
+  useEffect(() => {
+    saveTierStatsConfig(config)
+  }, [config])
+
+  // Revalidate columns when available fields change
+  useEffect(() => {
+    setConfig(prev => {
+      const validated = validateColumnConfig(prev.selectedColumns, availableFields)
+      // Only update if validation changed something
+      if (validated.length !== prev.selectedColumns.length) {
+        return { ...prev, selectedColumns: validated }
+      }
+      return prev
+    })
+  }, [availableFields])
+
+  // Calculate unselected fields
+  const unselectedFields = useMemo(
+    () => getUnselectedFields(availableFields, config.selectedColumns),
+    [availableFields, config.selectedColumns]
+  )
+
+  // Add a column to the configuration
+  const addColumn = useCallback((fieldName: string) => {
+    setConfig(prev => {
+      // Check if already selected
+      if (prev.selectedColumns.some(col => col.fieldName === fieldName)) {
+        return prev
+      }
+
+      return {
+        ...prev,
+        selectedColumns: [
+          ...prev.selectedColumns,
+          { fieldName, showHourlyRate: false }
+        ]
+      }
+    })
+  }, [])
+
+  // Remove a column from the configuration
+  const removeColumn = useCallback((fieldName: string) => {
+    setConfig(prev => ({
+      ...prev,
+      selectedColumns: prev.selectedColumns.filter(col => col.fieldName !== fieldName)
+    }))
+  }, [])
+
+  // Toggle hourly rate for a specific column
+  const toggleColumnHourlyRate = useCallback((fieldName: string) => {
+    setConfig(prev => ({
+      ...prev,
+      selectedColumns: prev.selectedColumns.map(col =>
+        col.fieldName === fieldName
+          ? { ...col, showHourlyRate: !col.showHourlyRate }
+          : col
+      )
+    }))
+  }, [])
+
+  // Toggle configuration section collapsed state
+  const toggleConfigSection = useCallback(() => {
+    setConfig(prev => ({
+      ...prev,
+      configSectionCollapsed: !prev.configSectionCollapsed
+    }))
+  }, [])
+
+  // Reset configuration to defaults
+  const resetToDefaults = useCallback(() => {
+    setConfig(getDefaultConfig())
+  }, [])
+
+  return {
+    selectedColumns: config.selectedColumns,
+    configSectionCollapsed: config.configSectionCollapsed,
+    availableFields,
+    unselectedFields,
+    addColumn,
+    removeColumn,
+    toggleColumnHourlyRate,
+    toggleConfigSection,
+    resetToDefaults
+  }
+}

--- a/src/features/data-tracking/types/tier-stats-config.types.ts
+++ b/src/features/data-tracking/types/tier-stats-config.types.ts
@@ -1,0 +1,78 @@
+import type { ParsedGameRun } from './game-run.types'
+
+/**
+ * Configuration for a single column in the tier stats table
+ */
+export interface TierStatsColumnConfig {
+  fieldName: string
+  showHourlyRate: boolean
+}
+
+/**
+ * Complete tier stats configuration persisted to localStorage
+ */
+export interface TierStatsConfig {
+  selectedColumns: TierStatsColumnConfig[]
+  configSectionCollapsed: boolean
+  lastUpdated: number
+}
+
+/**
+ * Available field for column selection
+ */
+export interface AvailableField {
+  fieldName: string
+  displayName: string
+  dataType: 'number' | 'duration' | 'string' | 'date'
+  isNumeric: boolean
+  canHaveHourlyRate: boolean // Whether hourly rate makes sense for this field
+}
+
+/**
+ * Column definition for dynamic table rendering
+ */
+export interface TierStatsColumn {
+  id: string
+  fieldName: string
+  displayName: string
+  showHourlyRate: boolean // Whether to show hourly rate in this column's cell
+  dataType: 'number' | 'duration' | 'string' | 'date'
+}
+
+/**
+ * Stats data for a single tier with dynamic fields
+ */
+export interface DynamicTierStats {
+  tier: number
+  runCount: number
+  fields: Record<string, FieldStats>
+}
+
+/**
+ * Statistics for a specific field within a tier
+ */
+export interface FieldStats {
+  maxValue: number
+  maxValueRun: ParsedGameRun
+  hourlyRate?: number // Only present for numeric fields
+  longestDuration?: number // Track longest run duration for reference
+  longestDurationRun?: ParsedGameRun
+}
+
+/**
+ * Tooltip data for cell hover information
+ */
+export interface CellTooltipData {
+  fieldName: string
+  displayName: string
+  value: number
+  run: ParsedGameRun
+  wave: number
+  duration: number
+  timestamp: Date
+  isHourlyRate: boolean
+  hourlyRateContext?: {
+    baseValue: number
+    runDuration: number
+  }
+}

--- a/src/features/data-tracking/utils/tier-stats-calculator.test.ts
+++ b/src/features/data-tracking/utils/tier-stats-calculator.test.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect } from 'vitest'
+import type { ParsedGameRun } from '../types/game-run.types'
+import type { AvailableField, TierStatsColumnConfig } from '../types/tier-stats-config.types'
+import {
+  calculateDynamicTierStats,
+  calculateFieldStats,
+  buildColumnDefinitions,
+  getCellValue,
+  calculateSummaryStats
+} from './tier-stats-calculator'
+import { createGameRunField } from './field-utils'
+
+describe('tier-stats-calculator', () => {
+  const createMockRun = (
+    tier: number,
+    wave: number,
+    coins: number,
+    cells: number,
+    duration: number
+  ): ParsedGameRun => ({
+    id: `run-${tier}-${wave}`,
+    timestamp: new Date('2024-01-01'),
+    fields: {
+      tier: createGameRunField('Tier', tier.toString()),
+      wave: createGameRunField('Wave', wave.toString()),
+      realTime: createGameRunField('Real Time', `${Math.floor(duration / 3600)}h ${Math.floor((duration % 3600) / 60)}m 0s`),
+      coinsEarned: createGameRunField('Coins Earned', coins.toString()),
+      cellsEarned: createGameRunField('Cells Earned', cells.toString())
+    },
+    tier,
+    wave,
+    coinsEarned: coins,
+    cellsEarned: cells,
+    realTime: duration,
+    runType: 'farm'
+  })
+
+  describe('calculateFieldStats', () => {
+    it('should find maximum value across runs', () => {
+      const runs = [
+        createMockRun(5, 1000, 100000, 5000, 3600),
+        createMockRun(5, 1200, 150000, 6000, 3600),
+        createMockRun(5, 900, 80000, 4000, 3600)
+      ]
+
+      const stats = calculateFieldStats(runs, 'coinsEarned')
+
+      expect(stats?.maxValue).toBe(150000)
+      expect(stats?.maxValueRun.wave).toBe(1200)
+    })
+
+    it('should calculate hourly rate from run with max value', () => {
+      const runs = [
+        createMockRun(5, 1000, 100000, 5000, 7200), // 2 hours, 50K/hour
+        createMockRun(5, 1200, 150000, 6000, 3600), // 1 hour, 150K/hour (max coins)
+        createMockRun(5, 900, 80000, 4000, 10800) // 3 hours, 26.7K/hour
+      ]
+
+      const stats = calculateFieldStats(runs, 'coinsEarned')
+
+      expect(stats?.maxValue).toBe(150000)
+      expect(stats?.hourlyRate).toBe(150000) // 150000 / 3600 * 3600
+    })
+
+    it('should track longest duration independently', () => {
+      const runs = [
+        createMockRun(5, 1000, 100000, 5000, 3600),
+        createMockRun(5, 1200, 150000, 6000, 7200), // max coins, 2 hours
+        createMockRun(5, 900, 80000, 4000, 10800) // longest: 3 hours
+      ]
+
+      const stats = calculateFieldStats(runs, 'coinsEarned')
+
+      expect(stats?.longestDuration).toBe(10800)
+      expect(stats?.longestDurationRun?.wave).toBe(900)
+      expect(stats?.maxValueRun.wave).toBe(1200) // Different run
+    })
+
+    it('should return null for non-existent field', () => {
+      const runs = [createMockRun(5, 1000, 100000, 5000, 3600)]
+      const stats = calculateFieldStats(runs, 'nonExistentField')
+
+      expect(stats).toBeNull()
+    })
+
+    it('should handle runs with zero duration', () => {
+      const runs = [
+        createMockRun(5, 1000, 100000, 5000, 0)
+      ]
+
+      const stats = calculateFieldStats(runs, 'coinsEarned')
+
+      expect(stats?.maxValue).toBe(100000)
+      expect(stats?.hourlyRate).toBeUndefined()
+    })
+  })
+
+  describe('calculateDynamicTierStats', () => {
+    it('should calculate stats for multiple tiers', () => {
+      const runs = [
+        createMockRun(5, 1000, 100000, 5000, 3600),
+        createMockRun(5, 1200, 150000, 6000, 3600),
+        createMockRun(6, 1500, 200000, 8000, 3600),
+        createMockRun(6, 1400, 180000, 7000, 3600)
+      ]
+
+      const columns: TierStatsColumnConfig[] = [
+        { fieldName: 'coinsEarned', showHourlyRate: true },
+        { fieldName: 'cellsEarned', showHourlyRate: true }
+      ]
+
+      const tierStats = calculateDynamicTierStats(runs, columns)
+
+      expect(tierStats).toHaveLength(2)
+      expect(tierStats[0].tier).toBe(6) // Highest tier first
+      expect(tierStats[1].tier).toBe(5)
+    })
+
+    it('should calculate correct max values per tier', () => {
+      const runs = [
+        createMockRun(5, 1000, 100000, 5000, 3600),
+        createMockRun(5, 1200, 150000, 6000, 3600),
+        createMockRun(6, 1500, 200000, 8000, 3600)
+      ]
+
+      const columns: TierStatsColumnConfig[] = [
+        { fieldName: 'coinsEarned', showHourlyRate: false }
+      ]
+
+      const tierStats = calculateDynamicTierStats(runs, columns)
+
+      const tier5 = tierStats.find(t => t.tier === 5)
+      const tier6 = tierStats.find(t => t.tier === 6)
+
+      expect(tier5?.fields.coinsEarned.maxValue).toBe(150000)
+      expect(tier6?.fields.coinsEarned.maxValue).toBe(200000)
+    })
+
+    it('should track run count per tier', () => {
+      const runs = [
+        createMockRun(5, 1000, 100000, 5000, 3600),
+        createMockRun(5, 1200, 150000, 6000, 3600),
+        createMockRun(5, 900, 80000, 4000, 3600),
+        createMockRun(6, 1500, 200000, 8000, 3600)
+      ]
+
+      const columns: TierStatsColumnConfig[] = [
+        { fieldName: 'wave', showHourlyRate: false }
+      ]
+
+      const tierStats = calculateDynamicTierStats(runs, columns)
+
+      const tier5 = tierStats.find(t => t.tier === 5)
+      const tier6 = tierStats.find(t => t.tier === 6)
+
+      expect(tier5?.runCount).toBe(3)
+      expect(tier6?.runCount).toBe(1)
+    })
+
+    it('should handle empty runs array', () => {
+      const columns: TierStatsColumnConfig[] = [
+        { fieldName: 'coinsEarned', showHourlyRate: false }
+      ]
+
+      const tierStats = calculateDynamicTierStats([], columns)
+      expect(tierStats).toEqual([])
+    })
+  })
+
+  describe('buildColumnDefinitions', () => {
+    const availableFields: AvailableField[] = [
+      { fieldName: 'wave', displayName: 'Wave', dataType: 'number', isNumeric: true, canHaveHourlyRate: true },
+      { fieldName: 'coinsEarned', displayName: 'Coins Earned', dataType: 'number', isNumeric: true, canHaveHourlyRate: true },
+      { fieldName: 'killedBy', displayName: 'Killed By', dataType: 'string', isNumeric: false, canHaveHourlyRate: false }
+    ]
+
+    it('should create columns for each selected field', () => {
+      const selectedColumns: TierStatsColumnConfig[] = [
+        { fieldName: 'wave', showHourlyRate: false },
+        { fieldName: 'coinsEarned', showHourlyRate: false }
+      ]
+
+      const columns = buildColumnDefinitions(selectedColumns, availableFields)
+
+      expect(columns).toHaveLength(2)
+      expect(columns[0].fieldName).toBe('wave')
+      expect(columns[1].fieldName).toBe('coinsEarned')
+    })
+
+    it('should set showHourlyRate flag when enabled for numeric fields', () => {
+      const selectedColumns: TierStatsColumnConfig[] = [
+        { fieldName: 'wave', showHourlyRate: false },
+        { fieldName: 'coinsEarned', showHourlyRate: true }
+      ]
+
+      const columns = buildColumnDefinitions(selectedColumns, availableFields)
+
+      expect(columns).toHaveLength(2)
+      expect(columns[0].showHourlyRate).toBe(false)
+      expect(columns[1].showHourlyRate).toBe(true)
+    })
+
+    it('should not enable hourly rate for non-numeric fields even if requested', () => {
+      const selectedColumns: TierStatsColumnConfig[] = [
+        { fieldName: 'killedBy', showHourlyRate: true }
+      ]
+
+      const columns = buildColumnDefinitions(selectedColumns, availableFields)
+
+      expect(columns).toHaveLength(1)
+      expect(columns[0].showHourlyRate).toBe(false) // Can't have hourly rate for non-numeric
+    })
+
+    it('should skip unavailable fields', () => {
+      const selectedColumns: TierStatsColumnConfig[] = [
+        { fieldName: 'wave', showHourlyRate: false },
+        { fieldName: 'invalidField', showHourlyRate: false },
+        { fieldName: 'coinsEarned', showHourlyRate: false }
+      ]
+
+      const columns = buildColumnDefinitions(selectedColumns, availableFields)
+
+      expect(columns).toHaveLength(2)
+      expect(columns.map(c => c.fieldName)).toEqual(['wave', 'coinsEarned'])
+    })
+  })
+
+  describe('getCellValue', () => {
+    const runs = [
+      createMockRun(5, 1000, 100000, 5000, 3600)
+    ]
+
+    const columns: TierStatsColumnConfig[] = [
+      { fieldName: 'coinsEarned', showHourlyRate: true }
+    ]
+
+    const tierStats = calculateDynamicTierStats(runs, columns)[0]
+
+    it('should return max value for base column', () => {
+      const value = getCellValue(tierStats, 'coinsEarned', false)
+      expect(value).toBe(100000)
+    })
+
+    it('should return hourly rate for hourly column', () => {
+      const value = getCellValue(tierStats, 'coinsEarned', true)
+      expect(value).toBe(100000) // 100000 / 3600 * 3600
+    })
+
+    it('should return null for non-existent field', () => {
+      const value = getCellValue(tierStats, 'invalidField', false)
+      expect(value).toBeNull()
+    })
+  })
+
+  describe('calculateSummaryStats', () => {
+    it('should calculate total tiers and runs', () => {
+      const runs = [
+        createMockRun(5, 1000, 100000, 5000, 3600),
+        createMockRun(5, 1200, 150000, 6000, 3600),
+        createMockRun(6, 1500, 200000, 8000, 3600)
+      ]
+
+      const columns: TierStatsColumnConfig[] = [
+        { fieldName: 'coinsEarned', showHourlyRate: false }
+      ]
+
+      const tierStats = calculateDynamicTierStats(runs, columns)
+      const summary = calculateSummaryStats(tierStats, columns)
+
+      expect(summary.totalTiers).toBe(2)
+      expect(summary.totalRuns).toBe(3)
+    })
+
+    it('should find highest value across all tiers', () => {
+      const runs = [
+        createMockRun(5, 1000, 100000, 5000, 3600),
+        createMockRun(5, 1200, 150000, 6000, 3600),
+        createMockRun(6, 1500, 200000, 8000, 3600)
+      ]
+
+      const columns: TierStatsColumnConfig[] = [
+        { fieldName: 'coinsEarned', showHourlyRate: false },
+        { fieldName: 'cellsEarned', showHourlyRate: false }
+      ]
+
+      const tierStats = calculateDynamicTierStats(runs, columns)
+      const summary = calculateSummaryStats(tierStats, columns)
+
+      expect(summary.highestValues.coinsEarned).toBe(200000)
+      expect(summary.highestValues.cellsEarned).toBe(8000)
+    })
+
+    it('should handle empty tier stats', () => {
+      const summary = calculateSummaryStats([], [])
+
+      expect(summary.totalTiers).toBe(0)
+      expect(summary.totalRuns).toBe(0)
+      expect(summary.highestValues).toEqual({})
+    })
+  })
+})

--- a/src/features/data-tracking/utils/tier-stats-calculator.ts
+++ b/src/features/data-tracking/utils/tier-stats-calculator.ts
@@ -1,0 +1,176 @@
+import type { ParsedGameRun } from '../types/game-run.types'
+import type {
+  DynamicTierStats,
+  FieldStats,
+  TierStatsColumnConfig,
+  TierStatsColumn,
+  AvailableField
+} from '../types/tier-stats-config.types'
+import { getFieldValue } from './field-utils'
+import { getColumnDisplayName } from './tier-stats-config'
+
+/**
+ * Calculate dynamic tier stats for all tiers based on selected columns
+ */
+export function calculateDynamicTierStats(
+  runs: ParsedGameRun[],
+  selectedColumns: TierStatsColumnConfig[]
+): DynamicTierStats[] {
+  // Group runs by tier
+  const tierGroups = new Map<number, ParsedGameRun[]>()
+
+  runs.forEach(run => {
+    if (run.tier) {
+      if (!tierGroups.has(run.tier)) {
+        tierGroups.set(run.tier, [])
+      }
+      tierGroups.get(run.tier)!.push(run)
+    }
+  })
+
+  // Calculate stats for each tier
+  const tierStats: DynamicTierStats[] = []
+
+  tierGroups.forEach((tierRuns, tier) => {
+    const fields: Record<string, FieldStats> = {}
+
+    // Calculate stats for each selected column
+    selectedColumns.forEach(column => {
+      const fieldStats = calculateFieldStats(tierRuns, column.fieldName)
+      if (fieldStats) {
+        fields[column.fieldName] = fieldStats
+      }
+    })
+
+    tierStats.push({
+      tier,
+      runCount: tierRuns.length,
+      fields
+    })
+  })
+
+  return tierStats.sort((a, b) => b.tier - a.tier) // Highest tier first
+}
+
+/**
+ * Calculate statistics for a specific field across runs in a tier
+ */
+export function calculateFieldStats(
+  runs: ParsedGameRun[],
+  fieldName: string
+): FieldStats | null {
+  let maxValue = -Infinity
+  let maxValueRun: ParsedGameRun | null = null
+  let longestDuration = 0
+  let longestDurationRun: ParsedGameRun | null = null
+
+  runs.forEach(run => {
+    const value = getFieldValue<number>(run, fieldName)
+
+    // Track maximum value
+    if (value !== null && value > maxValue) {
+      maxValue = value
+      maxValueRun = run
+    }
+
+    // Track longest duration for reference
+    const duration = run.realTime
+    if (duration > longestDuration) {
+      longestDuration = duration
+      longestDurationRun = run
+    }
+  })
+
+  if (!maxValueRun) return null
+
+  const fieldStats: FieldStats = {
+    maxValue,
+    maxValueRun: maxValueRun as ParsedGameRun,
+    longestDuration,
+    longestDurationRun: longestDurationRun ?? undefined
+  }
+
+  // Calculate hourly rate based on the run that achieved max value
+  const runRealTime = (maxValueRun as ParsedGameRun).realTime
+  if (runRealTime > 0 && typeof maxValue === 'number') {
+    fieldStats.hourlyRate = (maxValue / runRealTime) * 3600
+  }
+
+  return fieldStats
+}
+
+/**
+ * Build column definitions for table rendering
+ * Now creates one column per field, with hourly rate shown in same cell
+ */
+export function buildColumnDefinitions(
+  selectedColumns: TierStatsColumnConfig[],
+  availableFields: AvailableField[]
+): TierStatsColumn[] {
+  const columns: TierStatsColumn[] = []
+
+  selectedColumns.forEach(columnConfig => {
+    const field = availableFields.find(f => f.fieldName === columnConfig.fieldName)
+    if (!field) return
+
+    // Add single column (hourly rate will be shown in same cell if enabled)
+    columns.push({
+      id: columnConfig.fieldName,
+      fieldName: columnConfig.fieldName,
+      displayName: getColumnDisplayName(columnConfig.fieldName, false, availableFields),
+      showHourlyRate: columnConfig.showHourlyRate && field.canHaveHourlyRate,
+      dataType: field.dataType
+    })
+  })
+
+  return columns
+}
+
+/**
+ * Get the value to display in a table cell
+ */
+export function getCellValue(
+  tierStats: DynamicTierStats,
+  fieldName: string,
+  isHourlyRate: boolean
+): number | null {
+  const fieldStats = tierStats.fields[fieldName]
+  if (!fieldStats) return null
+
+  return isHourlyRate ? fieldStats.hourlyRate ?? null : fieldStats.maxValue
+}
+
+/**
+ * Calculate summary statistics across all tiers
+ */
+export interface TierStatsSummary {
+  totalTiers: number
+  totalRuns: number
+  highestValues: Record<string, number>
+}
+
+export function calculateSummaryStats(
+  tierStats: DynamicTierStats[],
+  selectedColumns: TierStatsColumnConfig[]
+): TierStatsSummary {
+  const highestValues: Record<string, number> = {}
+  let totalRuns = 0
+
+  tierStats.forEach(tier => {
+    totalRuns += tier.runCount
+
+    selectedColumns.forEach(column => {
+      const fieldStats = tier.fields[column.fieldName]
+      if (fieldStats) {
+        const current = highestValues[column.fieldName] ?? -Infinity
+        highestValues[column.fieldName] = Math.max(current, fieldStats.maxValue)
+      }
+    })
+  })
+
+  return {
+    totalTiers: tierStats.length,
+    totalRuns,
+    highestValues
+  }
+}

--- a/src/features/data-tracking/utils/tier-stats-cell-styles.test.ts
+++ b/src/features/data-tracking/utils/tier-stats-cell-styles.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest'
+import { getTierStatsCellClassName, type CellStyleConfig } from './tier-stats-cell-styles'
+
+describe('tier-stats-cell-styles', () => {
+  describe('getTierStatsCellClassName', () => {
+    const baseClasses = 'font-mono text-sm px-3 py-1.5 rounded-md cursor-help transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-400/50'
+
+    it('should return hourly rate styling when isHourlyRate is true', () => {
+      const config: CellStyleConfig = {
+        isHourlyRate: true,
+        dataType: 'number'
+      }
+
+      const result = getTierStatsCellClassName(config)
+
+      expect(result).toBe(
+        `${baseClasses} bg-orange-500/10 border border-orange-500/30 text-orange-200 hover:bg-orange-500/20 hover:border-orange-500/40 hover:shadow-sm`
+      )
+    })
+
+    it('should return duration styling for duration data type', () => {
+      const config: CellStyleConfig = {
+        isHourlyRate: false,
+        dataType: 'duration'
+      }
+
+      const result = getTierStatsCellClassName(config)
+
+      expect(result).toBe(`${baseClasses} bg-slate-700/40 border border-slate-600/40 text-slate-200 hover:bg-slate-700/60 hover:border-slate-600/60`)
+    })
+
+    it('should return default styling for number data type', () => {
+      const config: CellStyleConfig = {
+        isHourlyRate: false,
+        dataType: 'number'
+      }
+
+      const result = getTierStatsCellClassName(config)
+
+      expect(result).toBe(`${baseClasses} bg-slate-700/40 border border-slate-600/40 text-slate-200 hover:bg-slate-700/60 hover:border-slate-600/60`)
+    })
+
+    it('should return default styling for string data type', () => {
+      const config: CellStyleConfig = {
+        isHourlyRate: false,
+        dataType: 'string'
+      }
+
+      const result = getTierStatsCellClassName(config)
+
+      expect(result).toBe(`${baseClasses} bg-slate-700/40 border border-slate-600/40 text-slate-200 hover:bg-slate-700/60 hover:border-slate-600/60`)
+    })
+
+    it('should return default styling for date data type', () => {
+      const config: CellStyleConfig = {
+        isHourlyRate: false,
+        dataType: 'date'
+      }
+
+      const result = getTierStatsCellClassName(config)
+
+      expect(result).toBe(`${baseClasses} bg-slate-700/40 border border-slate-600/40 text-slate-200 hover:bg-slate-700/60 hover:border-slate-600/60`)
+    })
+
+    it('should prioritize hourly rate styling over duration styling', () => {
+      const config: CellStyleConfig = {
+        isHourlyRate: true,
+        dataType: 'duration'
+      }
+
+      const result = getTierStatsCellClassName(config)
+
+      expect(result).toBe(
+        `${baseClasses} bg-orange-500/10 border border-orange-500/30 text-orange-200 hover:bg-orange-500/20 hover:border-orange-500/40 hover:shadow-sm`
+      )
+    })
+  })
+})

--- a/src/features/data-tracking/utils/tier-stats-cell-styles.ts
+++ b/src/features/data-tracking/utils/tier-stats-cell-styles.ts
@@ -1,0 +1,28 @@
+/**
+ * Pure functions for tier stats table cell styling
+ */
+
+export interface CellStyleConfig {
+  isHourlyRate: boolean
+  dataType: 'number' | 'duration' | 'string' | 'date'
+}
+
+/**
+ * Get the CSS class name for a tier stats table cell based on its type
+ *
+ * @param config - Cell configuration specifying type and hourly rate status
+ * @returns Tailwind CSS class string for the cell
+ */
+export function getTierStatsCellClassName(config: CellStyleConfig): string {
+  const base = 'font-mono text-sm px-3 py-1.5 rounded-md cursor-help transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-400/50'
+
+  if (config.isHourlyRate) {
+    return `${base} bg-orange-500/10 border border-orange-500/30 text-orange-200 hover:bg-orange-500/20 hover:border-orange-500/40 hover:shadow-sm`
+  }
+
+  if (config.dataType === 'duration') {
+    return `${base} bg-slate-700/40 border border-slate-600/40 text-slate-200 hover:bg-slate-700/60 hover:border-slate-600/60`
+  }
+
+  return `${base} bg-slate-700/40 border border-slate-600/40 text-slate-200 hover:bg-slate-700/60 hover:border-slate-600/60`
+}

--- a/src/features/data-tracking/utils/tier-stats-config.test.ts
+++ b/src/features/data-tracking/utils/tier-stats-config.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect } from 'vitest'
+import type { ParsedGameRun } from '../types/game-run.types'
+import type { AvailableField, TierStatsColumnConfig } from '../types/tier-stats-config.types'
+import {
+  DEFAULT_COLUMNS,
+  getDefaultConfig,
+  discoverAvailableFields,
+  getUnselectedFields,
+  validateColumnConfig,
+  isNumericField,
+  getFieldDisplayName,
+  getColumnDisplayName
+} from './tier-stats-config'
+import { createGameRunField } from './field-utils'
+
+describe('tier-stats-config', () => {
+  const createMockRun = (overrides?: Partial<ParsedGameRun>): ParsedGameRun => ({
+    id: '1',
+    timestamp: new Date('2024-01-01'),
+    fields: {
+      tier: createGameRunField('Tier', '5'),
+      wave: createGameRunField('Wave', '1000'),
+      realTime: createGameRunField('Real Time', '2h 30m 0s'),
+      coinsEarned: createGameRunField('Coins Earned', '100M'),
+      cellsEarned: createGameRunField('Cells Earned', '50K'),
+      shards: createGameRunField('Shards', '1000'),
+      runType: createGameRunField('Run Type', 'farm')
+    },
+    tier: 5,
+    wave: 1000,
+    coinsEarned: 100000000,
+    cellsEarned: 50000,
+    realTime: 9000,
+    runType: 'farm',
+    ...overrides
+  })
+
+  describe('getDefaultConfig', () => {
+    it('should return default configuration with expected columns', () => {
+      const config = getDefaultConfig()
+
+      expect(config.selectedColumns).toEqual(DEFAULT_COLUMNS)
+      expect(config.configSectionCollapsed).toBe(true)
+      expect(config.lastUpdated).toBeGreaterThan(0)
+    })
+
+    it('should include wave, realTime, coinsEarned, and cellsEarned in defaults', () => {
+      const config = getDefaultConfig()
+      const fieldNames = config.selectedColumns.map(col => col.fieldName)
+
+      expect(fieldNames).toContain('wave')
+      expect(fieldNames).toContain('realTime')
+      expect(fieldNames).toContain('coinsEarned')
+      expect(fieldNames).toContain('cellsEarned')
+    })
+  })
+
+  describe('discoverAvailableFields', () => {
+    it('should return empty array for empty runs', () => {
+      const fields = discoverAvailableFields([])
+      expect(fields).toEqual([])
+    })
+
+    it('should discover all non-internal fields from runs', () => {
+      const runs = [createMockRun()]
+      const fields = discoverAvailableFields(runs)
+
+      const fieldNames = fields.map(f => f.fieldName)
+      expect(fieldNames).toContain('tier')
+      expect(fieldNames).toContain('wave')
+      expect(fieldNames).toContain('realTime')
+      expect(fieldNames).toContain('coinsEarned')
+      expect(fieldNames).toContain('cellsEarned')
+      expect(fieldNames).toContain('shards')
+    })
+
+    it('should exclude internal fields starting with underscore', () => {
+      const run = createMockRun()
+      run.fields._internalField = createGameRunField('_Internal', 'test')
+
+      const fields = discoverAvailableFields([run])
+      const fieldNames = fields.map(f => f.fieldName)
+
+      expect(fieldNames).not.toContain('_internalField')
+    })
+
+    it('should exclude date fields', () => {
+      const run = createMockRun()
+      run.fields.battleDate = createGameRunField('Battle Date', '2024-01-01')
+
+      const fields = discoverAvailableFields([run])
+      const fieldNames = fields.map(f => f.fieldName)
+
+      expect(fieldNames).not.toContain('battleDate')
+    })
+
+    it('should exclude runType field', () => {
+      const runs = [createMockRun()]
+      const fields = discoverAvailableFields(runs)
+      const fieldNames = fields.map(f => f.fieldName)
+
+      expect(fieldNames).not.toContain('runType')
+    })
+
+    it('should mark numeric and duration fields as isNumeric', () => {
+      const runs = [createMockRun()]
+      const fields = discoverAvailableFields(runs)
+
+      const coinsField = fields.find(f => f.fieldName === 'coinsEarned')
+      expect(coinsField?.isNumeric).toBe(true)
+      expect(coinsField?.canHaveHourlyRate).toBe(true)
+
+      const realTimeField = fields.find(f => f.fieldName === 'realTime')
+      expect(realTimeField?.isNumeric).toBe(true)
+      expect(realTimeField?.canHaveHourlyRate).toBe(false) // Duration fields can't have hourly rates
+    })
+
+    it('should sort fields alphabetically by display name', () => {
+      const runs = [createMockRun()]
+      const fields = discoverAvailableFields(runs)
+
+      const displayNames = fields.map(f => f.displayName)
+      const sorted = [...displayNames].sort()
+
+      expect(displayNames).toEqual(sorted)
+    })
+  })
+
+  describe('getUnselectedFields', () => {
+    const availableFields: AvailableField[] = [
+      { fieldName: 'wave', displayName: 'Wave', dataType: 'number', isNumeric: true, canHaveHourlyRate: true },
+      { fieldName: 'coinsEarned', displayName: 'Coins Earned', dataType: 'number', isNumeric: true, canHaveHourlyRate: true },
+      { fieldName: 'cellsEarned', displayName: 'Cells Earned', dataType: 'number', isNumeric: true, canHaveHourlyRate: true },
+      { fieldName: 'shards', displayName: 'Shards', dataType: 'number', isNumeric: true, canHaveHourlyRate: true }
+    ]
+
+    it('should return fields not in selected columns', () => {
+      const selected: TierStatsColumnConfig[] = [
+        { fieldName: 'wave', showHourlyRate: false },
+        { fieldName: 'coinsEarned', showHourlyRate: true }
+      ]
+
+      const unselected = getUnselectedFields(availableFields, selected)
+      const fieldNames = unselected.map(f => f.fieldName)
+
+      expect(fieldNames).toContain('cellsEarned')
+      expect(fieldNames).toContain('shards')
+      expect(fieldNames).not.toContain('wave')
+      expect(fieldNames).not.toContain('coinsEarned')
+    })
+
+    it('should return all fields when none selected', () => {
+      const unselected = getUnselectedFields(availableFields, [])
+      expect(unselected).toEqual(availableFields)
+    })
+
+    it('should return empty array when all fields selected', () => {
+      const selected: TierStatsColumnConfig[] = availableFields.map(f => ({
+        fieldName: f.fieldName,
+        showHourlyRate: false
+      }))
+
+      const unselected = getUnselectedFields(availableFields, selected)
+      expect(unselected).toEqual([])
+    })
+  })
+
+  describe('validateColumnConfig', () => {
+    const availableFields: AvailableField[] = [
+      { fieldName: 'wave', displayName: 'Wave', dataType: 'number', isNumeric: true },
+      { fieldName: 'coinsEarned', displayName: 'Coins Earned', dataType: 'number', isNumeric: true }
+    ]
+
+    it('should keep valid columns', () => {
+      const config: TierStatsColumnConfig[] = [
+        { fieldName: 'wave', showHourlyRate: false },
+        { fieldName: 'coinsEarned', showHourlyRate: true }
+      ]
+
+      const validated = validateColumnConfig(config, availableFields)
+      expect(validated).toEqual(config)
+    })
+
+    it('should remove columns with non-existent fields', () => {
+      const config: TierStatsColumnConfig[] = [
+        { fieldName: 'wave', showHourlyRate: false },
+        { fieldName: 'invalidField', showHourlyRate: false },
+        { fieldName: 'coinsEarned', showHourlyRate: true }
+      ]
+
+      const validated = validateColumnConfig(config, availableFields)
+      expect(validated).toHaveLength(2)
+      expect(validated.map(c => c.fieldName)).toEqual(['wave', 'coinsEarned'])
+    })
+
+    it('should return empty array when no valid columns', () => {
+      const config: TierStatsColumnConfig[] = [
+        { fieldName: 'invalidField1', showHourlyRate: false },
+        { fieldName: 'invalidField2', showHourlyRate: false }
+      ]
+
+      const validated = validateColumnConfig(config, availableFields)
+      expect(validated).toEqual([])
+    })
+  })
+
+  describe('isNumericField', () => {
+    const availableFields: AvailableField[] = [
+      { fieldName: 'wave', displayName: 'Wave', dataType: 'number', isNumeric: true },
+      { fieldName: 'realTime', displayName: 'Real Time', dataType: 'duration', isNumeric: true },
+      { fieldName: 'killedBy', displayName: 'Killed By', dataType: 'string', isNumeric: false }
+    ]
+
+    it('should return true for numeric fields', () => {
+      expect(isNumericField('wave', availableFields)).toBe(true)
+      expect(isNumericField('realTime', availableFields)).toBe(true)
+    })
+
+    it('should return false for non-numeric fields', () => {
+      expect(isNumericField('killedBy', availableFields)).toBe(false)
+    })
+
+    it('should return false for non-existent fields', () => {
+      expect(isNumericField('invalidField', availableFields)).toBe(false)
+    })
+  })
+
+  describe('getFieldDisplayName', () => {
+    const availableFields: AvailableField[] = [
+      { fieldName: 'coinsEarned', displayName: 'Coins Earned', dataType: 'number', isNumeric: true },
+      { fieldName: 'wave', displayName: 'Wave', dataType: 'number', isNumeric: true }
+    ]
+
+    it('should return display name for existing field', () => {
+      expect(getFieldDisplayName('coinsEarned', availableFields)).toBe('Coins Earned')
+    })
+
+    it('should return field name for non-existent field', () => {
+      expect(getFieldDisplayName('invalidField', availableFields)).toBe('invalidField')
+    })
+  })
+
+  describe('getColumnDisplayName', () => {
+    const availableFields: AvailableField[] = [
+      { fieldName: 'coinsEarned', displayName: 'Coins Earned', dataType: 'number', isNumeric: true },
+      { fieldName: 'realTime', displayName: 'Real Time', dataType: 'duration', isNumeric: true },
+      { fieldName: 'wave', displayName: 'Wave', dataType: 'number', isNumeric: true }
+    ]
+
+    it('should return base display name when not hourly rate', () => {
+      const name = getColumnDisplayName('coinsEarned', false, availableFields)
+      expect(name).toBe('Coins Earned')
+    })
+
+    it('should append /Hour suffix for hourly rate columns', () => {
+      const name = getColumnDisplayName('coinsEarned', true, availableFields)
+      expect(name).toBe('Coins Earned/Hour')
+    })
+
+    it('should use special label for realTime non-hourly column', () => {
+      const name = getColumnDisplayName('realTime', false, availableFields)
+      expect(name).toBe('Longest Run Duration')
+    })
+
+    it('should use /Hour suffix for realTime hourly column', () => {
+      const name = getColumnDisplayName('realTime', true, availableFields)
+      expect(name).toBe('Real Time/Hour')
+    })
+  })
+})

--- a/src/features/data-tracking/utils/tier-stats-config.ts
+++ b/src/features/data-tracking/utils/tier-stats-config.ts
@@ -1,0 +1,142 @@
+import type { ParsedGameRun } from '../types/game-run.types'
+import type {
+  AvailableField,
+  TierStatsColumnConfig,
+  TierStatsConfig
+} from '../types/tier-stats-config.types'
+
+/**
+ * Default columns for tier stats table
+ */
+export const DEFAULT_COLUMNS: TierStatsColumnConfig[] = [
+  { fieldName: 'wave', showHourlyRate: false },
+  { fieldName: 'realTime', showHourlyRate: false },
+  { fieldName: 'coinsEarned', showHourlyRate: true },
+  { fieldName: 'cellsEarned', showHourlyRate: true }
+]
+
+/**
+ * Default configuration for tier stats
+ */
+export function getDefaultConfig(): TierStatsConfig {
+  return {
+    selectedColumns: DEFAULT_COLUMNS,
+    configSectionCollapsed: true,
+    lastUpdated: Date.now()
+  }
+}
+
+/**
+ * Discover all available fields from runs data
+ * Excludes internal fields (prefixed with _) and non-tier-stat fields
+ */
+export function discoverAvailableFields(runs: ParsedGameRun[]): AvailableField[] {
+  if (runs.length === 0) return []
+
+  const fieldMap = new Map<string, AvailableField>()
+
+  // Sample first run to get field structure
+  const sampleRun = runs[0]
+
+  Object.entries(sampleRun.fields).forEach(([fieldName, field]) => {
+    // Skip internal fields
+    if (fieldName.startsWith('_')) return
+
+    // Skip date/time fields (not useful for tier stats)
+    if (field.dataType === 'date') return
+
+    // Skip run type field (already filtered at higher level)
+    if (fieldName === 'runType') return
+
+    const isNumeric = field.dataType === 'number' || field.dataType === 'duration'
+
+    // Hourly rates don't make sense for duration fields (hours per hour = 1)
+    const canHaveHourlyRate = field.dataType === 'number'
+
+    fieldMap.set(fieldName, {
+      fieldName,
+      displayName: field.originalKey,
+      dataType: field.dataType,
+      isNumeric,
+      canHaveHourlyRate
+    })
+  })
+
+  return Array.from(fieldMap.values()).sort((a, b) =>
+    a.displayName.localeCompare(b.displayName)
+  )
+}
+
+/**
+ * Get fields that are not currently selected
+ */
+export function getUnselectedFields(
+  availableFields: AvailableField[],
+  selectedColumns: TierStatsColumnConfig[]
+): AvailableField[] {
+  const selectedFieldNames = new Set(selectedColumns.map(col => col.fieldName))
+  return availableFields.filter(field => !selectedFieldNames.has(field.fieldName))
+}
+
+/**
+ * Validate column configuration against available fields
+ * Removes columns that no longer exist in the data
+ */
+export function validateColumnConfig(
+  config: TierStatsColumnConfig[],
+  availableFields: AvailableField[]
+): TierStatsColumnConfig[] {
+  const validFieldNames = new Set(availableFields.map(f => f.fieldName))
+  return config.filter(col => validFieldNames.has(col.fieldName))
+}
+
+/**
+ * Check if a field name is valid and numeric (can have hourly rates)
+ */
+export function isNumericField(
+  fieldName: string,
+  availableFields: AvailableField[]
+): boolean {
+  const field = availableFields.find(f => f.fieldName === fieldName)
+  return field?.isNumeric ?? false
+}
+
+/**
+ * Check if a field can have hourly rates (excludes duration fields)
+ */
+export function canFieldHaveHourlyRate(
+  fieldName: string,
+  availableFields: AvailableField[]
+): boolean {
+  const field = availableFields.find(f => f.fieldName === fieldName)
+  return field?.canHaveHourlyRate ?? false
+}
+
+/**
+ * Get display name for a field
+ */
+export function getFieldDisplayName(
+  fieldName: string,
+  availableFields: AvailableField[]
+): string {
+  const field = availableFields.find(f => f.fieldName === fieldName)
+  return field?.displayName ?? fieldName
+}
+
+/**
+ * Generate column display name including hourly rate suffix
+ */
+export function getColumnDisplayName(
+  fieldName: string,
+  isHourlyRate: boolean,
+  availableFields: AvailableField[]
+): string {
+  const baseName = getFieldDisplayName(fieldName, availableFields)
+
+  // Special case for duration fields
+  if (fieldName === 'realTime') {
+    return isHourlyRate ? `${baseName}/Hour` : 'Longest Run Duration'
+  }
+
+  return isHourlyRate ? `${baseName}/Hour` : baseName
+}

--- a/src/features/data-tracking/utils/tier-stats-persistence.test.ts
+++ b/src/features/data-tracking/utils/tier-stats-persistence.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  loadTierStatsConfig,
+  saveTierStatsConfig,
+  clearTierStatsConfig
+} from './tier-stats-persistence'
+import { getDefaultConfig } from './tier-stats-config'
+import type { TierStatsConfig } from '../types/tier-stats-config.types'
+
+describe('tier-stats-persistence', () => {
+  const STORAGE_KEY = 'tower-tracking-tier-stats-config'
+
+  beforeEach(() => {
+    localStorage.clear()
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  describe('loadTierStatsConfig', () => {
+    it('should return default config when nothing in localStorage', () => {
+      const config = loadTierStatsConfig()
+      const defaultConfig = getDefaultConfig()
+
+      expect(config.selectedColumns).toEqual(defaultConfig.selectedColumns)
+      expect(config.configSectionCollapsed).toBe(defaultConfig.configSectionCollapsed)
+    })
+
+    it('should load valid config from localStorage', () => {
+      const savedConfig: TierStatsConfig = {
+        selectedColumns: [
+          { fieldName: 'wave', showHourlyRate: false },
+          { fieldName: 'shards', showHourlyRate: true }
+        ],
+        configSectionCollapsed: false,
+        lastUpdated: Date.now()
+      }
+
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(savedConfig))
+
+      const loaded = loadTierStatsConfig()
+      expect(loaded).toEqual(savedConfig)
+    })
+
+    it('should return default config for invalid JSON', () => {
+      localStorage.setItem(STORAGE_KEY, 'invalid json{')
+
+      const config = loadTierStatsConfig()
+      const defaultConfig = getDefaultConfig()
+
+      expect(config.selectedColumns).toEqual(defaultConfig.selectedColumns)
+    })
+
+    it('should return default config for missing required fields', () => {
+      const invalidConfig = {
+        selectedColumns: [{ fieldName: 'wave', showHourlyRate: false }],
+        // Missing configSectionCollapsed
+        lastUpdated: Date.now()
+      }
+
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(invalidConfig))
+
+      const config = loadTierStatsConfig()
+      const defaultConfig = getDefaultConfig()
+
+      expect(config).toEqual(defaultConfig)
+    })
+
+    it('should return default config for invalid column structure', () => {
+      const invalidConfig = {
+        selectedColumns: [
+          { fieldName: 'wave' } // Missing showHourlyRate
+        ],
+        configSectionCollapsed: true,
+        lastUpdated: Date.now()
+      }
+
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(invalidConfig))
+
+      const config = loadTierStatsConfig()
+      const defaultConfig = getDefaultConfig()
+
+      expect(config).toEqual(defaultConfig)
+    })
+
+    it('should return default config when selectedColumns is not an array', () => {
+      const invalidConfig = {
+        selectedColumns: { wave: true }, // Not an array
+        configSectionCollapsed: true,
+        lastUpdated: Date.now()
+      }
+
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(invalidConfig))
+
+      const config = loadTierStatsConfig()
+      const defaultConfig = getDefaultConfig()
+
+      expect(config).toEqual(defaultConfig)
+    })
+  })
+
+  describe('saveTierStatsConfig', () => {
+    it('should save config to localStorage', () => {
+      const config: TierStatsConfig = {
+        selectedColumns: [
+          { fieldName: 'wave', showHourlyRate: false },
+          { fieldName: 'coinsEarned', showHourlyRate: true }
+        ],
+        configSectionCollapsed: false,
+        lastUpdated: 12345
+      }
+
+      saveTierStatsConfig(config)
+
+      const stored = localStorage.getItem(STORAGE_KEY)
+      expect(stored).not.toBeNull()
+
+      const parsed = JSON.parse(stored!)
+      expect(parsed.selectedColumns).toEqual(config.selectedColumns)
+      expect(parsed.configSectionCollapsed).toBe(config.configSectionCollapsed)
+    })
+
+    it('should update lastUpdated timestamp', () => {
+      const config: TierStatsConfig = {
+        selectedColumns: [],
+        configSectionCollapsed: true,
+        lastUpdated: 12345
+      }
+
+      const beforeSave = Date.now()
+      saveTierStatsConfig(config)
+      const afterSave = Date.now()
+
+      const stored = localStorage.getItem(STORAGE_KEY)
+      const parsed = JSON.parse(stored!)
+
+      expect(parsed.lastUpdated).toBeGreaterThanOrEqual(beforeSave)
+      expect(parsed.lastUpdated).toBeLessThanOrEqual(afterSave)
+    })
+
+    it('should handle localStorage errors gracefully', () => {
+      const config = getDefaultConfig()
+
+      // Mock localStorage to throw an error
+      const setItemSpy = vi.spyOn(Storage.prototype, 'setItem')
+      setItemSpy.mockImplementation(() => {
+        throw new Error('Storage quota exceeded')
+      })
+
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      expect(() => saveTierStatsConfig(config)).not.toThrow()
+      expect(consoleSpy).toHaveBeenCalled()
+
+      setItemSpy.mockRestore()
+      consoleSpy.mockRestore()
+    })
+  })
+
+  describe('clearTierStatsConfig', () => {
+    it('should remove config from localStorage', () => {
+      const config = getDefaultConfig()
+      saveTierStatsConfig(config)
+
+      expect(localStorage.getItem(STORAGE_KEY)).not.toBeNull()
+
+      clearTierStatsConfig()
+
+      expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
+    })
+
+    it('should handle localStorage errors gracefully', () => {
+      const removeItemSpy = vi.spyOn(Storage.prototype, 'removeItem')
+      removeItemSpy.mockImplementation(() => {
+        throw new Error('Storage error')
+      })
+
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      expect(() => clearTierStatsConfig()).not.toThrow()
+      expect(consoleSpy).toHaveBeenCalled()
+
+      removeItemSpy.mockRestore()
+      consoleSpy.mockRestore()
+    })
+  })
+
+  describe('roundtrip persistence', () => {
+    it('should preserve config through save and load', () => {
+      const original: TierStatsConfig = {
+        selectedColumns: [
+          { fieldName: 'wave', showHourlyRate: false },
+          { fieldName: 'coinsEarned', showHourlyRate: true },
+          { fieldName: 'shards', showHourlyRate: false }
+        ],
+        configSectionCollapsed: false,
+        lastUpdated: Date.now()
+      }
+
+      saveTierStatsConfig(original)
+      const loaded = loadTierStatsConfig()
+
+      expect(loaded.selectedColumns).toEqual(original.selectedColumns)
+      expect(loaded.configSectionCollapsed).toBe(original.configSectionCollapsed)
+      expect(loaded.lastUpdated).toBeGreaterThanOrEqual(original.lastUpdated)
+    })
+  })
+})

--- a/src/features/data-tracking/utils/tier-stats-persistence.ts
+++ b/src/features/data-tracking/utils/tier-stats-persistence.ts
@@ -1,0 +1,99 @@
+import type { TierStatsConfig } from '../types/tier-stats-config.types'
+import { getDefaultConfig } from './tier-stats-config'
+
+const STORAGE_KEY = 'tower-tracking-tier-stats-config'
+
+/**
+ * Load tier stats configuration from localStorage
+ * Returns default config if none exists or if parsing fails
+ */
+export function loadTierStatsConfig(): TierStatsConfig {
+  if (typeof window === 'undefined') {
+    return getDefaultConfig()
+  }
+
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (!stored) {
+      return getDefaultConfig()
+    }
+
+    const parsed = JSON.parse(stored) as TierStatsConfig
+    return validateStoredConfig(parsed)
+  } catch (error) {
+    console.warn('Failed to load tier stats config from localStorage:', error)
+    return getDefaultConfig()
+  }
+}
+
+/**
+ * Save tier stats configuration to localStorage
+ */
+export function saveTierStatsConfig(config: TierStatsConfig): void {
+  if (typeof window === 'undefined') return
+
+  try {
+    const updated = {
+      ...config,
+      lastUpdated: Date.now()
+    }
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(updated))
+  } catch (error) {
+    console.error('Failed to save tier stats config to localStorage:', error)
+  }
+}
+
+/**
+ * Type guard to check if value is a valid column config
+ */
+function isValidColumnConfig(col: unknown): col is { fieldName: string; showHourlyRate: boolean } {
+  return (
+    col !== null &&
+    typeof col === 'object' &&
+    'fieldName' in col &&
+    'showHourlyRate' in col &&
+    typeof col.fieldName === 'string' &&
+    typeof col.showHourlyRate === 'boolean'
+  )
+}
+
+/**
+ * Validate stored configuration has required fields
+ */
+function validateStoredConfig(config: unknown): TierStatsConfig {
+  const defaultConfig = getDefaultConfig()
+
+  // Ensure all required fields exist
+  if (
+    !config ||
+    typeof config !== 'object' ||
+    !('selectedColumns' in config) ||
+    !('configSectionCollapsed' in config) ||
+    !Array.isArray(config.selectedColumns) ||
+    typeof config.configSectionCollapsed !== 'boolean'
+  ) {
+    return defaultConfig
+  }
+
+  // Validate column structure
+  const validColumns = config.selectedColumns.every(isValidColumnConfig)
+
+  if (!validColumns) {
+    return defaultConfig
+  }
+
+  return config as TierStatsConfig
+}
+
+/**
+ * Clear tier stats configuration from localStorage
+ */
+export function clearTierStatsConfig(): void {
+  if (typeof window === 'undefined') return
+
+  try {
+    localStorage.removeItem(STORAGE_KEY)
+  } catch (error) {
+    console.error('Failed to clear tier stats config from localStorage:', error)
+  }
+}


### PR DESCRIPTION
## What Changed

- **Dynamic column selection** - users can now add/remove any numeric resource column from tier stats table
- **Collapsible configuration panel** - customize columns without cluttering the data view
- **Per-column hourly rate toggles** - show/hide efficiency metrics independently for each resource
- **localStorage persistence** - column selections and hourly rate preferences saved across sessions
- **Inline hourly rate display** - rates shown beneath main values for compact table layout
- **Smart field discovery** - automatically detects all available numeric fields from imported run data
- **Duration field exclusion** - prevents nonsensical hourly rates for time-based fields
- **Detailed hover tooltips** - shows which specific run each stat comes from (wave, duration, timestamp)

## Why

**Core Problem**: The tier stats page had a **fixed column layout** (wave, duration, coins, cells) that prevented users from tracking other important farming resources like shards, metals, reroll shards, or module shards. Players optimize for different resources depending on their current progression goals, but couldn't customize the view to match their needs.

**Solution**: Made the tier stats table **fully configurable** with dynamic column selection:
1. Users can track any numeric resource from their run data
2. Columns auto-discovered from imported data (no hardcoding)
3. Preferences persist across sessions via localStorage
4. Clean UI with collapsible configuration panel

## Context

**Design Decisions**

**Inline Hourly Rates vs. Separate Columns**
- Initially implemented hourly rates as separate columns (coins + coins/hour = 2 columns)
- With 5+ resources selected, table became unwieldy (10+ columns requiring horizontal scroll)
- **Redesigned to stack hourly rates inline** beneath main values → 50% width reduction
- Enables tracking 8-10 resources simultaneously without scroll
- Trade-off: Can't sort by hourly rate directly, but sorting by main value is more common use case

**Per-Column Hourly Toggles vs. Global Toggle**
- Global "show all hourly rates" was too coarse-grained
- Users want efficiency metrics for coins/cells but not for wave count or duration
- Per-column control provides necessary flexibility

**Duration Field Handling**
- Excluded `dataType === 'duration'` fields from hourly rate option
- Prevents meaningless "hours per hour = 1" calculations
- Only `dataType === 'number'` fields can show hourly rates

**Configuration Panel UX**
- Collapsed by default to prioritize data consumption over configuration
- Selected columns show as rows with inline toggles (not pills) for better scanability
- Available columns in grid layout for quick discovery
- Reset to defaults button for easy recovery

**Data Transparency**
- Tooltips clarify which specific run each stat comes from
- Addresses user confusion about hourly rate calculation source
- Shows wave, duration, timestamp, and hourly rate breakdown on hover

**Technical Implementation**
- Pure function logic layer with 100% test coverage
- React hooks for state orchestration
- Ultra-thin components following separation of concerns
- Type-safe column configuration with validation
- Graceful fallback for invalid/outdated localStorage configs