### PR TITLE
BUG: Fix timeline charts displaying no data on Coins and Cells pages

### DIFF
--- a/src/routes/charts.tsx
+++ b/src/routes/charts.tsx
@@ -118,7 +118,7 @@ function ChartsPage() {
               <CardContent className="p-0">
                 <div className="p-8 w-full">
                   <TimeSeriesChart 
-                    metric="coins"
+                    metric="coinsEarned"
                     title="Coins Earned"
                     subtitle="Track your coin earnings from farming runs over different time periods"
                     defaultPeriod="hourly"
@@ -140,7 +140,7 @@ function ChartsPage() {
               <CardContent className="p-0">
                 <div className="p-8 w-full">
                   <TimeSeriesChart 
-                    metric="cells"
+                    metric="cellsEarned"
                     title="Cells Earned"
                     subtitle="Track your cell earnings from farming runs over different time periods"
                     defaultPeriod="hourly"

--- a/src/routes/charts/cells.tsx
+++ b/src/routes/charts/cells.tsx
@@ -29,7 +29,7 @@ function CellsChartPage() {
           <CardContent className="p-0">
             <div className="p-8 w-full">
               <TimeSeriesChart
-                metric="cells"
+                metric="cellsEarned"
                 title="Cells Earned"
                 subtitle="Track your cell earnings from farm runs over different time periods"
                 defaultPeriod="hourly"

--- a/src/routes/charts/coins.tsx
+++ b/src/routes/charts/coins.tsx
@@ -29,7 +29,7 @@ function CoinsChartPage() {
           <CardContent className="p-0">
             <div className="p-8 w-full">
               <TimeSeriesChart
-                metric="coins"
+                metric="coinsEarned"
                 title="Coins Earned"
                 subtitle="Track your coin earnings from farm runs over different time periods"
                 defaultPeriod="hourly"


### PR DESCRIPTION
## Summary

Fixed broken timeline charts on the Coins and Cells Analytics pages that were showing flat lines with "no data available" messages. The charts now properly display earnings data by using the correct field names from the data model.

## Technical Details

- Updated `TimeSeriesChart` metric prop from `"coins"` to `"coinsEarned"` on charts.tsx (main charts page)
- Updated `TimeSeriesChart` metric prop from `"coins"` to `"coinsEarned"` on charts/coins.tsx (dedicated coins page)
- Updated `TimeSeriesChart` metric prop from `"cells"` to `"cellsEarned"` on charts.tsx (main charts page)
- Updated `TimeSeriesChart` metric prop from `"cells"` to `"cellsEarned"` on charts/cells.tsx (dedicated cells page)
- All metric identifiers now align with the `ParsedGameRun` interface field names

## Context

The `TimeSeriesChart` component's aggregation logic expects metric names that match the actual field names in the `ParsedGameRun` data structure. The shorthand identifiers ("coins", "cells") were not matching the actual field names ("coinsEarned", "cellsEarned"), causing the chart to fail data lookup and display empty results.

<img width="1381" height="903" alt="image" src="https://github.com/user-attachments/assets/13f135e1-ffab-429f-aebd-f816795bbb48" />

