### PR TITLE
IMPROVE: Add Source Analysis E2E tests with enhanced multi-chart support

### DIFF
--- a/e2e/features/analytics/source-analysis.spec.ts
+++ b/e2e/features/analytics/source-analysis.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '../../fixtures/seeded-page';
+import { AppPage } from '../../page-objects/app-page';
+import { SourceAnalysisPage } from '../../page-objects/source-analysis-page';
+
+/**
+ * Source Analysis E2E Test
+ *
+ * Single happy-path test that verifies:
+ * - Page loads and renders charts
+ * - Duration filter switching works
+ * - Timeline chart tooltip shows real data on hover
+ * - Source Ranking bar chart displays real source data with values and percentages
+ */
+
+test.describe('Source Analysis', () => {
+  test('loads page, switches to monthly, shows tooltip, and renders source ranking with real data', async ({ seededPage }) => {
+    const appPage = new AppPage(seededPage);
+    const sourceAnalysisPage = new SourceAnalysisPage(seededPage);
+
+    // Step 1: Navigate to Source Analysis page via sidebar
+    await appPage.goto();
+    await appPage.sourceAnalysisLink.click();
+    await sourceAnalysisPage.waitForChartLoad();
+
+    // Step 2: Verify chart container is visible
+    await expect(sourceAnalysisPage.chartContainer).toBeVisible();
+
+    // Step 3: Switch to Monthly duration to get aggregated data
+    await sourceAnalysisPage.switchToMonthly();
+
+    // Step 4: Hover over Oct 25 on the timeline chart to trigger tooltip
+    await sourceAnalysisPage.hoverOverChartLabel('Oct 25');
+
+    // Step 5: Verify tooltip appears with real data content
+    const tooltipContent = await sourceAnalysisPage.getTooltipContent();
+    expect(tooltipContent).toBeTruthy();
+    expect(tooltipContent).toContain('Chain Lightning');
+
+    // Step 6: Verify Source Ranking bar chart shows real source data
+    const sourceRankingContent = await sourceAnalysisPage.getSourceRankingContent();
+    expect(sourceRankingContent).toBeTruthy();
+
+    // Verify specific source appears with its value and percentage
+    // Chain Lightning is the top damage source in the seed data
+    expect(sourceRankingContent).toContain('Chain Lightning');
+    expect(sourceRankingContent).toContain('2.9S'); // ~2.9 sextillion damage
+    expect(sourceRankingContent).toContain('56.0%'); // Top source percentage
+  });
+});

--- a/e2e/page-objects/app-page.ts
+++ b/e2e/page-objects/app-page.ts
@@ -29,6 +29,7 @@ export class AppPage {
   readonly deathAnalyticsLink: Locator;
   readonly tierStatsLink: Locator;
   readonly tierTrendsLink: Locator;
+  readonly sourceAnalysisLink: Locator;
 
   // Sidebar navigation - Settings section (deep links to settings page)
   readonly bulkImportLink: Locator;
@@ -57,6 +58,7 @@ export class AppPage {
     this.deathAnalyticsLink = page.locator('a:has-text("Death Analytics")');
     this.tierStatsLink = page.locator('a:has-text("Tier Stats")');
     this.tierTrendsLink = page.locator('a:has-text("Tier Trends")');
+    this.sourceAnalysisLink = page.locator('a:has-text("Source Analysis")');
 
     // Settings section (deep links to settings page)
     this.bulkImportLink = page.locator('a:has-text("Bulk Import")');

--- a/e2e/page-objects/source-analysis-page.ts
+++ b/e2e/page-objects/source-analysis-page.ts
@@ -1,0 +1,60 @@
+import { Page } from '@playwright/test';
+import { BaseAnalyticsPage } from './base-analytics-page';
+
+/**
+ * Source Analysis Page Object Model
+ *
+ * Extends BaseAnalyticsPage to provide Source Analysis specific functionality:
+ * - Multi-chart page with timeline, pie, and bar charts
+ * - Source ranking content verification
+ *
+ * Inherits from BaseAnalyticsPage:
+ * - Time period switching
+ * - Chart hover with optional chartTitle parameter for multi-chart targeting
+ * - Tooltip content retrieval with multi-strategy detection
+ */
+export class SourceAnalysisPage extends BaseAnalyticsPage {
+  // Timeline chart title for targeting hover interactions
+  static readonly TIMELINE_CHART_TITLE = 'Source Proportions Over Time';
+
+  constructor(page: Page) {
+    super(page);
+  }
+
+  /**
+   * Navigate to the Source Analysis page
+   */
+  async goto(): Promise<void> {
+    await this.page.goto('/charts/sources');
+    await this.waitForChartLoad();
+  }
+
+  /**
+   * Hover over a specific X-axis label on the TIMELINE chart to trigger tooltip
+   *
+   * Overrides base implementation to automatically target the timeline chart
+   * since Source Analysis has multiple charts.
+   *
+   * @param labelText - The X-axis label text to hover over (e.g., "Oct 25")
+   */
+  async hoverOverChartLabel(labelText: string): Promise<void> {
+    // Call base implementation with the timeline chart title
+    await super.hoverOverChartLabel(labelText, SourceAnalysisPage.TIMELINE_CHART_TITLE);
+  }
+
+  /**
+   * Get the text content of the Source Ranking section (bar chart area)
+   * This includes source names, values, and percentages displayed as inline labels
+   */
+  async getSourceRankingContent(): Promise<string> {
+    const sourceRankingSection = this.page.locator('h3:has-text("Source Ranking")').locator('..').locator('..');
+
+    try {
+      await sourceRankingSection.waitFor({ state: 'visible', timeout: 2000 });
+      const content = await sourceRankingSection.textContent();
+      return content || '';
+    } catch {
+      return '';
+    }
+  }
+}

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1,9 +1,4 @@
 {
-  "e2e/page-objects/base-analytics-page.ts": {
-    "max-statements": {
-      "count": 1
-    }
-  },
   "src/components/ui/calendar.tsx": {
     "max-lines-per-function": {
       "count": 1


### PR DESCRIPTION
## Summary
Adds E2E test coverage for the Source Analysis page and enhances the base analytics page object to support pages with multiple charts. The chart hover functionality now works correctly for both single-chart and multi-chart pages, and tooltip detection handles different Recharts rendering patterns reliably.

## Technical Details
- Enhanced `hoverOverChartLabel()` with optional `chartTitle` parameter to target specific charts by h3 heading
- Implemented multi-strategy tooltip detection in `getTooltipContent()` (recharts-wrapper, backdrop-blur, slate-900)
- Created `SourceAnalysisPage` extending `BaseAnalyticsPage` with timeline chart auto-targeting
- Added `scrollIntoViewIfNeeded()` before hover operations for reliability
- Added `sourceAnalysisLink` locator to `AppPage` for sidebar navigation
- E2E test verifies page load, monthly filter switch, tooltip data, and Source Ranking bar chart content

## Context
Source Analysis has three charts (timeline, pie, bar) requiring targeted interactions. The existing single-chart hover logic could not distinguish between charts, and Recharts renders tooltips differently depending on chart type.