### PR TITLE
Fix run type detection for production URLs and clipboard paste

### DIFF
--- a/src/features/data-tracking/hooks/use-data-input-form.ts
+++ b/src/features/data-tracking/hooks/use-data-input-form.ts
@@ -12,6 +12,7 @@ import type { DuplicateDetectionResult } from '../utils/duplicate-detection';
 import type { DuplicateResolution } from '../components/duplicate-info';
 import { useData } from './use-data';
 import { useRunTypeContext } from './use-run-type-context';
+import { hasExplicitRunType } from '../utils/run-type-detection';
 
 export interface DataInputFormState {
   inputData: string;
@@ -92,7 +93,12 @@ export function useDataInputForm(): DataInputFormState & DataInputFormActions {
       try {
         const parsed = parseGameRun(data, getDateTimeFromSelection());
         setPreviewData(parsed);
-        setSelectedRunType(parsed.runType);
+
+        // Only override run type if clipboard data has explicit run_type field
+        // Otherwise preserve the context-aware default (e.g., tournament tab → tournament type)
+        if (hasExplicitRunType(parsed.fields)) {
+          setSelectedRunType(parsed.runType);
+        }
 
         const hasBattleDateField = !!parsed.fields.battleDate;
         setHasBattleDate(hasBattleDateField);

--- a/src/features/data-tracking/hooks/use-run-type-context.test.tsx
+++ b/src/features/data-tracking/hooks/use-run-type-context.test.tsx
@@ -103,4 +103,61 @@ describe('useRunTypeContext', () => {
 
     expect(result.current).toBe('farm')
   })
+
+  describe('production environment (with base path)', () => {
+    it('should return "tournament" when on /TowerOfTracking/runs page with type=tournament', () => {
+      mockUseLocation.mockReturnValue({
+        pathname: '/TowerOfTracking/runs',
+        search: { type: 'tournament' },
+      } as ReturnType<typeof TanStackRouter.useLocation>)
+
+      const { result } = renderHook(() => useRunTypeContext())
+
+      expect(result.current).toBe('tournament')
+    })
+
+    it('should return "milestone" when on /TowerOfTracking/runs page with type=milestone', () => {
+      mockUseLocation.mockReturnValue({
+        pathname: '/TowerOfTracking/runs',
+        search: { type: 'milestone' },
+      } as ReturnType<typeof TanStackRouter.useLocation>)
+
+      const { result } = renderHook(() => useRunTypeContext())
+
+      expect(result.current).toBe('milestone')
+    })
+
+    it('should return "farm" when on /TowerOfTracking/runs page with type=farm', () => {
+      mockUseLocation.mockReturnValue({
+        pathname: '/TowerOfTracking/runs',
+        search: { type: 'farm' },
+      } as ReturnType<typeof TanStackRouter.useLocation>)
+
+      const { result } = renderHook(() => useRunTypeContext())
+
+      expect(result.current).toBe('farm')
+    })
+
+    it('should return "farm" when on /TowerOfTracking/runs page without type parameter', () => {
+      mockUseLocation.mockReturnValue({
+        pathname: '/TowerOfTracking/runs',
+        search: {},
+      } as ReturnType<typeof TanStackRouter.useLocation>)
+
+      const { result } = renderHook(() => useRunTypeContext())
+
+      expect(result.current).toBe('farm')
+    })
+
+    it('should ignore type parameter when on /TowerOfTracking/dashboard', () => {
+      mockUseLocation.mockReturnValue({
+        pathname: '/TowerOfTracking/dashboard',
+        search: { type: 'tournament' },
+      } as ReturnType<typeof TanStackRouter.useLocation>)
+
+      const { result } = renderHook(() => useRunTypeContext())
+
+      expect(result.current).toBe('farm')
+    })
+  })
 })

--- a/src/features/data-tracking/hooks/use-run-type-context.ts
+++ b/src/features/data-tracking/hooks/use-run-type-context.ts
@@ -14,7 +14,8 @@ export function useRunTypeContext(): RunTypeValue {
   const location = useLocation()
 
   // Check if we're on the runs page and extract type parameter
-  const isRunsPage = location.pathname === '/runs'
+  // Use endsWith to support both local (/runs) and production (/TowerOfTracking/runs) paths
+  const isRunsPage = location.pathname.endsWith('/runs')
 
   if (isRunsPage) {
     const searchParams = location.search as RunsSearchParams

--- a/src/features/data-tracking/utils/run-type-detection.test.ts
+++ b/src/features/data-tracking/utils/run-type-detection.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { detectRunTypeFromFields, extractNumericStats } from './run-type-detection';
+import { detectRunTypeFromFields, extractNumericStats, hasExplicitRunType } from './run-type-detection';
 import { RunType } from '../types/game-run.types';
 import type { GameRunField } from '../types/game-run.types';
 
@@ -207,6 +207,98 @@ describe('Run Type Detection', () => {
         cellsEarned: 0,
         realTime: 0
       });
+    });
+  });
+
+  describe('hasExplicitRunType', () => {
+    it('should return true when run_type field contains valid milestone value', () => {
+      const fields: Record<string, GameRunField> = {
+        runType: {
+          value: 'milestone',
+          rawValue: 'milestone',
+          displayValue: 'Milestone',
+          originalKey: 'Run Type',
+          dataType: 'string'
+        }
+      };
+
+      expect(hasExplicitRunType(fields)).toBe(true);
+    });
+
+    it('should return true when run_type field contains valid tournament value', () => {
+      const fields: Record<string, GameRunField> = {
+        runType: {
+          value: 'tournament',
+          rawValue: 'tournament',
+          displayValue: 'Tournament',
+          originalKey: 'Run Type',
+          dataType: 'string'
+        }
+      };
+
+      expect(hasExplicitRunType(fields)).toBe(true);
+    });
+
+    it('should return true when run_type field contains valid farm value', () => {
+      const fields: Record<string, GameRunField> = {
+        runType: {
+          value: 'farm',
+          rawValue: 'farm',
+          displayValue: 'Farm',
+          originalKey: 'Run Type',
+          dataType: 'string'
+        }
+      };
+
+      expect(hasExplicitRunType(fields)).toBe(true);
+    });
+
+    it('should be case insensitive', () => {
+      const fields: Record<string, GameRunField> = {
+        runType: {
+          value: 'MILESTONE',
+          rawValue: 'MILESTONE',
+          displayValue: 'MILESTONE',
+          originalKey: 'Run Type',
+          dataType: 'string'
+        }
+      };
+
+      expect(hasExplicitRunType(fields)).toBe(true);
+    });
+
+    it('should return false when run_type field is missing', () => {
+      const fields: Record<string, GameRunField> = {
+        tier: {
+          value: 10,
+          rawValue: '10+',
+          displayValue: 'Tier 10+',
+          originalKey: 'Tier',
+          dataType: 'number'
+        }
+      };
+
+      expect(hasExplicitRunType(fields)).toBe(false);
+    });
+
+    it('should return false when run_type field contains invalid value', () => {
+      const fields: Record<string, GameRunField> = {
+        runType: {
+          value: 'invalid',
+          rawValue: 'invalid',
+          displayValue: 'Invalid',
+          originalKey: 'Run Type',
+          dataType: 'string'
+        }
+      };
+
+      expect(hasExplicitRunType(fields)).toBe(false);
+    });
+
+    it('should return false when fields object is empty', () => {
+      const fields: Record<string, GameRunField> = {};
+
+      expect(hasExplicitRunType(fields)).toBe(false);
     });
   });
 });

