### PR TITLE
Fix tier trends filter disappearance on empty results

### DIFF
--- a/src/features/data-tracking/components/tier-trends-empty-state.tsx
+++ b/src/features/data-tracking/components/tier-trends-empty-state.tsx
@@ -1,0 +1,42 @@
+import { TrendingUp } from 'lucide-react'
+import { EmptyState } from '../../../components/ui/empty-state'
+import { LoadingState } from '../../../components/ui/loading-state'
+import { formatRunTypeFilterDisplay } from '../logic/tier-trends-display'
+import type { RunTypeFilter } from '../utils/run-type-filter'
+
+interface TierTrendsEmptyStateProps {
+  variant: 'no-data' | 'loading'
+  runType?: RunTypeFilter
+}
+
+export function TierTrendsEmptyState({ variant, runType }: TierTrendsEmptyStateProps) {
+  if (variant === 'loading') {
+    return (
+      <div
+        className="animate-in fade-in duration-300"
+        role="status"
+        aria-live="polite"
+        aria-label="Loading trends analysis"
+      >
+        <LoadingState rows={3} height="400px" />
+      </div>
+    )
+  }
+
+  const runTypeText = runType ? formatRunTypeFilterDisplay(runType) : ''
+
+  return (
+    <div
+      className="h-[400px] flex items-center justify-center animate-in fade-in duration-300"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+    >
+      <div className="max-w-md">
+        <EmptyState icon={<TrendingUp className="w-8 h-8" />}>
+          No tier data available for trends analysis. You need at least 2 {runTypeText} runs in the same tier to see trends.
+        </EmptyState>
+      </div>
+    </div>
+  )
+}

--- a/src/features/data-tracking/hooks/use-tier-trends-view-state.test.tsx
+++ b/src/features/data-tracking/hooks/use-tier-trends-view-state.test.tsx
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useTierTrendsViewState } from './use-tier-trends-view-state'
+import { RunType, TrendsDuration, TrendsAggregation } from '../types/game-run.types'
+import type { ParsedGameRun, TierTrendsFilters } from '../types/game-run.types'
+
+describe('useTierTrendsViewState', () => {
+  const mockFilters: TierTrendsFilters = {
+    tier: 0,
+    changeThresholdPercent: 0,
+    duration: TrendsDuration.PER_RUN,
+    quantity: 4,
+    aggregationType: TrendsAggregation.AVERAGE
+  }
+
+  const mockRuns: ParsedGameRun[] = [
+    {
+      id: '1',
+      timestamp: new Date('2024-01-15T14:30:00'),
+      tier: 10,
+      wave: 5881,
+      coinsEarned: 1130000000000,
+      cellsEarned: 45200,
+      realTime: 27966,
+      runType: RunType.FARM,
+      fields: {}
+    },
+    {
+      id: '2',
+      timestamp: new Date('2024-01-14T12:00:00'),
+      tier: 10,
+      wave: 5800,
+      coinsEarned: 1100000000000,
+      cellsEarned: 44000,
+      realTime: 27000,
+      runType: RunType.FARM,
+      fields: {}
+    }
+  ]
+
+  it('should return no-data state when no tiers available', () => {
+    const { result } = renderHook(() =>
+      useTierTrendsViewState(mockRuns, mockFilters, RunType.FARM, [])
+    )
+
+    expect(result.current.type).toBe('no-data')
+    expect(result.current.trendsData).toBeNull()
+  })
+
+  it('should return ready state when data is available', () => {
+    const { result } = renderHook(() =>
+      useTierTrendsViewState(mockRuns, mockFilters, RunType.FARM, [10])
+    )
+
+    expect(result.current.type).toBe('ready')
+    expect(result.current.trendsData).not.toBeNull()
+  })
+
+  it('should return ready state with no trends when available tiers exist but no matching runs', () => {
+    const { result } = renderHook(() =>
+      useTierTrendsViewState([], mockFilters, RunType.FARM, [10])
+    )
+
+    // With empty runs array but available tiers, calculation still produces trendsData (with empty fieldTrends)
+    // This is the actual behavior of calculateTierTrends
+    expect(result.current.type).toBe('ready')
+    expect(result.current.trendsData).not.toBeNull()
+  })
+
+  it('should recalculate when filters change', () => {
+    const { result, rerender } = renderHook(
+      ({ filters }) => useTierTrendsViewState(mockRuns, filters, RunType.FARM, [10]),
+      { initialProps: { filters: mockFilters } }
+    )
+
+    const firstResult = result.current
+
+    const newFilters: TierTrendsFilters = {
+      ...mockFilters,
+      quantity: 8
+    }
+
+    rerender({ filters: newFilters })
+
+    // Should recalculate with new filters
+    expect(result.current).not.toBe(firstResult)
+    expect(result.current.type).toBe('ready')
+  })
+
+  it('should recalculate when run type filter changes', () => {
+    const { result, rerender } = renderHook(
+      ({ runTypeFilter }) => useTierTrendsViewState(mockRuns, mockFilters, runTypeFilter, [10]),
+      { initialProps: { runTypeFilter: RunType.FARM as const } }
+    )
+
+    expect(result.current.type).toBe('ready')
+
+    rerender({ runTypeFilter: RunType.TOURNAMENT })
+
+    // Should recalculate with new run type filter
+    // Note: calculateTierTrends still returns data structure even with no matching runs
+    expect(result.current.type).toBe('ready')
+    expect(result.current.trendsData).not.toBeNull()
+  })
+
+  it('should recalculate when available tiers change', () => {
+    const { result, rerender } = renderHook(
+      ({ tiers }) => useTierTrendsViewState(mockRuns, mockFilters, RunType.FARM, tiers),
+      { initialProps: { tiers: [10] } }
+    )
+
+    expect(result.current.type).toBe('ready')
+
+    rerender({ tiers: [] })
+
+    expect(result.current.type).toBe('no-data')
+  })
+})

