### PR TITLE
Add Field Analytics E2E test with BaseAnalyticsPage abstraction

### DIFF
--- a/e2e/features/analytics/field-analytics.spec.ts
+++ b/e2e/features/analytics/field-analytics.spec.ts
@@ -1,0 +1,82 @@
+import { test, expect } from '../../fixtures/seeded-page';
+import { AppPage } from '../../page-objects/app-page';
+import { FieldAnalyticsPage } from '../../page-objects/field-analytics-page';
+
+/**
+ * Field Analytics E2E Tests
+ *
+ * High-level smoke test: verify page loads with default field selection,
+ * field selector dropdown works with search, field switching updates chart,
+ * and period switching works.
+ *
+ * Uses seededPage fixture which loads localStorage from seed files.
+ */
+
+test.describe('Field Analytics', () => {
+  test('loads page, supports field selection with search, and period switching', async ({ seededPage }) => {
+    const appPage = new AppPage(seededPage);
+    const fieldAnalyticsPage = new FieldAnalyticsPage(seededPage);
+
+    // Step 1: Navigate to Field Analytics page via sidebar
+    await appPage.goto();
+    await appPage.fieldAnalyticsLink.click();
+    await fieldAnalyticsPage.waitForChartLoad();
+
+    // Step 2: Verify initial state - chart container visible with default field
+    await expect(fieldAnalyticsPage.chartContainer).toBeVisible();
+
+    // Verify default field selection (should be "Reroll Shards Earned")
+    const selectedFieldText = await fieldAnalyticsPage.getSelectedFieldText();
+    expect(selectedFieldText).toContain('Reroll Shards Earned');
+
+    // Verify chart has data
+    const hasData = await fieldAnalyticsPage.hasChartData();
+    expect(hasData).toBe(true);
+
+    // Step 3: Open field selector and search for "golden tower"
+    await fieldAnalyticsPage.openFieldSelector();
+
+    // Verify dropdown is visible with search input
+    await expect(fieldAnalyticsPage.searchInput).toBeVisible();
+
+    // Type fuzzy search query
+    await fieldAnalyticsPage.searchFields('golden tower');
+
+    // Step 4: Select "Coins From Golden Tower" from filtered results
+    await fieldAnalyticsPage.selectField('Coins From Golden Tower');
+
+    // Verify dropdown closes and selection updates
+    const newSelectedField = await fieldAnalyticsPage.getSelectedFieldText();
+    expect(newSelectedField).toContain('Coins From Golden Tower');
+
+    // Wait for chart to update
+    await fieldAnalyticsPage.waitForChartLoad();
+
+    // Verify chart container is still visible after field change
+    await expect(fieldAnalyticsPage.chartContainer).toBeVisible();
+
+    // Step 5: Switch to Daily period
+    await fieldAnalyticsPage.switchToDaily();
+
+    // Verify chart updates and has data
+    await expect(fieldAnalyticsPage.chartContainer).toBeVisible();
+    const dailyDataPoints = await fieldAnalyticsPage.getDataPointCount();
+    expect(dailyDataPoints).toBeGreaterThan(0);
+
+    // Step 6: Switch to Monthly period
+    await fieldAnalyticsPage.switchToMonthly();
+
+    // Verify chart updates and has data
+    await expect(fieldAnalyticsPage.chartContainer).toBeVisible();
+    const monthlyDataPoints = await fieldAnalyticsPage.getDataPointCount();
+    expect(monthlyDataPoints).toBeGreaterThan(0);
+
+    // Step 7: Verify tooltip appears on hover over September 2025
+    await fieldAnalyticsPage.hoverOverChartLabel('Sep 2025');
+
+    // Get tooltip content and verify it contains the field name
+    const tooltipContent = await fieldAnalyticsPage.getTooltipContent();
+    expect(tooltipContent).toBeTruthy();
+    expect(tooltipContent).toContain('Coins From Golden Tower');
+  });
+});

