### PR TITLE
MINOR: Add Totals Analysis page scaffolding

### DIFF
--- a/src/features/analysis/totals-analytics/totals-analysis.tsx
+++ b/src/features/analysis/totals-analytics/totals-analysis.tsx
@@ -1,0 +1,82 @@
+export function TotalsAnalysis() {
+  return (
+    <div className="flex items-center justify-center min-h-[32rem] sm:min-h-[36rem] px-4 py-8">
+      <div className="max-w-2xl w-full text-center space-y-8">
+        <div className="flex justify-center">
+          <div className="w-28 h-28 sm:w-32 sm:h-32 rounded-full bg-gradient-to-br from-purple-500/20 to-violet-500/20 flex items-center justify-center border border-purple-500/30 shadow-lg shadow-purple-500/10">
+            <svg
+              className="w-14 h-14 sm:w-16 sm:h-16 text-purple-400"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"
+              />
+            </svg>
+          </div>
+        </div>
+
+        <div className="space-y-3">
+          <h2 className="text-2xl sm:text-3xl font-bold text-slate-100">
+            Totals Analysis - Coming Soon!
+          </h2>
+          <p className="text-base sm:text-lg text-slate-400">
+            Analyze the sources of your aggregate metrics
+          </p>
+        </div>
+
+        <div className="space-y-6 text-slate-300">
+          <p className="text-sm sm:text-base">
+            This page will allow you to analyze the breakdown of aggregate metrics like damage dealt and coin income:
+          </p>
+
+          <ul className="text-left space-y-3 max-w-xl mx-auto text-sm sm:text-base">
+            <li className="flex items-start gap-3">
+              <span className="text-purple-400 mt-1 font-bold">•</span>
+              <span>Damage dealt breakdown (orb damage, thorn damage, chain lightning, etc.)</span>
+            </li>
+            <li className="flex items-start gap-3">
+              <span className="text-purple-400 mt-1 font-bold">•</span>
+              <span>Coin income sources (golden tower, black hole, spotlight, upgrades, etc.)</span>
+            </li>
+            <li className="flex items-start gap-3">
+              <span className="text-purple-400 mt-1 font-bold">•</span>
+              <span>Enemy type breakdown (total enemies killed by type)</span>
+            </li>
+            <li className="flex items-start gap-3">
+              <span className="text-purple-400 mt-1 font-bold">•</span>
+              <span>Potentially more metrics where data breakdown is available</span>
+            </li>
+          </ul>
+
+          <p className="pt-2 text-sm sm:text-base text-slate-400">
+            Stay tuned for timeline charts, pie charts, and detailed source breakdowns
+            to help you optimize your strategy.
+          </p>
+        </div>
+
+        <div className="pt-4">
+          <a
+            href="https://discord.gg/J444xGFbTt"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 px-5 py-2.5 sm:px-6 sm:py-3 rounded-lg bg-purple-500/10 hover:bg-purple-500/15 border border-purple-500/30 hover:border-purple-400/50 text-purple-200 hover:text-purple-100 transition-all duration-200 shadow-sm hover:shadow-md hover:shadow-purple-500/20 text-sm sm:text-base"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path d="M20.317 4.37a19.791 19.791 0 00-4.885-1.515.074.074 0 00-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 00-5.487 0 12.64 12.64 0 00-.617-1.25.077.077 0 00-.079-.037A19.736 19.736 0 003.677 4.37a.07.07 0 00-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 00.031.057 19.9 19.9 0 005.993 3.03.078.078 0 00.084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 00-.041-.106 13.107 13.107 0 01-1.872-.892.077.077 0 01-.008-.128 10.2 10.2 0 00.372-.292.074.074 0 01.077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 01.078.01c.12.098.246.198.373.292a.077.077 0 01-.006.127 12.299 12.299 0 01-1.873.892.077.077 0 00-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 00.084.028 19.839 19.839 0 006.002-3.03.077.077 0 00.032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 00-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z" />
+            </svg>
+            Join Discord to Request Features
+          </a>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/features/navigation/chart-navigation/use-chart-navigation.ts
+++ b/src/features/navigation/chart-navigation/use-chart-navigation.ts
@@ -1,7 +1,7 @@
 import { useUrlSearchParam } from './use-url-search-param'
 import { useEffect, useState } from 'react'
 
-export type ChartType = 'coins' | 'cells' | 'deaths' | 'tiers' | 'trends' | 'fields'
+export type ChartType = 'coins' | 'cells' | 'deaths' | 'tiers' | 'trends' | 'fields' | 'totals'
 
 interface ChartSearchParams extends Record<string, unknown> {
   chart?: ChartType

--- a/src/features/navigation/config/navigation-config.ts
+++ b/src/features/navigation/config/navigation-config.ts
@@ -64,6 +64,12 @@ export const NAVIGATION_SECTIONS: NavigationSection[] = [
         label: 'Tier Trends',
         href: '/charts?chart=trends',
         icon: 'tier-trends'
+      },
+      {
+        id: 'totals-analytics',
+        label: 'Totals Analysis',
+        href: '/charts?chart=totals',
+        icon: 'field-analytics'
       }
     ]
   },

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as RunsRouteImport } from './routes/runs'
 import { Route as ChartsRouteImport } from './routes/charts'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as SettingsDataManagementRouteImport } from './routes/settings/data-management'