--- a/src/features/data-tracking/hooks/use-tier-trends-view-state.ts
+++ b/src/features/data-tracking/hooks/use-tier-trends-view-state.ts
@@ -1,0 +1,34 @@
+import { useMemo } from 'react'
+import type { ParsedGameRun, TierTrendsFilters } from '../types/game-run.types'
+import { calculateTierTrends } from '../utils/tier-trends'
+import type { RunTypeFilter } from '../utils/run-type-filter'
+
+/**
+ * Manages derived view state for tier trends analysis component
+ * Determines what should be displayed based on data availability
+ */
+export function useTierTrendsViewState(
+  runs: ParsedGameRun[],
+  filters: TierTrendsFilters,
+  runTypeFilter: RunTypeFilter,
+  availableTiers: number[]
+) {
+  // Calculate trends data
+  const trendsData = useMemo(() => {
+    if (availableTiers.length === 0) return null
+    return calculateTierTrends(runs, filters, runTypeFilter)
+  }, [runs, filters, runTypeFilter, availableTiers])
+
+  // Determine view state
+  const viewState = useMemo(() => {
+    if (availableTiers.length === 0) {
+      return { type: 'no-data' as const, trendsData: null }
+    }
+    if (!trendsData) {
+      return { type: 'loading' as const, trendsData: null }
+    }
+    return { type: 'ready' as const, trendsData }
+  }, [availableTiers.length, trendsData])
+
+  return viewState
+}