--- a/e2e/page-objects/app-page.ts
+++ b/e2e/page-objects/app-page.ts
@@ -25,6 +25,7 @@ export class AppPage {
   // Sidebar navigation - Charts section
   readonly coinAnalyticsLink: Locator;
   readonly cellAnalyticsLink: Locator;
+  readonly fieldAnalyticsLink: Locator;
   readonly deathAnalyticsLink: Locator;
   readonly tierStatsLink: Locator;
   readonly tierTrendsLink: Locator;
@@ -53,6 +54,7 @@ export class AppPage {
     // Charts section
     this.coinAnalyticsLink = page.locator('a:has-text("Coin Analytics")');
     this.cellAnalyticsLink = page.locator('a:has-text("Cell Analytics")');
+    this.fieldAnalyticsLink = page.locator('a:has-text("Field Analytics")');
     this.deathAnalyticsLink = page.locator('a:has-text("Death Analytics")');
     this.tierStatsLink = page.locator('a:has-text("Tier Stats")');
     this.tierTrendsLink = page.locator('a:has-text("Tier Trends")');

--- a/e2e/page-objects/base-analytics-page.ts
+++ b/e2e/page-objects/base-analytics-page.ts
@@ -1,0 +1,205 @@
+import { Page, Locator } from '@playwright/test';
+
+/**
+ * Base Analytics Page Object Model
+ *
+ * Provides shared functionality for all analytics chart pages:
+ * - Time period switching (Hourly, Daily, Weekly, Monthly, Yearly)
+ * - Chart rendering verification
+ * - Chart data presence validation
+ *
+ * Extend this class for specific analytics pages (Coin, Cell, Field, etc.)
+ */
+export abstract class BaseAnalyticsPage {
+  readonly page: Page;
+
+  // Period filter buttons - shared across all analytics pages
+  readonly hourlyButton: Locator;
+  readonly dailyButton: Locator;
+  readonly weeklyButton: Locator;
+  readonly monthlyButton: Locator;
+  readonly yearlyButton: Locator;
+
+  // Chart elements - shared across all analytics pages
+  readonly chartContainer: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+
+    // Period buttons - consistent across all chart pages
+    this.hourlyButton = page.locator('button:has-text("Hourly")');
+    this.dailyButton = page.locator('button:has-text("Daily")');
+    this.weeklyButton = page.locator('button:has-text("Weekly")');
+    this.monthlyButton = page.locator('button:has-text("Monthly")');
+    this.yearlyButton = page.locator('button:has-text("Yearly")');
+
+    // Chart container - consistent selector
+    this.chartContainer = page.locator('.chart-container');
+  }
+
+  /**
+   * Navigate to the specific analytics page
+   * Subclasses must implement to provide the correct route
+   */
+  abstract goto(): Promise<void>;
+
+  /**
+   * Wait for chart to finish loading
+   * Shared timeout and rendering delay logic
+   */
+  async waitForChartLoad() {
+    // Wait for chart container to be visible
+    await this.chartContainer.waitFor({ state: 'visible', timeout: 10000 });
+    // Add a small delay for chart rendering
+    await this.page.waitForTimeout(500);
+  }
+
+  /**
+   * Switch to hourly view
+   */
+  async switchToHourly() {
+    await this.hourlyButton.click();
+    await this.waitForChartLoad();
+  }
+
+  /**
+   * Switch to daily view
+   */
+  async switchToDaily() {
+    await this.dailyButton.click();
+    await this.waitForChartLoad();
+  }
+
+  /**
+   * Switch to weekly view
+   */
+  async switchToWeekly() {
+    await this.weeklyButton.click();
+    await this.waitForChartLoad();
+  }
+
+  /**
+   * Switch to monthly view
+   */
+  async switchToMonthly() {
+    await this.monthlyButton.click();
+    await this.waitForChartLoad();
+  }
+
+  /**
+   * Switch to yearly view
+   */
+  async switchToYearly() {
+    await this.yearlyButton.click();
+    await this.waitForChartLoad();
+  }
+
+  /**
+   * Verify chart has data (checks for SVG elements)
+   * Returns true if chart has data points
+   */
+  async hasChartData(): Promise<boolean> {
+    // Check for SVG elements that represent data
+    const svgElements = await this.page.locator('svg').count();
+    return svgElements > 0;
+  }
+
+  /**
+   * Get count of data points in chart
+   */
+  async getDataPointCount(): Promise<number> {
+    // Count circle elements (typical for line charts) or rect elements (for bar charts)
+    const circles = await this.page.locator('svg circle').count();
+    const rects = await this.page.locator('svg rect').count();
+    return Math.max(circles, rects);
+  }
+
+  /**
+   * Hover over a specific X-axis label to trigger tooltip
+   *
+   * @param labelText - The X-axis label text to hover over (e.g., "Sep 2025")
+   *
+   * @example
+   * await page.hoverOverChartLabel('Sep 2025');
+   */
+  async hoverOverChartLabel(labelText: string) {
+    // Wait for chart to be fully rendered
+    await this.page.waitForTimeout(1500);
+
+    // Find the specific X-axis label
+    // Recharts renders axis ticks as: <text class="recharts-cartesian-axis-tick-value"><tspan>Label</tspan></text>
+    const axisTickLabels = this.page.locator('.recharts-cartesian-axis-tick-value');
+    const tickCount = await axisTickLabels.count();
+
+    let targetElement = null;
+
+    // Search through all tick labels to find the one with our text
+    for (let i = 0; i < tickCount; i++) {
+      const element = axisTickLabels.nth(i);
+      const text = await element.textContent();
+
+      if (text && text.trim() === labelText) {
+        targetElement = element;
+        break;
+      }
+    }
+
+    if (!targetElement) {
+      return;
+    }
+
+    // Found the label - get the chart container to find the data area
+    const box = await targetElement.boundingBox();
+    if (!box) {
+      return;
+    }
+
+    // Get the chart container to find the actual chart area
+    const chartBox = await this.chartContainer.boundingBox();
+    if (!chartBox) {
+      return;
+    }
+
+    // Move mouse to the X position of the label, but at the vertical center of the chart area
+    // This ensures we're hovering over the data area, not too far above or below
+    const targetX = box.x + (box.width / 2);
+    const targetY = chartBox.y + (chartBox.height * 0.5);
+
+    await this.page.mouse.move(targetX, targetY);
+
+    // Wait for tooltip to appear and stabilize
+    await this.page.waitForTimeout(1200);
+  }
+
+  /**
+   * Get tooltip content if visible
+   * Waits for tooltip to be visible and returns its text content
+   *
+   * @returns The tooltip text content, or empty string if not visible
+   */
+  async getTooltipContent(): Promise<string> {
+    // Wait for tooltip wrapper to be visible
+    const tooltipWrapper = this.page.locator('.recharts-tooltip-wrapper');
+
+    try {
+      // Wait for tooltip to become visible (with timeout)
+      await tooltipWrapper.waitFor({ state: 'visible', timeout: 2000 });
+    } catch {
+      // Tooltip didn't appear
+      return '';
+    }
+
+    // Get the tooltip content from within the wrapper
+    // The tooltip has a specific structure with backdrop-blur class
+    const tooltipContent = tooltipWrapper.locator('[class*="backdrop-blur"]').first();
+    const isContentVisible = await tooltipContent.isVisible({ timeout: 1000 }).catch(() => false);
+
+    if (isContentVisible) {
+      const content = await tooltipContent.textContent();
+      return content || '';
+    }
+
+    // Fallback: get all text from the wrapper
+    return await tooltipWrapper.textContent() || '';
+  }
+}

--- a/e2e/page-objects/cells-analytics-page.ts
+++ b/e2e/page-objects/cells-analytics-page.ts
@@ -1,38 +1,15 @@
-import { Page, Locator } from '@playwright/test';
+import { Page } from '@playwright/test';
+import { BaseAnalyticsPage } from './base-analytics-page';
 
 /**
  * Cells Analytics Page Object Model
  *
- * Encapsulates interactions with the Cells Analytics page (/charts/cells):
- * - Time period switching (Hourly, Daily, Weekly, Monthly, Yearly)
- * - Chart rendering verification
- * - Chart data presence
+ * Extends BaseAnalyticsPage to provide Cells Analytics specific functionality.
+ * Inherits period switching, chart verification, and chart data methods.
  */
-export class CellsAnalyticsPage {
-  readonly page: Page;
-
-  // Period filter buttons
-  readonly hourlyButton: Locator;
-  readonly dailyButton: Locator;
-  readonly weeklyButton: Locator;
-  readonly monthlyButton: Locator;
-  readonly yearlyButton: Locator;
-
-  // Chart elements
-  readonly chartContainer: Locator;
-
+export class CellsAnalyticsPage extends BaseAnalyticsPage {
   constructor(page: Page) {
-    this.page = page;
-
-    // Period buttons - adjust selectors based on actual implementation
-    this.hourlyButton = page.locator('button:has-text("Hourly")');
-    this.dailyButton = page.locator('button:has-text("Daily")');
-    this.weeklyButton = page.locator('button:has-text("Weekly")');
-    this.monthlyButton = page.locator('button:has-text("Monthly")');
-    this.yearlyButton = page.locator('button:has-text("Yearly")');
-
-    // Chart container
-    this.chartContainer = page.locator('.chart-container');
+    super(page);
   }
 
   /**
@@ -41,75 +18,5 @@ export class CellsAnalyticsPage {
   async goto() {
     await this.page.goto('/charts/cells');
     await this.waitForChartLoad();
-  }
-
-  /**
-   * Wait for chart to finish loading
-   */
-  async waitForChartLoad() {
-    // Wait for chart container to be visible
-    await this.chartContainer.waitFor({ state: 'visible' });
-    // Add a small delay for chart rendering
-    await this.page.waitForTimeout(500);
-  }
-
-  /**
-   * Switch to hourly view
-   */
-  async switchToHourly() {
-    await this.hourlyButton.click();
-    await this.waitForChartLoad();
-  }
-
-  /**
-   * Switch to daily view
-   */
-  async switchToDaily() {
-    await this.dailyButton.click();
-    await this.waitForChartLoad();
-  }
-
-  /**
-   * Switch to weekly view
-   */
-  async switchToWeekly() {
-    await this.weeklyButton.click();
-    await this.waitForChartLoad();
-  }
-
-  /**
-   * Switch to monthly view
-   */
-  async switchToMonthly() {
-    await this.monthlyButton.click();
-    await this.waitForChartLoad();
-  }
-
-  /**
-   * Switch to yearly view
-   */
-  async switchToYearly() {
-    await this.yearlyButton.click();
-    await this.waitForChartLoad();
-  }
-
-  /**
-   * Verify chart has data (checks for SVG elements)
-   * Returns true if chart has data points
-   */
-  async hasChartData(): Promise<boolean> {
-    // Check for SVG elements that represent data
-    const svgElements = await this.page.locator('svg').count();
-    return svgElements > 0;
-  }
-
-  /**
-   * Get count of data points in chart
-   */
-  async getDataPointCount(): Promise<number> {
-    // Count circle elements (typical for line charts) or rect elements (for bar charts)
-    const circles = await this.page.locator('svg circle').count();
-    const rects = await this.page.locator('svg rect').count();
-    return Math.max(circles, rects);
   }
 }

--- a/e2e/page-objects/coin-analytics-page.ts
+++ b/e2e/page-objects/coin-analytics-page.ts
@@ -1,38 +1,15 @@
-import { Page, Locator } from '@playwright/test';
+import { Page } from '@playwright/test';
+import { BaseAnalyticsPage } from './base-analytics-page';
 
 /**
  * Coin Analytics Page Object Model
  *
- * Encapsulates interactions with the Coin Analytics page (/charts/coins):
- * - Time period switching (Hourly, Daily, Weekly, Monthly, Yearly)
- * - Chart rendering verification
- * - Chart data presence
+ * Extends BaseAnalyticsPage to provide Coin Analytics specific functionality.
+ * Inherits period switching, chart verification, and chart data methods.
  */
-export class CoinAnalyticsPage {
-  readonly page: Page;
-
-  // Period filter buttons
-  readonly hourlyButton: Locator;
-  readonly dailyButton: Locator;
-  readonly weeklyButton: Locator;
-  readonly monthlyButton: Locator;
-  readonly yearlyButton: Locator;
-
-  // Chart elements
-  readonly chartContainer: Locator;
-
+export class CoinAnalyticsPage extends BaseAnalyticsPage {
   constructor(page: Page) {
-    this.page = page;
-
-    // Period buttons - adjust selectors based on actual implementation
-    this.hourlyButton = page.locator('button:has-text("Hourly")');
-    this.dailyButton = page.locator('button:has-text("Daily")');
-    this.weeklyButton = page.locator('button:has-text("Weekly")');
-    this.monthlyButton = page.locator('button:has-text("Monthly")');
-    this.yearlyButton = page.locator('button:has-text("Yearly")');
-
-    // Chart container - may need adjustment based on actual implementation
-    this.chartContainer = page.locator('.chart-container');
+    super(page);
   }
 
   /**
@@ -41,75 +18,5 @@ export class CoinAnalyticsPage {
   async goto() {
     await this.page.goto('/charts/coins');
     await this.waitForChartLoad();
-  }
-
-  /**
-   * Wait for chart to finish loading
-   */
-  async waitForChartLoad() {
-    // Wait for chart container to be visible
-    await this.chartContainer.waitFor({ state: 'visible' });
-    // Add a small delay for chart rendering
-    await this.page.waitForTimeout(500);
-  }
-
-  /**
-   * Switch to hourly view
-   */
-  async switchToHourly() {
-    await this.hourlyButton.click();
-    await this.waitForChartLoad();
-  }
-
-  /**
-   * Switch to daily view
-   */
-  async switchToDaily() {
-    await this.dailyButton.click();
-    await this.waitForChartLoad();
-  }
-
-  /**
-   * Switch to weekly view
-   */
-  async switchToWeekly() {
-    await this.weeklyButton.click();
-    await this.waitForChartLoad();
-  }
-
-  /**
-   * Switch to monthly view
-   */
-  async switchToMonthly() {
-    await this.monthlyButton.click();
-    await this.waitForChartLoad();
-  }
-
-  /**
-   * Switch to yearly view
-   */
-  async switchToYearly() {
-    await this.yearlyButton.click();
-    await this.waitForChartLoad();
-  }
-
-  /**
-   * Verify chart has data (checks for SVG elements)
-   * Returns true if chart has data points
-   */
-  async hasChartData(): Promise<boolean> {
-    // Check for SVG elements that represent data
-    const svgElements = await this.page.locator('svg').count();
-    return svgElements > 0;
-  }
-
-  /**
-   * Get count of data points in chart
-   */
-  async getDataPointCount(): Promise<number> {
-    // Count circle elements (typical for line charts) or rect elements (for bar charts)
-    const circles = await this.page.locator('svg circle').count();
-    const rects = await this.page.locator('svg rect').count();
-    return Math.max(circles, rects);
   }
 }

--- a/e2e/page-objects/field-analytics-page.ts
+++ b/e2e/page-objects/field-analytics-page.ts
@@ -1,0 +1,76 @@
+import { Page, Locator } from '@playwright/test';
+import { BaseAnalyticsPage } from './base-analytics-page';
+
+/**
+ * Field Analytics Page Object Model
+ *
+ * Extends BaseAnalyticsPage to provide Field Analytics specific functionality:
+ * - Field selector dropdown with search functionality
+ * - Field selection and switching
+ *
+ * Inherits from BaseAnalyticsPage:
+ * - Time period switching (Hourly, Daily, Weekly, Monthly, Yearly)
+ * - Chart rendering verification
+ * - Chart data presence validation
+ */
+export class FieldAnalyticsPage extends BaseAnalyticsPage {
+  // Field selector elements (unique to Field Analytics)
+  readonly fieldSelectorButton: Locator;
+  readonly searchInput: Locator;
+  readonly dropdownPanel: Locator;
+  readonly chartTitle: Locator;
+
+  constructor(page: Page) {
+    super(page);
+
+    // Field selector - button that opens dropdown
+    this.fieldSelectorButton = page.locator('button').filter({ hasText: '📊' });
+
+    // Search input in dropdown (appears when dropdown is open)
+    this.searchInput = page.locator('input[placeholder="Search fields..."]');
+
+    // Dropdown panel container
+    this.dropdownPanel = page.locator('.absolute.z-50').filter({ hasText: 'Showing' });
+
+    // Chart title (in the card)
+    this.chartTitle = page.locator('h3').filter({ hasText: 'Over Time' });
+  }
+
+  /**
+   * Get the currently selected field text from the selector button
+   */
+  async getSelectedFieldText(): Promise<string> {
+    const buttonText = await this.fieldSelectorButton.textContent();
+    return buttonText || '';
+  }
+
+  /**
+   * Open the field selector dropdown
+   */
+  async openFieldSelector() {
+    await this.fieldSelectorButton.click();
+    // Wait for search input to be visible
+    await this.searchInput.waitFor({ state: 'visible' });
+  }
+
+  /**
+   * Search for fields using the search input
+   * Assumes dropdown is already open
+   */
+  async searchFields(searchTerm: string) {
+    await this.searchInput.fill(searchTerm);
+    // Small delay for filtering to take effect
+    await this.page.waitForTimeout(200);
+  }
+
+  /**
+   * Select a specific field from the dropdown
+   * Assumes dropdown is already open
+   */
+  async selectField(fieldLabel: string) {
+    const fieldButton = this.page.locator('button').filter({ hasText: fieldLabel }).first();
+    await fieldButton.click();
+    // Wait for dropdown to close
+    await this.searchInput.waitFor({ state: 'hidden', timeout: 2000 });
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -34,6 +34,7 @@ export default defineConfig({
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',
     trace: 'on-first-retry',
+    viewport: { width: 1600, height: 900 },
   },
 
   // Projects configuration


### PR DESCRIPTION
## Summary
Added comprehensive E2E test coverage for the Field Analytics page and eliminated significant code duplication in analytics page objects. A new base class extracts common period switching, chart verification, and tooltip functionality shared across all analytics pages. The viewport size was increased to improve chart rendering reliability during E2E tests.

## Technical Details
- Created `BaseAnalyticsPage` POM with shared methods for period switching (Hourly/Daily/Weekly/Monthly/Yearly), chart rendering verification, data presence validation, chart label hovering, and tooltip content extraction
- Implemented `FieldAnalyticsPage` POM extending `BaseAnalyticsPage` with field selector-specific methods (`openFieldSelector()`, `searchFields()`, `selectField()`, `getSelectedFieldText()`)
- Refactored `CoinAnalyticsPage` and `CellsAnalyticsPage` to extend `BaseAnalyticsPage`, eliminating ~140 lines of duplicated code
- Added comprehensive E2E test (`field-analytics.spec.ts`) covering field selection with fuzzy search ("golden tower"), period switching across multiple timeframes, chart data validation, and tooltip verification
- Updated `AppPage` POM with `fieldAnalyticsLink` locator for navigation
- Increased E2E viewport size from default to 1600x900 in `playwright.config.ts` for improved chart rendering and interaction reliability

## Context
The Field Analytics page was added in PR #90 but lacked E2E test coverage. This PR adds comprehensive test coverage while simultaneously improving the test infrastructure by eliminating duplication across analytics page objects through inheritance.