--- a/src/features/data-tracking/utils/run-type-detection.ts
+++ b/src/features/data-tracking/utils/run-type-detection.ts
@@ -14,10 +14,24 @@ export function detectRunTypeFromFields(fields: Record<string, GameRunField>): R
       return explicitType;
     }
   }
-  
+
   // Fallback to auto-detection from tier string
   const tierStr = fields.tier?.rawValue || '';
   return /\+/.test(tierStr) ? RunType.TOURNAMENT : RunType.FARM;
+}
+
+/**
+ * Checks if clipboard data contains an explicit run_type field
+ * Returns true if the data explicitly specifies a run type, false otherwise
+ */
+export function hasExplicitRunType(fields: Record<string, GameRunField>): boolean {
+  const runTypeField = fields.runType?.rawValue?.toLowerCase();
+  if (!runTypeField) {
+    return false;
+  }
+
+  const explicitType = mapExplicitRunType(runTypeField);
+  return explicitType !== null;
 }
 
 /**


### PR DESCRIPTION
## Summary
Fixed two bugs preventing run type detection from working correctly. Users in production (GitHub Pages) can now use the run type feature, and pasting clipboard data no longer unexpectedly resets the run type when users open the form from specific tabs (tournament, milestone). The form now respects user context unless clipboard data explicitly specifies a run type.

## Technical Details
- Changed pathname check in `use-run-type-context.ts` from exact match (`===`) to suffix match (`endsWith`) to support production base path
- Added `hasExplicitRunType()` utility function to detect if clipboard data contains explicit run_type field
- Modified `use-data-input-form.ts` to conditionally update run type only when clipboard has explicit field
- Added 5 test cases for production URL structure with `/TowerOfTracking` base path
- Added 7 test cases for explicit run type field detection

## Context
Bug #1 was production-only due to Vite config setting `base: '/TowerOfTracking/'` in CI. Bug #2 affected all environments but only manifested when users opened the form from tournament/milestone tabs where context-aware defaults were being incorrectly overridden by auto-detection logic.