+import { Route as ChartsTotalsRouteImport } from './routes/charts/totals'
 import { Route as ChartsTierTrendsRouteImport } from './routes/charts/tier-trends'
 import { Route as ChartsTierStatsRouteImport } from './routes/charts/tier-stats'
 import { Route as ChartsFieldsRouteImport } from './routes/charts/fields'
@@ -45,6 +46,11 @@ const SettingsDataManagementRoute = SettingsDataManagementRouteImport.update({
   id: '/data-management',
   path: '/data-management',
   getParentRoute: () => SettingsRoute,
+} as any)
+const ChartsTotalsRoute = ChartsTotalsRouteImport.update({
+  id: '/totals',
+  path: '/totals',
+  getParentRoute: () => ChartsRoute,
 } as any)
 const ChartsTierTrendsRoute = ChartsTierTrendsRouteImport.update({
   id: '/tier-trends',
@@ -88,6 +94,7 @@ export interface FileRoutesByFullPath {
   '/charts/fields': typeof ChartsFieldsRoute
   '/charts/tier-stats': typeof ChartsTierStatsRoute
   '/charts/tier-trends': typeof ChartsTierTrendsRoute
+  '/charts/totals': typeof ChartsTotalsRoute
   '/settings/data-management': typeof SettingsDataManagementRoute
 }
 export interface FileRoutesByTo {
@@ -101,6 +108,7 @@ export interface FileRoutesByTo {
   '/charts/fields': typeof ChartsFieldsRoute
   '/charts/tier-stats': typeof ChartsTierStatsRoute
   '/charts/tier-trends': typeof ChartsTierTrendsRoute
+  '/charts/totals': typeof ChartsTotalsRoute
   '/settings/data-management': typeof SettingsDataManagementRoute
 }
 export interface FileRoutesById {
@@ -115,6 +123,7 @@ export interface FileRoutesById {
   '/charts/fields': typeof ChartsFieldsRoute
   '/charts/tier-stats': typeof ChartsTierStatsRoute
   '/charts/tier-trends': typeof ChartsTierTrendsRoute
+  '/charts/totals': typeof ChartsTotalsRoute
   '/settings/data-management': typeof SettingsDataManagementRoute
 }
 export interface FileRouteTypes {
@@ -130,6 +139,7 @@ export interface FileRouteTypes {
     | '/charts/fields'
     | '/charts/tier-stats'
     | '/charts/tier-trends'
+    | '/charts/totals'
     | '/settings/data-management'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -143,6 +153,7 @@ export interface FileRouteTypes {
     | '/charts/fields'
     | '/charts/tier-stats'
     | '/charts/tier-trends'
+    | '/charts/totals'
     | '/settings/data-management'
   id:
     | '__root__'
@@ -156,6 +167,7 @@ export interface FileRouteTypes {
     | '/charts/fields'
     | '/charts/tier-stats'
     | '/charts/tier-trends'
+    | '/charts/totals'
     | '/settings/data-management'
   fileRoutesById: FileRoutesById
 }
@@ -202,6 +214,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/settings/data-management'
       preLoaderRoute: typeof SettingsDataManagementRouteImport
       parentRoute: typeof SettingsRoute
+    }
+    '/charts/totals': {
+      id: '/charts/totals'
+      path: '/totals'
+      fullPath: '/charts/totals'
+      preLoaderRoute: typeof ChartsTotalsRouteImport
+      parentRoute: typeof ChartsRoute
     }
     '/charts/tier-trends': {
       id: '/charts/tier-trends'
@@ -255,6 +274,7 @@ interface ChartsRouteChildren {
   ChartsFieldsRoute: typeof ChartsFieldsRoute
   ChartsTierStatsRoute: typeof ChartsTierStatsRoute
   ChartsTierTrendsRoute: typeof ChartsTierTrendsRoute
+  ChartsTotalsRoute: typeof ChartsTotalsRoute
 }
 
 const ChartsRouteChildren: ChartsRouteChildren = {
@@ -264,6 +284,7 @@ const ChartsRouteChildren: ChartsRouteChildren = {
   ChartsFieldsRoute: ChartsFieldsRoute,
   ChartsTierStatsRoute: ChartsTierStatsRoute,
   ChartsTierTrendsRoute: ChartsTierTrendsRoute,
+  ChartsTotalsRoute: ChartsTotalsRoute,
 }
 
 const ChartsRouteWithChildren =

--- a/src/routes/charts.tsx
+++ b/src/routes/charts.tsx
@@ -8,6 +8,7 @@ import { TierTrendsAnalysis } from '../features/analysis/tier-trends/tier-trends
 import { TimeSeriesChart } from '../features/analysis/time-series/time-series-chart'
 import { FieldSelector } from '../features/analysis/field-analytics/field-selector'
 import { useFieldSelector } from '../features/analysis/field-analytics/use-field-selector'
+import { TotalsAnalysis } from '../features/analysis/totals-analytics/totals-analysis'
 import { useChartNavigation, ChartType } from '../features/navigation'
 import { useData } from '../shared/domain/use-data'
 import { formatFieldDisplayName, getFieldFormatter } from '../shared/domain/fields/field-formatters'
@@ -53,7 +54,7 @@ function ChartsPage() {
         {/* Analytics Tabs */}
         <Tabs value={activeChart} onValueChange={handleTabChange} className="w-full">
           <div className="flex justify-center mb-8">
-            <TabsList className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 w-full max-w-5xl gap-1">
+            <TabsList className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-7 w-full max-w-5xl gap-1">
               <TabsTrigger
                 value="coins"
                 className="data-[state=active]:bg-emerald-500/15 data-[state=active]:text-emerald-100 hover:bg-emerald-500/10 text-xs sm:text-sm"
@@ -95,6 +96,13 @@ function ChartsPage() {
               >
                 <span className="hidden sm:inline">Tier Trends</span>
                 <span className="sm:hidden">Trends</span>
+              </TabsTrigger>
+              <TabsTrigger
+                value="totals"
+                className="data-[state=active]:bg-purple-500/15 data-[state=active]:text-purple-100 hover:bg-purple-500/10 text-xs sm:text-sm"
+              >
+                <span className="hidden sm:inline">Totals Analysis</span>
+                <span className="sm:hidden">Totals</span>
               </TabsTrigger>
             </TabsList>
           </div>
@@ -240,6 +248,26 @@ function ChartsPage() {
               <CardContent className="p-0">
                 <div className="p-0 md:p-8 w-full">
                   <TierTrendsAnalysis />
+                </div>
+              </CardContent>
+            </Card>
+          </TabsContent>
+
+          <TabsContent value="totals" className="space-y-8 lg:space-y-12">
+            <Card className="chart-container overflow-hidden border-slate-700/50 bg-slate-800/50 shadow-2xl hover:shadow-purple-500/10 transition-all duration-300">
+              <CardHeader className="bg-gradient-to-r from-purple-500/10 via-transparent to-purple-500/10 border-b border-slate-700/50">
+                <CardTitle className="text-2xl font-semibold text-slate-100 flex items-center gap-3">
+                  <div className="w-2 h-8 bg-gradient-to-b from-purple-400 to-purple-600 rounded-full shadow-lg shadow-purple-500/30"></div>
+                  Totals Analysis
+                  <span className="text-sm font-normal text-slate-400 ml-auto">Income Source Breakdown</span>
+                </CardTitle>
+                <p className="text-slate-400 text-sm mt-2">
+                  Analyze the breakdown of aggregate metrics like damage dealt and coin income.
+                </p>
+              </CardHeader>
+              <CardContent className="p-0">
+                <div className="p-8 w-full">
+                  <TotalsAnalysis />
                 </div>
               </CardContent>
             </Card>

--- a/src/routes/charts/totals.tsx
+++ b/src/routes/charts/totals.tsx
@@ -1,0 +1,38 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui'
+import { TotalsAnalysis } from '../../features/analysis/totals-analytics/totals-analysis'
+
+export const Route = createFileRoute('/charts/totals')({
+  component: TotalsAnalysisPage,
+})
+
+function TotalsAnalysisPage() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900">
+      <div className="max-w-7xl mx-auto p-6 space-y-8">
+        <div className="space-y-4">
+          <div className="relative">
+            <h1 className="text-4xl font-bold bg-gradient-to-r from-purple-400 to-violet-400 bg-clip-text text-transparent">
+              📊 Totals Analysis
+            </h1>
+            <div className="absolute -inset-1 bg-gradient-to-r from-purple-600/20 to-violet-600/20 blur-lg -z-10 rounded-lg"></div>
+          </div>
+          <p className="text-muted-foreground text-lg">
+            Analyze the breakdown of aggregate metrics like damage dealt and coin income
+          </p>
+        </div>
+
+        <Card className="chart-container overflow-hidden border-slate-700/50 bg-slate-800/50 backdrop-blur-sm shadow-2xl hover:shadow-purple-500/10 transition-all duration-300">
+          <CardHeader className="bg-gradient-to-r from-purple-500/10 via-transparent to-purple-500/10 border-b border-slate-700/50">
+            <CardTitle className="text-xl font-medium text-slate-100">Income Source Breakdown</CardTitle>
+          </CardHeader>
+          <CardContent className="p-0">
+            <div className="p-8 w-full">
+              <TotalsAnalysis />
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
Users will soon be able to analyze the sources of their aggregate metrics like damage dealt and coin income. This change prepares the navigation infrastructure by adding a new "Totals Analysis" tab with a "Coming Soon" placeholder, setting expectations and preventing routing conflicts when the full feature is implemented later.

## Technical Details
- Extended `ChartType` union with `'totals'` in `use-chart-navigation.ts`
- Created placeholder component `totals-analysis.tsx` with purple color scheme and responsive design
- Updated Charts page tab grid layout from 6 to 7 columns (`lg:grid-cols-7`)
- Added sidebar navigation entry pointing to `/charts?chart=totals`
- Implemented mobile-responsive tab labels ("Totals Analysis" → "Totals")
- Placeholder describes future damage dealt and coin income breakdowns (excludes cell earnings per PRD)

## Context
Follows PRD at `docs/PRD-totals-analysis-scaffolding.md`. Scaffolding now allows users to discover the planned feature and provides isolated development environment for future implementation without touching navigation code.