### PR TITLE
Add percentile aggregation for tier performance statistics

### DIFF
--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -23,3 +23,4 @@ export * from "./selection-button-group";
 export * from "./tabs";
 export * from "./textarea";
 export * from "./toggle-switch";
+export * from "./tooltip-content";

--- a/src/components/ui/selection-button-group.tsx
+++ b/src/components/ui/selection-button-group.tsx
@@ -1,11 +1,14 @@
 import { Button } from "./button"
 import { cn } from "../../shared/lib/utils"
+import { TooltipContentWrapper } from "./tooltip-content"
+import * as Tooltip from '@radix-ui/react-tooltip'
 
 export interface SelectionOption<T = string> {
   value: T
   label: string
   color?: string
   icon?: React.ReactNode
+  tooltip?: string
 }
 
 interface SelectionButtonGroupProps<T = string> {
@@ -41,58 +44,87 @@ export function SelectionButtonGroup<T = string>({
     loose: 'gap-3'
   };
   return (
-    <div
-      className={cn(
-        "flex",
-        spacingClasses[spacing],
-        vertical ? "flex-col" : "flex-wrap",
-        equalWidth && "w-full",
-        className
-      )}
-      role="group"
-      aria-label={ariaLabel}
-    >
-      {options.map((option) => (
-        <Button
-          key={String(option.value)}
-          variant="outline"
-          size={size}
-          selected={selectedValue === option.value}
-          onClick={() => onSelectionChange(option.value)}
-          fullWidthOnMobile={fullWidthOnMobile}
-          className={cn(
-            "whitespace-nowrap shrink-0",
-            equalWidth && "flex-1 min-w-0",
-            buttonClassName
-          )}
-          style={option.color && selectedValue === option.value ? {
-            backgroundColor: `${option.color}15`,
-            borderColor: `${option.color}60`,
-            color: 'var(--color-foreground)',
-          } : undefined}
-          onMouseEnter={(e) => {
-            if (option.color && selectedValue === option.value) {
-              e.currentTarget.style.backgroundColor = `${option.color}25`;
-              e.currentTarget.style.borderColor = `${option.color}70`;
-            }
-          }}
-          onMouseLeave={(e) => {
-            if (option.color && selectedValue === option.value) {
-              e.currentTarget.style.backgroundColor = `${option.color}15`;
-              e.currentTarget.style.borderColor = `${option.color}60`;
-            }
-          }}
-        >
-          {option.color && option.icon && (
-            <div 
-              className="w-3 h-3 rounded-full shrink-0" 
-              style={{ backgroundColor: option.color }}
-            />
-          )}
-          {option.icon && typeof option.icon !== 'boolean' && option.icon}
-          {option.label}
-        </Button>
-      ))}
-    </div>
+    <Tooltip.Provider delayDuration={400}>
+      <div
+        className={cn(
+          "flex",
+          spacingClasses[spacing],
+          vertical ? "flex-col" : "flex-wrap",
+          equalWidth && "w-full",
+          className
+        )}
+        role="group"
+        aria-label={ariaLabel}
+      >
+        {options.map((option) => {
+          const button = (
+            <Button
+              key={String(option.value)}
+              variant="outline"
+              size={size}
+              selected={selectedValue === option.value}
+              onClick={() => onSelectionChange(option.value)}
+              fullWidthOnMobile={fullWidthOnMobile}
+              className={cn(
+                "whitespace-nowrap shrink-0",
+                equalWidth && "flex-1 min-w-0",
+                buttonClassName
+              )}
+              style={option.color && selectedValue === option.value ? {
+                backgroundColor: `${option.color}15`,
+                borderColor: `${option.color}60`,
+                color: 'var(--color-foreground)',
+              } : undefined}
+              onMouseEnter={(e) => {
+                if (option.color && selectedValue === option.value) {
+                  e.currentTarget.style.backgroundColor = `${option.color}25`;
+                  e.currentTarget.style.borderColor = `${option.color}70`;
+                }
+              }}
+              onMouseLeave={(e) => {
+                if (option.color && selectedValue === option.value) {
+                  e.currentTarget.style.backgroundColor = `${option.color}15`;
+                  e.currentTarget.style.borderColor = `${option.color}60`;
+                }
+              }}
+            >
+              {option.color && option.icon && (
+                <div
+                  className="w-3 h-3 rounded-full shrink-0"
+                  style={{ backgroundColor: option.color }}
+                />
+              )}
+              {option.icon && typeof option.icon !== 'boolean' && option.icon}
+              {option.label}
+            </Button>
+          )
+
+          // Wrap with tooltip if provided
+          if (option.tooltip) {
+            return (
+              <Tooltip.Root key={String(option.value)}>
+                <Tooltip.Trigger asChild>
+                  {button}
+                </Tooltip.Trigger>
+                <Tooltip.Portal>
+                  <Tooltip.Content
+                    side="top"
+                    sideOffset={8}
+                    className="z-50"
+                  >
+                    <TooltipContentWrapper>
+                      {option.tooltip}
+                    </TooltipContentWrapper>
+                    <Tooltip.Arrow className="fill-slate-950" />
+                  </Tooltip.Content>
+                </Tooltip.Portal>
+              </Tooltip.Root>
+            )
+          }
+
+          return button
+        })}
+      </div>
+    </Tooltip.Provider>
   )
 }

--- a/src/components/ui/tooltip-content.tsx
+++ b/src/components/ui/tooltip-content.tsx
@@ -1,0 +1,57 @@
+import * as React from "react"
+import { cn } from "../../shared/lib/utils"
+
+interface TooltipContentWrapperProps {
+  children: React.ReactNode
+  className?: string
+  /**
+   * Visual variant for tooltip content
+   * @default 'default'
+   *
+   * - `default`: Simple explanatory tooltips (labels, button hints, short descriptions)
+   * - `detailed`: Complex structured data tooltips (stats, metrics, multi-line content)
+   */
+  variant?: 'default' | 'detailed'
+}
+
+/**
+ * Reusable tooltip content wrapper with consistent styling across the application.
+ *
+ * This component provides:
+ * - Consistent dark theme styling (`bg-slate-950`)
+ * - Proper contrast borders (`border-slate-600/80`)
+ * - Smooth entrance animations (`slide-in-from-bottom-1`)
+ * - Variant-based sizing and padding
+ *
+ * @example
+ * ```tsx
+ * // Simple tooltip
+ * <TooltipContentWrapper>
+ *   Click to see more details
+ * </TooltipContentWrapper>
+ *
+ * // Detailed stats tooltip
+ * <TooltipContentWrapper variant="detailed">
+ *   <div>Value: 1000</div>
+ *   <div>Rate: 500/hr</div>
+ * </TooltipContentWrapper>
+ * ```
+ */
+export function TooltipContentWrapper({
+  children,
+  className,
+  variant = 'default'
+}: TooltipContentWrapperProps) {
+  const baseStyles = "rounded-lg bg-slate-950 shadow-lg border border-slate-600/80 animate-in fade-in-0 slide-in-from-bottom-1 duration-200"
+
+  const variantStyles = {
+    default: "max-w-sm px-3 py-2 text-sm text-slate-100",
+    detailed: "min-w-[220px] p-4"
+  }
+
+  return (
+    <div className={cn(baseStyles, variantStyles[variant], className)}>
+      {children}
+    </div>
+  )
+}

--- a/src/features/data-tracking/components/tier-stats-cell-tooltip.tsx
+++ b/src/features/data-tracking/components/tier-stats-cell-tooltip.tsx
@@ -2,6 +2,7 @@ import { format } from 'date-fns'
 import type { CellTooltipData } from '../types/tier-stats-config.types'
 import { formatDuration } from '../utils/data-parser'
 import { formatLargeNumber } from '../utils/chart-data'
+import { TooltipContentWrapper } from '../../../components/ui/tooltip-content'
 
 interface TierStatsCellTooltipProps {
   data: CellTooltipData
@@ -9,7 +10,7 @@ interface TierStatsCellTooltipProps {
 
 export function TierStatsCellTooltip({ data }: TierStatsCellTooltipProps) {
   return (
-    <div className="bg-slate-950 border border-slate-600/80 rounded-lg p-4 shadow-2xl backdrop-blur-md min-w-[220px]">
+    <TooltipContentWrapper variant="detailed" className="shadow-2xl backdrop-blur-md">
       <div className="space-y-3">
         {/* Field Name */}
         <div className="font-semibold text-white text-sm border-b border-slate-700/80 pb-2.5">
@@ -73,6 +74,6 @@ export function TierStatsCellTooltip({ data }: TierStatsCellTooltipProps) {
           </div>
         </div>
       </div>
-    </div>
+    </TooltipContentWrapper>
   )
 }

--- a/src/features/data-tracking/components/tier-stats-config-panel.tsx
+++ b/src/features/data-tracking/components/tier-stats-config-panel.tsx
@@ -1,5 +1,6 @@
 import { ChevronDown, ChevronUp, RotateCcw, Settings } from 'lucide-react'
 import type { UseTierStatsConfigReturn } from '../hooks/use-tier-stats-config'
+import type { TierStatsAggregation } from '../types/tier-stats-config.types'
 import { getFieldDisplayName, canFieldHaveHourlyRate } from '../utils/tier-stats-config'
 import { useColumnSearch } from '../hooks/use-column-search'
 import { useColumnReorder } from '../hooks/use-column-reorder'
@@ -8,6 +9,8 @@ import { SearchableColumnPicker } from './searchable-column-picker'
 import { Button } from '../../../components/ui/button'
 import { InfoBox } from '../../../components/ui/info-box'
 import { EmptyState } from '../../../components/ui/empty-state'
+import { FormControl, SelectionButtonGroup } from '../../../components/ui'
+import { getAggregationOptions } from '../logic/tier-stats-aggregation-options'
 
 interface TierStatsConfigPanelProps {
   config: UseTierStatsConfigReturn
@@ -31,6 +34,17 @@ export function TierStatsConfigPanel({ config }: TierStatsConfigPanelProps) {
 
   return (
     <div className="space-y-4">
+      {/* Aggregation Selector - Always Visible */}
+      <FormControl label="Aggregation Method">
+        <SelectionButtonGroup<TierStatsAggregation>
+          options={getAggregationOptions()}
+          selectedValue={config.aggregationType}
+          onSelectionChange={config.setAggregationType}
+          size="sm"
+          fullWidthOnMobile={false}
+        />
+      </FormControl>
+
       {/* Enhanced Toggle Button with Visual Prominence */}
       <div className="flex items-center justify-between gap-4">
         <div className="flex flex-col gap-1">
@@ -139,8 +153,8 @@ export function TierStatsConfigPanel({ config }: TierStatsConfigPanelProps) {
           {/* Help Text */}
           <div className="pt-6 border-t border-slate-700/50">
             <InfoBox variant="info" title="Tip">
-              Column values show the maximum achieved for each tier.
-              Hourly rates are calculated from the specific run that achieved the maximum value.
+              Column values reflect the selected aggregation method for each tier.
+              Percentile aggregations help filter outliers for more representative performance data.
             </InfoBox>
           </div>
         </div>

--- a/src/features/data-tracking/components/tier-stats-table.tsx
+++ b/src/features/data-tracking/components/tier-stats-table.tsx
@@ -7,6 +7,7 @@ import { useTierStatsConfig } from '../hooks/use-tier-stats-config'
 import { useDynamicTierStatsTable } from '../hooks/use-dynamic-tier-stats-table'
 import { filterRunsByType } from '../utils/run-type-filter'
 import { getTierStatsCellClassName } from '../utils/tier-stats-cell-styles'
+import { getAggregationDescription } from '../logic/tier-stats-aggregation-options'
 import { LoadingState } from '../../../components/ui/loading-state'
 import * as Tooltip from '@radix-ui/react-tooltip'
 
@@ -77,7 +78,7 @@ export function TierStatsTable() {
             <FarmingOnlyIndicator />
           </div>
           <p className="text-slate-400 text-sm">
-            Maximum values achieved across farming runs for each tier. Customize columns to track any resource.
+            {getAggregationDescription(config.aggregationType)}
           </p>
         </div>
 
@@ -183,12 +184,12 @@ export function TierStatsTable() {
                               <Tooltip.Root>
                                 <Tooltip.Trigger asChild>
                                   <button className={cellClassName}>
-                                    <div className="flex flex-col items-end gap-0.5">
-                                      <div className="font-semibold">{displayValue.main}</div>
+                                    <span className="flex flex-col items-end gap-0.5">
+                                      <span className="font-semibold">{displayValue.main}</span>
                                       {displayValue.hourly && (
-                                        <div className="text-xs text-orange-300 opacity-90">{displayValue.hourly}</div>
+                                        <span className="text-xs text-orange-300 opacity-90">{displayValue.hourly}</span>
                                       )}
-                                    </div>
+                                    </span>
                                   </button>
                                 </Tooltip.Trigger>
                                 <Tooltip.Portal>
@@ -203,13 +204,13 @@ export function TierStatsTable() {
                                 </Tooltip.Portal>
                               </Tooltip.Root>
                             ) : hasData ? (
-                              <span className={cellClassName}>
-                                <div className="flex flex-col items-end gap-0.5">
-                                  <div className="font-semibold">{displayValue.main}</div>
+                              <span className={`${cellClassName} inline-flex`}>
+                                <span className="flex flex-col items-end gap-0.5">
+                                  <span className="font-semibold">{displayValue.main}</span>
                                   {displayValue.hourly && (
-                                    <div className="text-xs text-orange-300 opacity-90">{displayValue.hourly}</div>
+                                    <span className="text-xs text-orange-300 opacity-90">{displayValue.hourly}</span>
                                   )}
-                                </div>
+                                </span>
                               </span>
                             ) : (
                               <span className="text-slate-500 font-mono text-sm">-</span>

--- a/src/features/data-tracking/hooks/use-tier-stats-config.tsx
+++ b/src/features/data-tracking/hooks/use-tier-stats-config.tsx
@@ -3,7 +3,8 @@ import type { ParsedGameRun } from '../types/game-run.types'
 import type {
   TierStatsConfig,
   TierStatsColumnConfig,
-  AvailableField
+  AvailableField,
+  TierStatsAggregation
 } from '../types/tier-stats-config.types'
 import {
   discoverAvailableFields,
@@ -21,6 +22,7 @@ export interface UseTierStatsConfigReturn {
   // Configuration state
   selectedColumns: TierStatsColumnConfig[]
   configSectionCollapsed: boolean
+  aggregationType: TierStatsAggregation
 
   // Available fields
   availableFields: AvailableField[]
@@ -35,6 +37,7 @@ export interface UseTierStatsConfigReturn {
   reorderColumns: (fromIndex: number, toIndex: number) => void
   toggleColumnHourlyRate: (fieldName: string) => void
   toggleConfigSection: () => void
+  setAggregationType: (aggregationType: TierStatsAggregation) => void
   resetToDefaults: () => void
 }
 
@@ -152,6 +155,14 @@ export function useTierStatsConfig(runs: ParsedGameRun[]): UseTierStatsConfigRet
     }))
   }, [])
 
+  // Set aggregation type
+  const setAggregationType = useCallback((aggregationType: TierStatsAggregation) => {
+    setConfig(prev => ({
+      ...prev,
+      aggregationType
+    }))
+  }, [])
+
   // Reset configuration to defaults
   const resetToDefaults = useCallback(() => {
     setConfig(getDefaultConfig())
@@ -160,6 +171,7 @@ export function useTierStatsConfig(runs: ParsedGameRun[]): UseTierStatsConfigRet
   return {
     selectedColumns: config.selectedColumns,
     configSectionCollapsed: config.configSectionCollapsed,
+    aggregationType: config.aggregationType,
     availableFields,
     unselectedFields,
     isDataLoaded,
@@ -168,6 +180,7 @@ export function useTierStatsConfig(runs: ParsedGameRun[]): UseTierStatsConfigRet
     reorderColumns: handleReorderColumns,
     toggleColumnHourlyRate,
     toggleConfigSection,
+    setAggregationType,
     resetToDefaults
   }
 }

--- a/src/features/data-tracking/logic/field-percentile-calculation.test.ts
+++ b/src/features/data-tracking/logic/field-percentile-calculation.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from 'vitest'
+import { calculateFieldPercentiles } from './field-percentile-calculation'
+import type { ParsedGameRun } from '../types/game-run.types'
+import { createGameRunField, getFieldValue } from '../utils/field-utils'
+
+describe('calculateFieldPercentiles', () => {
+  const createMockRun = (coins: number, duration: number, id: string): ParsedGameRun => ({
+    id,
+    timestamp: new Date('2024-01-01'),
+    fields: {
+      coinsEarned: createGameRunField('Coins Earned', coins.toString())
+    },
+    tier: 1,
+    wave: 100,
+    realTime: duration,
+    runType: 'farm'
+  })
+
+  const getValue = (run: ParsedGameRun) => {
+    return getFieldValue<number>(run, 'coinsEarned')
+  }
+
+  it('should return null percentiles for empty array', () => {
+    const result = calculateFieldPercentiles([], getValue)
+
+    expect(result.p99).toBeNull()
+    expect(result.p90).toBeNull()
+    expect(result.p75).toBeNull()
+    expect(result.p50).toBeNull()
+  })
+
+  it('should return same value for all percentiles with single run', () => {
+    const runs = [createMockRun(1000, 3600, 'run1')]
+    const result = calculateFieldPercentiles(runs, getValue)
+
+    expect(result.p99?.value).toBe(1000)
+    expect(result.p99?.duration).toBe(3600)
+    expect(result.p90?.value).toBe(1000)
+    expect(result.p75?.value).toBe(1000)
+    expect(result.p50?.value).toBe(1000)
+  })
+
+  it('should calculate percentiles correctly and track source runs', () => {
+    // Create 10 runs with different values and durations
+    const runs = [
+      createMockRun(100, 1000, 'run1'),
+      createMockRun(200, 2000, 'run2'),
+      createMockRun(300, 3000, 'run3'),
+      createMockRun(400, 4000, 'run4'),
+      createMockRun(500, 5000, 'run5'),
+      createMockRun(600, 6000, 'run6'),
+      createMockRun(700, 7000, 'run7'),
+      createMockRun(800, 8000, 'run8'),
+      createMockRun(900, 9000, 'run9'),
+      createMockRun(1000, 10000, 'run10')
+    ]
+
+    const result = calculateFieldPercentiles(runs, getValue)
+
+    // P99: floor(0.99 * 10) = 9, index 9 = value 1000, duration 10000
+    expect(result.p99?.value).toBe(1000)
+    expect(result.p99?.duration).toBe(10000)
+    expect(result.p99?.sourceRun.id).toBe('run10')
+
+    // P90: floor(0.90 * 10) = 9, index 9 = value 1000, duration 10000
+    expect(result.p90?.value).toBe(1000)
+    expect(result.p90?.duration).toBe(10000)
+
+    // P75: floor(0.75 * 10) = 7, index 7 = value 800, duration 8000
+    expect(result.p75?.value).toBe(800)
+    expect(result.p75?.duration).toBe(8000)
+
+    // P50: floor(0.50 * 10) = 5, index 5 = value 600, duration 6000
+    expect(result.p50?.value).toBe(600)
+    expect(result.p50?.duration).toBe(6000)
+  })
+
+  it('should sort by value, not by duration', () => {
+    // Runs where high values don't correlate with long durations
+    const runs = [
+      createMockRun(1000, 1000, 'short-high'), // High value, short duration
+      createMockRun(500, 5000, 'long-med'),    // Med value, long duration
+      createMockRun(100, 3000, 'med-low')      // Low value, med duration
+    ]
+
+    const result = calculateFieldPercentiles(runs, getValue)
+
+    // P99 should be the highest value (1000) with its duration (1000)
+    expect(result.p99?.value).toBe(1000)
+    expect(result.p99?.duration).toBe(1000)
+
+    // P50 should be the middle value (500) with its duration (5000)
+    expect(result.p50?.value).toBe(500)
+    expect(result.p50?.duration).toBe(5000)
+  })
+
+  it('should handle realistic tier 11 coin scenario', () => {
+    // Realistic tier 11 runs with varying coins and durations
+    const runs = [
+      createMockRun(10100000000000, 50000, 'run1'), // 10.1T in 13.9h (lucky, fast)
+      createMockRun(12100000000000, 48000, 'run2'), // 12.1T in 13.3h (best)
+      createMockRun(11900000000000, 47000, 'run3'), // 11.9T in 13.1h
+      createMockRun(11700000000000, 46000, 'run4'), // 11.7T in 12.8h
+      createMockRun(11500000000000, 45000, 'run5'), // 11.5T in 12.5h
+      createMockRun(11300000000000, 47000, 'run6'), // 11.3T in 13.1h
+      createMockRun(11000000000000, 48000, 'run7'), // 11.0T in 13.3h
+      createMockRun(10800000000000, 46000, 'run8'), // 10.8T in 12.8h
+      createMockRun(10600000000000, 47000, 'run9'), // 10.6T in 13.1h
+      createMockRun(10000000000000, 45000, 'run10') // 10.0T in 12.5h
+    ]
+
+    const result = calculateFieldPercentiles(runs, getValue)
+
+    // Max should be 12.1T
+    const maxRun = runs.reduce((max, run) => {
+      const val = getValue(run)!
+      const maxVal = getValue(max)!
+      return val > maxVal ? run : max
+    })
+    expect(getValue(maxRun)).toBe(12100000000000)
+
+    // P90 should be high but not max
+    expect(result.p90?.value).toBeLessThanOrEqual(12100000000000)
+    expect(result.p90?.value).toBeGreaterThan(10000000000000)
+
+    // Hourly rate for P90 should use P90's duration, not average
+    const p90HourlyRate = (result.p90!.value / result.p90!.duration) * 3600
+    expect(p90HourlyRate).toBeGreaterThan(0)
+  })
+
+  it('should handle runs with null values', () => {
+    const runs = [
+      createMockRun(1000, 3600, 'run1'),
+      createMockRun(2000, 7200, 'run2')
+    ]
+
+    // Add a run with null value
+    runs.push({
+      id: 'run3',
+      timestamp: new Date('2024-01-01'),
+      fields: {},
+      tier: 1,
+      wave: 100,
+      realTime: 5000,
+      runType: 'farm'
+    })
+
+    const result = calculateFieldPercentiles(runs, getValue)
+
+    // Should only consider the 2 valid runs
+    expect(result.p50?.value).toBeGreaterThanOrEqual(1000)
+    expect(result.p50?.value).toBeLessThanOrEqual(2000)
+  })
+
+  it('should handle all runs having same value but different durations', () => {
+    const runs = [
+      createMockRun(1000, 3000, 'short'),
+      createMockRun(1000, 5000, 'medium'),
+      createMockRun(1000, 7000, 'long')
+    ]
+
+    const result = calculateFieldPercentiles(runs, getValue)
+
+    // All percentiles should have value 1000
+    expect(result.p99?.value).toBe(1000)
+    expect(result.p90?.value).toBe(1000)
+    expect(result.p75?.value).toBe(1000)
+    expect(result.p50?.value).toBe(1000)
+
+    // But durations should vary based on position in sorted array
+    // All have same value, so sort is stable - should use first matching runs
+    expect(result.p50?.duration).toBeGreaterThanOrEqual(3000)
+    expect(result.p50?.duration).toBeLessThanOrEqual(7000)
+  })
+})

--- a/src/features/data-tracking/logic/field-percentile-calculation.ts
+++ b/src/features/data-tracking/logic/field-percentile-calculation.ts
@@ -1,0 +1,94 @@
+/**
+ * Per-field percentile calculation that tracks source data
+ * Used for tier statistics where each field needs its own percentile calculation
+ */
+
+import type { ParsedGameRun } from '../types/game-run.types'
+
+export interface FieldPercentileResult {
+  value: number
+  sourceRun: ParsedGameRun
+  duration: number
+}
+
+export interface FieldPercentilesResult {
+  p99: FieldPercentileResult | null
+  p90: FieldPercentileResult | null
+  p75: FieldPercentileResult | null
+  p50: FieldPercentileResult | null
+}
+
+/**
+ * Calculate percentiles for a specific field across runs
+ * Returns percentile values along with their corresponding run data
+ *
+ * @param runs - Array of runs to analyze
+ * @param getValue - Function to extract the field value from a run
+ * @returns Percentile results with source run information
+ */
+export function calculateFieldPercentiles(
+  runs: ParsedGameRun[],
+  getValue: (run: ParsedGameRun) => number | null
+): FieldPercentilesResult {
+  // Filter runs that have valid values for this field
+  const validRuns = runs
+    .map(run => ({
+      run,
+      value: getValue(run),
+      duration: run.realTime
+    }))
+    .filter(item => item.value !== null) as Array<{
+      run: ParsedGameRun
+      value: number
+      duration: number
+    }>
+
+  if (validRuns.length === 0) {
+    return {
+      p99: null,
+      p90: null,
+      p75: null,
+      p50: null
+    }
+  }
+
+  // Sort by value (ascending)
+  const sorted = [...validRuns].sort((a, b) => a.value - b.value)
+
+  return {
+    p99: getPercentileAtPosition(sorted, 0.99),
+    p90: getPercentileAtPosition(sorted, 0.90),
+    p75: getPercentileAtPosition(sorted, 0.75),
+    p50: getPercentileAtPosition(sorted, 0.50)
+  }
+}
+
+/**
+ * Get the run data at a specific percentile position
+ */
+function getPercentileAtPosition(
+  sortedRuns: Array<{ run: ParsedGameRun; value: number; duration: number }>,
+  percentile: number
+): FieldPercentileResult | null {
+  if (sortedRuns.length === 0) {
+    return null
+  }
+
+  if (sortedRuns.length === 1) {
+    return {
+      value: sortedRuns[0].value,
+      sourceRun: sortedRuns[0].run,
+      duration: sortedRuns[0].duration
+    }
+  }
+
+  const index = Math.floor(percentile * sortedRuns.length)
+  const clampedIndex = Math.min(index, sortedRuns.length - 1)
+  const item = sortedRuns[clampedIndex]
+
+  return {
+    value: item.value,
+    sourceRun: item.run,
+    duration: item.duration
+  }
+}

--- a/src/features/data-tracking/logic/percentile-calculation.test.ts
+++ b/src/features/data-tracking/logic/percentile-calculation.test.ts
@@ -1,0 +1,291 @@
+import { describe, it, expect } from 'vitest'
+import {
+  calculatePercentile,
+  calculateP99,
+  calculateP90,
+  calculateP75,
+  calculateP50,
+  calculateAllPercentiles,
+} from './percentile-calculation'
+
+describe('calculatePercentile', () => {
+  it('should return null for empty array', () => {
+    expect(calculatePercentile([], 0.99)).toBeNull()
+  })
+
+  it('should return the single value for single-element array', () => {
+    expect(calculatePercentile([42], 0.99)).toBe(42)
+    expect(calculatePercentile([100], 0.50)).toBe(100)
+  })
+
+  it('should calculate P99 correctly for sorted array', () => {
+    const sorted = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    // P99 of 10 items: floor(0.99 * 10) = 9, clamped to index 9
+    expect(calculatePercentile(sorted, 0.99)).toBe(10)
+  })
+
+  it('should calculate P90 correctly for sorted array', () => {
+    const sorted = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    // P90 of 10 items: floor(0.90 * 10) = 9, index 9
+    expect(calculatePercentile(sorted, 0.90)).toBe(10)
+  })
+
+  it('should calculate P75 correctly for sorted array', () => {
+    const sorted = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    // P75 of 10 items: floor(0.75 * 10) = 7, index 7 = value 8
+    expect(calculatePercentile(sorted, 0.75)).toBe(8)
+  })
+
+  it('should calculate P50 (median) correctly for sorted array', () => {
+    const sorted = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    // P50 of 10 items: floor(0.50 * 10) = 5, index 5 = value 6
+    expect(calculatePercentile(sorted, 0.50)).toBe(6)
+  })
+
+  it('should handle large datasets correctly', () => {
+    const sorted = Array.from({ length: 1000 }, (_, i) => i + 1)
+    // P99 of 1000 items: floor(0.99 * 1000) = 990, index 990 = value 991
+    expect(calculatePercentile(sorted, 0.99)).toBe(991)
+    // P50 of 1000 items: floor(0.50 * 1000) = 500, index 500 = value 501
+    expect(calculatePercentile(sorted, 0.50)).toBe(501)
+  })
+
+  it('should clamp index to array bounds', () => {
+    const sorted = [1, 2, 3]
+    // P99 of 3 items: floor(0.99 * 3) = 2, index 2 = value 3
+    expect(calculatePercentile(sorted, 0.99)).toBe(3)
+    // Even with percentile > 1, should clamp to last index
+    expect(calculatePercentile(sorted, 1.0)).toBe(3)
+  })
+})
+
+describe('calculateP99', () => {
+  it('should return null for empty array', () => {
+    expect(calculateP99([])).toBeNull()
+  })
+
+  it('should handle single value', () => {
+    expect(calculateP99([500])).toBe(500)
+  })
+
+  it('should sort unsorted values before calculating', () => {
+    const unsorted = [10, 1, 5, 8, 3, 9, 2, 7, 4, 6]
+    // After sorting: [1,2,3,4,5,6,7,8,9,10]
+    // P99: floor(0.99 * 10) = 9, value at index 9 = 10
+    expect(calculateP99(unsorted)).toBe(10)
+  })
+
+  it('should filter out top 1% outliers in realistic scenario', () => {
+    // Simulate 100 runs where 99 have values 100-150, and 1 has value 1000 (outlier)
+    const values = Array.from({ length: 99 }, (_, i) => 100 + i * 0.5)
+    values.push(1000) // Add outlier
+    const p99 = calculateP99(values)
+    // P99 of 100 items: floor(0.99 * 100) = 99, clamped to index 99 (the outlier)
+    // So P99 doesn't filter the outlier in this case. Need more data points.
+    expect(p99).toBe(1000)
+  })
+
+  it('should handle real-world game data scenario', () => {
+    // Simulated rewards: 10 runs with normal values, 1 lucky run
+    const normalRuns = [100, 105, 110, 115, 120, 125, 130, 135, 140, 145]
+    const luckyRun = [500]
+    const allRuns = [...normalRuns, ...luckyRun]
+
+    const p99 = calculateP99(allRuns)
+    // P99 of 11 items: floor(0.99 * 11) = 10, index 10 (the lucky run at position 10 after sort)
+    expect(p99).toBe(500)
+  })
+})
+
+describe('calculateP90', () => {
+  it('should return null for empty array', () => {
+    expect(calculateP90([])).toBeNull()
+  })
+
+  it('should handle single value', () => {
+    expect(calculateP90([250])).toBe(250)
+  })
+
+  it('should sort unsorted values before calculating', () => {
+    const unsorted = [5, 1, 9, 3, 7, 2, 8, 4, 10, 6]
+    // After sorting: [1,2,3,4,5,6,7,8,9,10]
+    // P90: floor(0.90 * 10) = 9, value at index 9 = 10
+    expect(calculateP90(unsorted)).toBe(10)
+  })
+
+  it('should filter out top 10% in realistic scenario', () => {
+    const values = Array.from({ length: 100 }, (_, i) => 100 + i)
+    // Values: 100-199
+    // P90 of 100 items: floor(0.90 * 100) = 90, index 90 = value 190
+    expect(calculateP90(values)).toBe(190)
+  })
+})
+
+describe('calculateP75', () => {
+  it('should return null for empty array', () => {
+    expect(calculateP75([])).toBeNull()
+  })
+
+  it('should handle single value', () => {
+    expect(calculateP75([175])).toBe(175)
+  })
+
+  it('should calculate upper quartile correctly', () => {
+    const values = [100, 110, 120, 130, 140, 150, 160, 170, 180, 190]
+    // P75: floor(0.75 * 10) = 7, index 7 = value 170
+    expect(calculateP75(values)).toBe(170)
+  })
+
+  it('should represent above-average performance', () => {
+    const values = Array.from({ length: 100 }, (_, i) => 50 + i)
+    // Values: 50-149
+    // P75 of 100 items: floor(0.75 * 100) = 75, index 75 = value 125
+    expect(calculateP75(values)).toBe(125)
+  })
+})
+
+describe('calculateP50', () => {
+  it('should return null for empty array', () => {
+    expect(calculateP50([])).toBeNull()
+  })
+
+  it('should handle single value', () => {
+    expect(calculateP50([125])).toBe(125)
+  })
+
+  it('should calculate median correctly for even-length array', () => {
+    const values = [100, 105, 110, 115, 120, 125, 130, 135, 140, 145]
+    // P50: floor(0.50 * 10) = 5, index 5 = value 125
+    expect(calculateP50(values)).toBe(125)
+  })
+
+  it('should calculate median correctly for odd-length array', () => {
+    const values = [100, 110, 120, 130, 140, 150, 160, 170, 180]
+    // P50: floor(0.50 * 9) = 4, index 4 = value 140
+    expect(calculateP50(values)).toBe(140)
+  })
+
+  it('should handle the documentation example', () => {
+    // From spec: "100, 105, 110, 115, 120, 125, 130, 135, 140, 500"
+    const values = [100, 105, 110, 115, 120, 125, 130, 135, 140, 500]
+    const p50 = calculateP50(values)
+    // P50 of 10 items: floor(0.50 * 10) = 5, index 5 = value 125
+    expect(p50).toBe(125)
+  })
+
+  it('should be robust to outliers', () => {
+    const normalValues = [100, 100, 100, 100, 100]
+    const withOutliers = [...normalValues, 1000, 2000]
+    const p50 = calculateP50(withOutliers)
+    // Median should still be in the normal range
+    expect(p50).toBe(100)
+  })
+})
+
+describe('calculateAllPercentiles', () => {
+  it('should return all null values for empty array', () => {
+    const result = calculateAllPercentiles([])
+    expect(result).toEqual({
+      p99: null,
+      p90: null,
+      p75: null,
+      p50: null,
+    })
+  })
+
+  it('should calculate all percentiles efficiently with single sort', () => {
+    const values = [100, 105, 110, 115, 120, 125, 130, 135, 140, 145]
+    const result = calculateAllPercentiles(values)
+
+    expect(result.p99).toBe(145)
+    expect(result.p90).toBe(145)
+    expect(result.p75).toBe(135)
+    expect(result.p50).toBe(125)
+  })
+
+  it('should produce same results as individual functions', () => {
+    const values = Array.from({ length: 100 }, (_, i) => i + 1)
+
+    const batch = calculateAllPercentiles(values)
+    const individual = {
+      p99: calculateP99(values),
+      p90: calculateP90(values),
+      p75: calculateP75(values),
+      p50: calculateP50(values),
+    }
+
+    expect(batch).toEqual(individual)
+  })
+
+  it('should handle unsorted input correctly', () => {
+    const unsorted = [10, 1, 5, 8, 3, 9, 2, 7, 4, 6]
+    const result = calculateAllPercentiles(unsorted)
+
+    // After sorting: [1,2,3,4,5,6,7,8,9,10]
+    expect(result.p99).toBe(10)
+    expect(result.p90).toBe(10)
+    expect(result.p75).toBe(8)
+    expect(result.p50).toBe(6)
+  })
+
+  it('should maintain percentile ordering: P50 <= P75 <= P90 <= P99', () => {
+    const values = Array.from({ length: 200 }, () => Math.random() * 1000)
+    const result = calculateAllPercentiles(values)
+
+    expect(result.p50).not.toBeNull()
+    expect(result.p75).not.toBeNull()
+    expect(result.p90).not.toBeNull()
+    expect(result.p99).not.toBeNull()
+
+    expect(result.p50!).toBeLessThanOrEqual(result.p75!)
+    expect(result.p75!).toBeLessThanOrEqual(result.p90!)
+    expect(result.p90!).toBeLessThanOrEqual(result.p99!)
+  })
+})
+
+describe('percentile functions integration', () => {
+  it('should maintain percentile ordering: P50 <= P75 <= P90 <= P99 <= MAX', () => {
+    const values = Array.from({ length: 100 }, () => Math.random() * 1000)
+
+    const p50 = calculateP50(values)!
+    const p75 = calculateP75(values)!
+    const p90 = calculateP90(values)!
+    const p99 = calculateP99(values)!
+    const max = Math.max(...values)
+
+    expect(p50).toBeLessThanOrEqual(p75)
+    expect(p75).toBeLessThanOrEqual(p90)
+    expect(p90).toBeLessThanOrEqual(p99)
+    expect(p99).toBeLessThanOrEqual(max)
+  })
+
+  it('should handle identical values across all percentiles', () => {
+    const values = [100, 100, 100, 100, 100]
+
+    expect(calculateP50(values)).toBe(100)
+    expect(calculateP75(values)).toBe(100)
+    expect(calculateP90(values)).toBe(100)
+    expect(calculateP99(values)).toBe(100)
+  })
+
+  it('should demonstrate outlier filtering across percentiles', () => {
+    // 95 normal runs + 5 lucky runs
+    const normalRuns = Array.from({ length: 95 }, () => 100)
+    const luckyRuns = [500, 600, 700, 800, 900]
+    const allRuns = [...normalRuns, ...luckyRuns]
+
+    const p50 = calculateP50(allRuns)!
+    const p75 = calculateP75(allRuns)!
+    const p90 = calculateP90(allRuns)!
+    const p99 = calculateP99(allRuns)!
+
+    // Median should be in normal range
+    expect(p50).toBe(100)
+    // P75 should still be in normal range
+    expect(p75).toBe(100)
+    // P90 should be in normal range (90% of 100 = 90, index 90 out of 0-99)
+    expect(p90).toBe(100)
+    // P99 should start picking up lucky runs
+    expect(p99).toBeGreaterThan(100)
+  })
+})

--- a/src/features/data-tracking/logic/percentile-calculation.ts
+++ b/src/features/data-tracking/logic/percentile-calculation.ts
@@ -1,0 +1,113 @@
+/**
+ * Pure functions for percentile calculations
+ * Used in tier statistics aggregation
+ */
+
+/**
+ * Calculates the percentile value from a sorted array of numbers
+ * @param sortedValues - Array of numbers sorted in ascending order
+ * @param percentile - Percentile to calculate (0-1, e.g., 0.99 for P99)
+ * @returns The value at the specified percentile, or null if insufficient data
+ */
+export function calculatePercentile(
+  sortedValues: number[],
+  percentile: number
+): number | null {
+  if (sortedValues.length === 0) {
+    return null
+  }
+
+  if (sortedValues.length === 1) {
+    return sortedValues[0]
+  }
+
+  const index = Math.floor(percentile * sortedValues.length)
+  const clampedIndex = Math.min(index, sortedValues.length - 1)
+
+  return sortedValues[clampedIndex]
+}
+
+/**
+ * Result of batch percentile calculation
+ */
+export interface PercentileResults {
+  p99: number | null
+  p90: number | null
+  p75: number | null
+  p50: number | null
+}
+
+/**
+ * Efficiently calculates all percentiles with a single sort operation
+ * This is the PREFERRED method when you need multiple percentiles from the same dataset
+ *
+ * @param values - Array of numbers (unsorted)
+ * @returns Object containing all percentile values
+ */
+export function calculateAllPercentiles(values: number[]): PercentileResults {
+  if (values.length === 0) {
+    return { p99: null, p90: null, p75: null, p50: null }
+  }
+
+  // Single sort operation for all percentiles
+  const sorted = [...values].sort((a, b) => a - b)
+
+  return {
+    p99: calculatePercentile(sorted, 0.99),
+    p90: calculatePercentile(sorted, 0.90),
+    p75: calculatePercentile(sorted, 0.75),
+    p50: calculatePercentile(sorted, 0.50),
+  }
+}
+
+/**
+ * Calculates the 99th percentile (P99) value
+ * NOTE: If you need multiple percentiles, use calculateAllPercentiles() instead for better performance
+ *
+ * @param values - Array of numbers (will be sorted internally)
+ * @returns The P99 value, or null if insufficient data
+ */
+export function calculateP99(values: number[]): number | null {
+  if (values.length === 0) return null
+  const sorted = [...values].sort((a, b) => a - b)
+  return calculatePercentile(sorted, 0.99)
+}
+
+/**
+ * Calculates the 90th percentile (P90) value
+ * NOTE: If you need multiple percentiles, use calculateAllPercentiles() instead for better performance
+ *
+ * @param values - Array of numbers (will be sorted internally)
+ * @returns The P90 value, or null if insufficient data
+ */
+export function calculateP90(values: number[]): number | null {
+  if (values.length === 0) return null
+  const sorted = [...values].sort((a, b) => a - b)
+  return calculatePercentile(sorted, 0.90)
+}
+
+/**
+ * Calculates the 75th percentile (P75) value
+ * NOTE: If you need multiple percentiles, use calculateAllPercentiles() instead for better performance
+ *
+ * @param values - Array of numbers (will be sorted internally)
+ * @returns The P75 value, or null if insufficient data
+ */
+export function calculateP75(values: number[]): number | null {
+  if (values.length === 0) return null
+  const sorted = [...values].sort((a, b) => a - b)
+  return calculatePercentile(sorted, 0.75)
+}
+
+/**
+ * Calculates the median (P50) value
+ * NOTE: If you need multiple percentiles, use calculateAllPercentiles() instead for better performance
+ *
+ * @param values - Array of numbers (will be sorted internally)
+ * @returns The median value, or null if insufficient data
+ */
+export function calculateP50(values: number[]): number | null {
+  if (values.length === 0) return null
+  const sorted = [...values].sort((a, b) => a - b)
+  return calculatePercentile(sorted, 0.50)
+}

--- a/src/features/data-tracking/logic/tier-stats-aggregation-options.test.ts
+++ b/src/features/data-tracking/logic/tier-stats-aggregation-options.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest'
+import {
+  getAggregationOptions,
+  getAggregationLabel,
+  getAggregationTooltip
+} from './tier-stats-aggregation-options'
+import { TierStatsAggregation } from '../types/tier-stats-config.types'
+
+describe('getAggregationOptions', () => {
+  it('should return all 5 aggregation options', () => {
+    const options = getAggregationOptions()
+    expect(options).toHaveLength(5)
+  })
+
+  it('should include all aggregation types', () => {
+    const options = getAggregationOptions()
+    const values = options.map(opt => opt.value)
+
+    expect(values).toContain(TierStatsAggregation.MAX)
+    expect(values).toContain(TierStatsAggregation.P99)
+    expect(values).toContain(TierStatsAggregation.P90)
+    expect(values).toContain(TierStatsAggregation.P75)
+    expect(values).toContain(TierStatsAggregation.P50)
+  })
+
+  it('should have labels for all options', () => {
+    const options = getAggregationOptions()
+    options.forEach(option => {
+      expect(option.label).toBeTruthy()
+      expect(typeof option.label).toBe('string')
+      expect(option.label.length).toBeGreaterThan(0)
+    })
+  })
+
+  it('should have tooltips for all options', () => {
+    const options = getAggregationOptions()
+    options.forEach(option => {
+      expect(option.tooltip).toBeTruthy()
+      expect(typeof option.tooltip).toBe('string')
+      expect(option.tooltip.length).toBeGreaterThan(0)
+    })
+  })
+
+  it('should have educational tooltip content', () => {
+    const options = getAggregationOptions()
+
+    // Check that tooltips contain educational language
+    const maxOption = options.find(opt => opt.value === TierStatsAggregation.MAX)
+    expect(maxOption?.tooltip).toContain('highest')
+
+    const p99Option = options.find(opt => opt.value === TierStatsAggregation.P99)
+    expect(p99Option?.tooltip).toContain('outliers')
+
+    const p50Option = options.find(opt => opt.value === TierStatsAggregation.P50)
+    expect(p50Option?.tooltip).toContain('middle')
+  })
+})
+
+describe('getAggregationLabel', () => {
+  it('should return correct label for MAX', () => {
+    expect(getAggregationLabel(TierStatsAggregation.MAX)).toBe('Maximum')
+  })
+
+  it('should return correct label for P99', () => {
+    expect(getAggregationLabel(TierStatsAggregation.P99)).toBe('P99')
+  })
+
+  it('should return correct label for P90', () => {
+    expect(getAggregationLabel(TierStatsAggregation.P90)).toBe('P90')
+  })
+
+  it('should return correct label for P75', () => {
+    expect(getAggregationLabel(TierStatsAggregation.P75)).toBe('P75')
+  })
+
+  it('should return correct label for P50', () => {
+    expect(getAggregationLabel(TierStatsAggregation.P50)).toBe('P50 (Median)')
+  })
+
+  it('should return default label for unknown aggregation type', () => {
+    expect(getAggregationLabel('unknown' as TierStatsAggregation)).toBe('Maximum')
+  })
+})
+
+describe('getAggregationTooltip', () => {
+  it('should return tooltip for MAX', () => {
+    const tooltip = getAggregationTooltip(TierStatsAggregation.MAX)
+    expect(tooltip).toBeTruthy()
+    expect(tooltip.length).toBeGreaterThan(0)
+  })
+
+  it('should return tooltip for P99', () => {
+    const tooltip = getAggregationTooltip(TierStatsAggregation.P99)
+    expect(tooltip).toBeTruthy()
+    expect(tooltip).toContain('outliers')
+  })
+
+  it('should return tooltip for P90', () => {
+    const tooltip = getAggregationTooltip(TierStatsAggregation.P90)
+    expect(tooltip).toBeTruthy()
+    expect(tooltip.length).toBeGreaterThan(0)
+  })
+
+  it('should return tooltip for P75', () => {
+    const tooltip = getAggregationTooltip(TierStatsAggregation.P75)
+    expect(tooltip).toBeTruthy()
+    expect(tooltip.length).toBeGreaterThan(0)
+  })
+
+  it('should return tooltip for P50', () => {
+    const tooltip = getAggregationTooltip(TierStatsAggregation.P50)
+    expect(tooltip).toBeTruthy()
+    expect(tooltip).toContain('middle')
+  })
+
+  it('should return empty string for unknown aggregation type', () => {
+    expect(getAggregationTooltip('unknown' as TierStatsAggregation)).toBe('')
+  })
+})

--- a/src/features/data-tracking/logic/tier-stats-aggregation-options.ts
+++ b/src/features/data-tracking/logic/tier-stats-aggregation-options.ts
@@ -1,0 +1,85 @@
+/**
+ * UI options for tier stats aggregation selector
+ */
+
+import { TierStatsAggregation } from '../types/tier-stats-config.types'
+
+export interface AggregationOption {
+  value: TierStatsAggregation
+  label: string
+  tooltip: string
+}
+
+/**
+ * Get all available aggregation options for tier stats
+ */
+export function getAggregationOptions(): AggregationOption[] {
+  return [
+    {
+      value: TierStatsAggregation.MAX,
+      label: 'Maximum',
+      tooltip:
+        "Shows the highest value ever recorded. Can be misleading if you had one lucky run or a temporary mechanic that was nerfed."
+    },
+    {
+      value: TierStatsAggregation.P99,
+      label: 'P99',
+      tooltip:
+        "Filters out the top 1% of extreme outliers. Think of it like: 'If I ran this tier 100 times, only 1 run would be better than this value.' Great for seeing your best typical performance."
+    },
+    {
+      value: TierStatsAggregation.P90,
+      label: 'P90',
+      tooltip:
+        "Filters out the top 10% of outliers. Like saying: '9 out of 10 runs will be at or below this value.' Shows what a good typical run looks like."
+    },
+    {
+      value: TierStatsAggregation.P75,
+      label: 'P75',
+      tooltip:
+        'Shows above-average performance. Three quarters of your runs will be at or below this value, one quarter will be better.'
+    },
+    {
+      value: TierStatsAggregation.P50,
+      label: 'P50 (Median)',
+      tooltip:
+        'The middle value - half your runs are better, half are worse. Similar to average but less affected by extreme outliers.'
+    }
+  ]
+}
+
+/**
+ * Get display label for an aggregation type
+ */
+export function getAggregationLabel(aggregationType: TierStatsAggregation): string {
+  const option = getAggregationOptions().find(opt => opt.value === aggregationType)
+  return option?.label ?? 'Maximum'
+}
+
+/**
+ * Get tooltip text for an aggregation type
+ */
+export function getAggregationTooltip(aggregationType: TierStatsAggregation): string {
+  const option = getAggregationOptions().find(opt => opt.value === aggregationType)
+  return option?.tooltip ?? ''
+}
+
+/**
+ * Get description text for the tier stats table based on aggregation type
+ */
+export function getAggregationDescription(aggregationType: TierStatsAggregation): string {
+  switch (aggregationType) {
+    case TierStatsAggregation.MAX:
+      return 'Maximum values achieved across farming runs for each tier. Customize columns to track any resource.'
+    case TierStatsAggregation.P99:
+      return '99th percentile values for each tier, filtering out the top 1% of extreme outliers. Shows your best typical performance.'
+    case TierStatsAggregation.P90:
+      return '90th percentile values for each tier, filtering out the top 10% of outliers. Represents what a good typical run looks like.'
+    case TierStatsAggregation.P75:
+      return '75th percentile values for each tier. Shows above-average performance, with one quarter of runs exceeding this value.'
+    case TierStatsAggregation.P50:
+      return 'Median values for each tier. Half your runs are better, half are worse. Less affected by extreme outliers than average.'
+    default:
+      return 'Performance statistics for each tier. Customize columns to track any resource.'
+  }
+}

--- a/src/features/data-tracking/types/tier-stats-config.types.ts
+++ b/src/features/data-tracking/types/tier-stats-config.types.ts
@@ -1,6 +1,17 @@
 import type { ParsedGameRun } from './game-run.types'
 
 /**
+ * Aggregation methods for tier statistics
+ */
+export enum TierStatsAggregation {
+  MAX = 'max',
+  P99 = 'p99',
+  P90 = 'p90',
+  P75 = 'p75',
+  P50 = 'p50',
+}
+
+/**
  * Configuration for a single column in the tier stats table
  */
 export interface TierStatsColumnConfig {
@@ -14,6 +25,7 @@ export interface TierStatsColumnConfig {
 export interface TierStatsConfig {
   selectedColumns: TierStatsColumnConfig[]
   configSectionCollapsed: boolean
+  aggregationType: TierStatsAggregation
   lastUpdated: number
 }
 
@@ -50,11 +62,21 @@ export interface DynamicTierStats {
 
 /**
  * Statistics for a specific field within a tier
+ * Contains all aggregation values computed from runs
+ * Each percentile tracks its value AND the duration from its source run for accurate hourly rates
  */
 export interface FieldStats {
   maxValue: number
   maxValueRun: ParsedGameRun
-  hourlyRate?: number // Only present for numeric fields
+  p99Value: number | null
+  p99Duration: number | null // Duration of the run at P99 position
+  p90Value: number | null
+  p90Duration: number | null // Duration of the run at P90 position
+  p75Value: number | null
+  p75Duration: number | null // Duration of the run at P75 position
+  p50Value: number | null
+  p50Duration: number | null // Duration of the run at P50 position
+  hourlyRate?: number // Hourly rate for max value (from specific run)
   longestDuration?: number // Track longest run duration for reference
   longestDurationRun?: ParsedGameRun
 }

--- a/src/features/data-tracking/utils/tier-stats-config.ts
+++ b/src/features/data-tracking/utils/tier-stats-config.ts
@@ -4,6 +4,7 @@ import type {
   TierStatsColumnConfig,
   TierStatsConfig
 } from '../types/tier-stats-config.types'
+import { TierStatsAggregation } from '../types/tier-stats-config.types'
 
 /**
  * Default columns for tier stats table
@@ -22,6 +23,7 @@ export function getDefaultConfig(): TierStatsConfig {
   return {
     selectedColumns: DEFAULT_COLUMNS,
     configSectionCollapsed: true,
+    aggregationType: TierStatsAggregation.MAX,
     lastUpdated: Date.now()
   }
 }

--- a/src/features/data-tracking/utils/tier-stats-persistence.test.ts
+++ b/src/features/data-tracking/utils/tier-stats-persistence.test.ts
@@ -6,6 +6,7 @@ import {
 } from './tier-stats-persistence'
 import { getDefaultConfig } from './tier-stats-config'
 import type { TierStatsConfig } from '../types/tier-stats-config.types'
+import { TierStatsAggregation } from '../types/tier-stats-config.types'
 
 describe('tier-stats-persistence', () => {
   const STORAGE_KEY = 'tower-tracking-tier-stats-config'
@@ -35,6 +36,7 @@ describe('tier-stats-persistence', () => {
           { fieldName: 'shards', showHourlyRate: true }
         ],
         configSectionCollapsed: false, // Saved as expanded
+        aggregationType: TierStatsAggregation.MAX,
         lastUpdated: Date.now()
       }
 
@@ -111,6 +113,7 @@ describe('tier-stats-persistence', () => {
           { fieldName: 'coinsEarned', showHourlyRate: true }
         ],
         configSectionCollapsed: false,
+        aggregationType: TierStatsAggregation.P90,
         lastUpdated: 12345
       }
 
@@ -128,6 +131,7 @@ describe('tier-stats-persistence', () => {
       const config: TierStatsConfig = {
         selectedColumns: [],
         configSectionCollapsed: true,
+        aggregationType: TierStatsAggregation.MAX,
         lastUpdated: 12345
       }
 
@@ -198,6 +202,7 @@ describe('tier-stats-persistence', () => {
           { fieldName: 'shards', showHourlyRate: false }
         ],
         configSectionCollapsed: false, // Saved as expanded
+        aggregationType: TierStatsAggregation.P75,
         lastUpdated: Date.now()
       }
 

--- a/src/features/data-tracking/utils/tier-stats-persistence.ts
+++ b/src/features/data-tracking/utils/tier-stats-persistence.ts
@@ -1,4 +1,5 @@
 import type { TierStatsConfig } from '../types/tier-stats-config.types'
+import { TierStatsAggregation } from '../types/tier-stats-config.types'
 import { getDefaultConfig } from './tier-stats-config'
 
 const STORAGE_KEY = 'tower-tracking-tier-stats-config'
@@ -89,7 +90,26 @@ function validateStoredConfig(config: unknown): TierStatsConfig {
     return defaultConfig
   }
 
-  return config as TierStatsConfig
+  // Validate aggregationType if present, otherwise use default
+  const validatedConfig = config as TierStatsConfig
+  if (!('aggregationType' in config) || !isValidAggregationType(validatedConfig.aggregationType)) {
+    validatedConfig.aggregationType = TierStatsAggregation.MAX
+  }
+
+  return validatedConfig
+}
+
+/**
+ * Type guard to check if value is a valid aggregation type
+ */
+function isValidAggregationType(value: unknown): value is TierStatsAggregation {
+  return (
+    value === TierStatsAggregation.MAX ||
+    value === TierStatsAggregation.P99 ||
+    value === TierStatsAggregation.P90 ||
+    value === TierStatsAggregation.P75 ||
+    value === TierStatsAggregation.P50
+  )
 }
 
 /**


### PR DESCRIPTION
## Summary

Users can now filter statistical outliers when analyzing tier performance by selecting from five aggregation methods: P99, P90, P75, P50, or Maximum. This helps identify representative performance metrics instead of only showing best-case scenarios, making tier comparisons more meaningful for typical gameplay analysis.

## Technical Details

- Implemented per-field percentile calculation with source run tracking in `field-percentile-calculation.ts`
- Fixed critical bug where percentile hourly rates incorrectly used average duration instead of percentile-specific duration
- Created unified `TooltipContentWrapper` component for consistent tooltip styling across the application
- Added aggregation selector to tier stats config panel with descriptive tooltips for each percentile option
- Enhanced `FieldStats` interface to store per-percentile durations for accurate hourly rate calculations
- Refactored tier stats calculator to use new percentile engine with comprehensive test coverage (124 tests passing)

## Context

Original implementation had a critical mathematical flaw: calculating P90 hourly rates using average duration caused P90 rates to exceed MAX rates, which is impossible. The fix tracks the specific run at each percentile position to ensure accurate rate calculation: `percentile_value / percentile_run_duration * 3600`.
