### PR TITLE
BUG: Disable SSR globally to fix hydration errors on analysis pages

### DIFF
--- a/src/router.tsx
+++ b/src/router.tsx
@@ -9,7 +9,8 @@ export const createRouter = () => {
     routeTree,
     scrollRestoration: true,
     defaultPreloadStaleTime: 0,
-    basepath: import.meta.env.BASE_URL
+    basepath: import.meta.env.BASE_URL,
+    defaultSsr: false, // Disable SSR for all routes - app is client-only
   })
 }
 


### PR DESCRIPTION
## Summary
Users reported seeing "code soup" (raw CSS classes and partial HTML fragments) when directly loading or refreshing analysis pages. This fix disables server-side rendering globally by adding `defaultSsr: false` to the router configuration, ensuring the app runs in client-only mode as originally intended.

## Technical Details
- Added `defaultSsr: false` option to TanStack Router configuration in `src/router.tsx`
- Single-line change with explanatory comment documenting client-only rendering intent
- Prevents SSR hydration mismatches that cause rendering corruption

## Context
**IMPORTANT: This is a speculative/experimental fix**

- Issue reported by users but **could not be replicated locally** despite multiple attempts
- Application architecture assumes client-only rendering, not SSR
- Production testing needed to verify this fix resolves the reported issue
- May require follow-up PR to revert or enhance approach based on production results

For context, this is how the github pages page looks like after a page refresh (or opening it up in a new tab)
<img width="2560" height="1279" alt="image" src="https://github.com/user-attachments/assets/66c5a4d5-96f5-4c53-95eb-fc091b92b6b4" />
