### PR TITLE
BUG: Fix tab navigation not highlighting active tab in production

### DIFF
--- a/src/features/navigation/tabs-navigation/tabs-navigation.tsx
+++ b/src/features/navigation/tabs-navigation/tabs-navigation.tsx
@@ -1,4 +1,4 @@
-import { Link, useLocation } from '@tanstack/react-router'
+import { Link, useRouterState } from '@tanstack/react-router'
 import { cn } from '@/shared/lib/utils'
 
 export interface TabConfig {
@@ -18,6 +18,16 @@ interface TabsNavigationProps {
 }
 
 /**
+ * Extract the route path from the current location, accounting for basepath.
+ * Uses router state which provides the href without basepath prefix.
+ */
+function useCurrentRoutePath(): string {
+  const routerState = useRouterState()
+  // location.href gives us the path as the router sees it (without basepath)
+  return routerState.location.href.split('?')[0].split('#')[0]
+}
+
+/**
  * Shared route-based tabs navigation component.
  * Renders a grid of Link components that navigate to different routes.
  */
@@ -28,8 +38,7 @@ export function TabsNavigation({
   columns = tabs.length,
   renderTabContent,
 }: TabsNavigationProps) {
-  const location = useLocation()
-  const currentPath = location.pathname
+  const currentPath = useCurrentRoutePath()
 
   // Determine grid columns class based on count
   const getGridColsClass = () => {


### PR DESCRIPTION
## Summary
Fixed a bug where tab navigation (Charts/Runs tabs on analytics pages) wasn't highlighting the active tab in production builds. The tabs worked correctly in development but failed in production because the path comparison included the `/TowerOfTracking/` basepath prefix on one side but not the other.

## Technical Details
- Changed from `useLocation().pathname` to `useRouterState().location.href` for current path detection
- Extracted path logic into `useCurrentRoutePath()` helper that strips query params and hash fragments
- The `location.href` from router state provides the path without basepath prefix, matching how `tab.route` values are defined
- Aligns with how sidebar navigation works (uses TanStack Router's built-in `activeProps` which handles basepath automatically)

## Context
The sidebar navigation worked correctly because it uses TanStack Router's `activeProps` feature which internally normalizes basepath. The tabs navigation was manually comparing paths without this normalization.