--- a/src/features/data-tracking/logic/tier-trends-display.test.ts
+++ b/src/features/data-tracking/logic/tier-trends-display.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest'
+import {
+  formatRunTypeDisplay,
+  formatRunTypeFilterDisplay,
+  formatDurationDisplay,
+  formatPeriodSummary
+} from './tier-trends-display'
+import { RunType, TrendsDuration } from '../types/game-run.types'
+import type { RunTypeFilter } from '../utils/run-type-filter'
+
+describe('formatRunTypeDisplay', () => {
+  it('should format farm run type', () => {
+    expect(formatRunTypeDisplay(RunType.FARM)).toBe('Farm')
+  })
+
+  it('should format tournament run type', () => {
+    expect(formatRunTypeDisplay(RunType.TOURNAMENT)).toBe('Tournament')
+  })
+
+  it('should format milestone run type', () => {
+    expect(formatRunTypeDisplay(RunType.MILESTONE)).toBe('Milestone')
+  })
+
+  it('should return empty string for undefined', () => {
+    expect(formatRunTypeDisplay(undefined)).toBe('')
+  })
+
+  it('should return empty string for unknown run type', () => {
+    expect(formatRunTypeDisplay('unknown' as RunType)).toBe('')
+  })
+})
+
+describe('formatRunTypeFilterDisplay', () => {
+  it('should format farm run type filter', () => {
+    expect(formatRunTypeFilterDisplay(RunType.FARM as RunTypeFilter)).toBe('farm')
+  })
+
+  it('should format tournament run type filter', () => {
+    expect(formatRunTypeFilterDisplay(RunType.TOURNAMENT as RunTypeFilter)).toBe('tournament')
+  })
+
+  it('should format milestone run type filter', () => {
+    expect(formatRunTypeFilterDisplay(RunType.MILESTONE as RunTypeFilter)).toBe('milestone')
+  })
+
+  it('should format all run type filter', () => {
+    expect(formatRunTypeFilterDisplay('all')).toBe('all')
+  })
+})
+
+describe('formatDurationDisplay', () => {
+  describe('singular forms', () => {
+    it('should format per-run duration (singular)', () => {
+      expect(formatDurationDisplay(TrendsDuration.PER_RUN, 1)).toBe('Run')
+    })
+
+    it('should format daily duration (singular)', () => {
+      expect(formatDurationDisplay(TrendsDuration.DAILY, 1)).toBe('Day')
+    })
+
+    it('should format weekly duration (singular)', () => {
+      expect(formatDurationDisplay(TrendsDuration.WEEKLY, 1)).toBe('Week')
+    })
+
+    it('should format monthly duration (singular)', () => {
+      expect(formatDurationDisplay(TrendsDuration.MONTHLY, 1)).toBe('Month')
+    })
+
+    it('should format yearly duration (singular)', () => {
+      expect(formatDurationDisplay(TrendsDuration.YEARLY, 1)).toBe('Year')
+    })
+  })
+
+  describe('plural forms', () => {
+    it('should format per-run duration (plural)', () => {
+      expect(formatDurationDisplay(TrendsDuration.PER_RUN, 4)).toBe('Runs')
+    })
+
+    it('should format daily duration (plural)', () => {
+      expect(formatDurationDisplay(TrendsDuration.DAILY, 7)).toBe('Days')
+    })
+
+    it('should format weekly duration (plural)', () => {
+      expect(formatDurationDisplay(TrendsDuration.WEEKLY, 2)).toBe('Weeks')
+    })
+
+    it('should format monthly duration (plural)', () => {
+      expect(formatDurationDisplay(TrendsDuration.MONTHLY, 3)).toBe('Months')
+    })
+
+    it('should format yearly duration (plural)', () => {
+      expect(formatDurationDisplay(TrendsDuration.YEARLY, 5)).toBe('Years')
+    })
+  })
+
+  it('should return empty string for unknown duration', () => {
+    expect(formatDurationDisplay('unknown' as TrendsDuration, 1)).toBe('')
+  })
+
+  it('should handle zero count as plural', () => {
+    expect(formatDurationDisplay(TrendsDuration.PER_RUN, 0)).toBe('Runs')
+  })
+})
+
+describe('formatPeriodSummary', () => {
+  it('should format complete period summary for farm runs', () => {
+    expect(formatPeriodSummary(4, TrendsDuration.PER_RUN, RunType.FARM as RunTypeFilter)).toBe(
+      'Last 4 Runs - Farm Mode'
+    )
+  })
+
+  it('should format complete period summary for tournament days', () => {
+    expect(formatPeriodSummary(7, TrendsDuration.DAILY, RunType.TOURNAMENT as RunTypeFilter)).toBe(
+      'Last 7 Days - Tournament Mode'
+    )
+  })
+
+  it('should format complete period summary for milestone weeks', () => {
+    expect(formatPeriodSummary(2, TrendsDuration.WEEKLY, RunType.MILESTONE as RunTypeFilter)).toBe(
+      'Last 2 Weeks - Milestone Mode'
+    )
+  })
+
+  it('should format complete period summary with singular duration', () => {
+    expect(formatPeriodSummary(1, TrendsDuration.MONTHLY, RunType.FARM as RunTypeFilter)).toBe(
+      'Last 1 Month - Farm Mode'
+    )
+  })
+
+  it('should format complete period summary for yearly data', () => {
+    expect(formatPeriodSummary(3, TrendsDuration.YEARLY, RunType.TOURNAMENT as RunTypeFilter)).toBe(
+      'Last 3 Years - Tournament Mode'
+    )
+  })
+
+  it('should format complete period summary for all runs filter', () => {
+    expect(formatPeriodSummary(4, TrendsDuration.PER_RUN, 'all')).toBe(
+      'Last 4 Runs - All Runs'
+    )
+  })
+})

