### PR TITLE
BUG: Fix React hydration mismatch in sidebar aria-hidden attribute

### DIFF
--- a/src/features/navigation/sidebar/sidebar.tsx
+++ b/src/features/navigation/sidebar/sidebar.tsx
@@ -4,14 +4,17 @@ import { useSidebarBehavior } from './use-sidebar-behavior'
 import { useSidebarToggleProps } from './use-sidebar-toggle'
 import { NavIcon } from '../top-navbar/nav-icon'
 import { NavLink, NavSection, NavCollapseButton } from '@/components/ui'
+import { useViewport } from '@/shared/hooks/use-viewport'
 
 export function Sidebar() {
   const { isSidebarOpen, closeSidebar, isCollapsed, toggleCollapsed } = useNavigation()
   const { sidebarRef, firstLinkRef } = useSidebarBehavior({ isSidebarOpen, closeSidebar })
-  const { getClickableAreaProps } = useSidebarToggleProps({ 
-    isCollapsed, 
-    onToggle: toggleCollapsed 
+  const { getClickableAreaProps } = useSidebarToggleProps({
+    isCollapsed,
+    onToggle: toggleCollapsed
   })
+  const viewport = useViewport()
+  const isMobile = viewport === 'mobile'
 
   return (
     <>
@@ -38,7 +41,7 @@ export function Sidebar() {
           ${isCollapsed ? 'w-16' : 'w-64'}
         `}
         aria-label="Navigation sidebar"
-        aria-hidden={!isSidebarOpen && typeof window !== 'undefined' && window.innerWidth < 768}
+        aria-hidden={!isSidebarOpen && isMobile}
         role="navigation"
       >
         {/* Enhanced navigation with improved spacing, visual hierarchy, and keyboard support */}


### PR DESCRIPTION
## Summary
Fixed a React hydration mismatch error (Error 418) in production where the sidebar's `aria-hidden` attribute had different values during server and client rendering. Mobile users experienced this when the server rendered `false` but the client evaluated `true` for viewports under 768px.

## Technical Details
- Replaced direct `window.innerWidth` check with the existing SSR-safe `useViewport` hook
- Added `viewport` state and derived `isMobile` value for cleaner conditional logic
- The hook defaults to 'desktop' on server and initial client render, then updates via useEffect
- This ensures server HTML matches initial client render, preventing hydration errors

## Context
The previous implementation checked `typeof window !== 'undefined' && window.innerWidth < 768`, which always evaluated to `false` on the server but could be `true` on mobile clients, causing the hydration mismatch.