--- a/src/features/data-tracking/logic/tier-trends-display.ts
+++ b/src/features/data-tracking/logic/tier-trends-display.ts
@@ -1,0 +1,72 @@
+import { RunType, TrendsDuration, type RunTypeValue } from '../types/game-run.types'
+import type { RunTypeFilter } from '../utils/run-type-filter'
+
+/**
+ * Formats run type for display in tier trends UI
+ * Returns capitalized run type name or empty string for unknown types
+ */
+export function formatRunTypeDisplay(runType: RunTypeValue | undefined): string {
+  if (!runType) return ''
+
+  switch (runType) {
+    case RunType.FARM:
+      return 'Farm'
+    case RunType.TOURNAMENT:
+      return 'Tournament'
+    case RunType.MILESTONE:
+      return 'Milestone'
+    default:
+      return ''
+  }
+}
+
+/**
+ * Formats run type filter for display in tier trends UI
+ * Handles both specific run types and 'all' filter
+ */
+export function formatRunTypeFilterDisplay(runType: RunTypeFilter): string {
+  if (runType === 'all') return 'all'
+  return formatRunTypeDisplay(runType).toLowerCase()
+}
+
+/**
+ * Formats duration type for display in tier trends UI
+ * Returns singular or plural form based on count
+ */
+export function formatDurationDisplay(duration: TrendsDuration, count: number): string {
+  const isPlural = count !== 1
+
+  switch (duration) {
+    case TrendsDuration.PER_RUN:
+      return isPlural ? 'Runs' : 'Run'
+    case TrendsDuration.DAILY:
+      return isPlural ? 'Days' : 'Day'
+    case TrendsDuration.WEEKLY:
+      return isPlural ? 'Weeks' : 'Week'
+    case TrendsDuration.MONTHLY:
+      return isPlural ? 'Months' : 'Month'
+    case TrendsDuration.YEARLY:
+      return isPlural ? 'Years' : 'Year'
+    default:
+      return ''
+  }
+}
+
+/**
+ * Formats complete period summary for tier trends header
+ * Example: "Last 4 Runs - Farm Mode"
+ */
+export function formatPeriodSummary(
+  periodCount: number,
+  duration: TrendsDuration,
+  runType: RunTypeFilter
+): string {
+  const durationText = formatDurationDisplay(duration, periodCount)
+
+  if (runType === 'all') {
+    return `Last ${periodCount} ${durationText} - All Runs`
+  }
+
+  const runTypeText = formatRunTypeDisplay(runType)
+  return `Last ${periodCount} ${durationText} - ${runTypeText} Mode`
+}


### PR DESCRIPTION
## Summary

Fixed a frustrating UX issue where selecting filters that produce no results would cause the entire filter interface to disappear, requiring a full page refresh to recover. Users can now adjust tier trends filters freely - empty state messages appear only in the results area while filter controls remain accessible at all times.

## Context

This issue created a "dead end" user experience where exploratory filter selections (like checking if tournament runs exist in a tier) would completely remove the filter interface. The discriminated union pattern provides a clear contract for what data is available in each state, preventing future regressions.

## Technical Details

**Component Architecture:**
- Removed problematic early return pattern that replaced entire UI with error message
- Implemented discriminated union view state pattern: `'no-data' | 'loading' | 'ready'`
- Created `TierTrendsEmptyState` component with TrendingUp icon and proper ARIA labels
- Extracted `useTierTrendsViewState` hook for clean state derivation
- Reduced main component from 171 to 160 lines while improving clarity

**Logic Extraction:**
- Created 4 pure display formatting functions in `tier-trends-display.ts`
  - `formatRunTypeDisplay()` - Capitalizes run type names
  - `formatRunTypeFilterDisplay()` - Handles 'all' filter case
  - `formatDurationDisplay()` - Singular/plural duration text
  - `formatPeriodSummary()` - Complete header text (e.g., "Last 4 Runs - Farm Mode")
- Replaced ternary chains in JSX with pure function calls

**Design Integration:**
- Integrated existing `EmptyState` and `LoadingState` design system components
- Added smooth 300ms fade-in transitions for state changes
- Implemented ARIA live regions for accessibility
- TrendingUp icon provides visual hierarchy for empty states
