### PR TITLE
Add tournament rank tracking for placement results

### DIFF
--- a/sampleData/supportedFields.json
+++ b/sampleData/supportedFields.json
@@ -3,6 +3,7 @@
     "_time",
     "_notes",
     "_runType",
+    "_rank",
     "battleDate",
     "coinsPerHour",
     "gameTime",

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -18,6 +18,7 @@ export * from "./nav-link";
 export * from "./nav-section";
 export * from "./popover";
 export * from "./responsive-dialog";
+export * from "./select";
 export * from "./selection-button-group";
 export * from "./textarea";
 export * from "./toggle-switch";

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,53 @@
+import * as React from "react"
+import { cn } from "../../shared/lib/utils"
+
+interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {
+  /** Width constraint for the select */
+  width?: 'auto' | 'full' | 'sm' | 'md' | 'lg'
+}
+
+const widthClasses = {
+  auto: 'w-auto',
+  full: 'w-full',
+  sm: 'w-24',
+  md: 'w-32',
+  lg: 'w-40'
+} as const
+
+/**
+ * Styled select component with consistent dark theme styling.
+ *
+ * Provides consistent appearance across the application for native
+ * HTML select elements with proper focus states and dark theme support.
+ */
+export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
+  ({ className, width = 'auto', children, ...props }, ref) => {
+    return (
+      <select
+        ref={ref}
+        className={cn(
+          // Base styles - min-h-[44px] matches Button component for consistent vertical alignment
+          "flex h-9 min-h-[44px] rounded-md border border-input bg-background px-3 py-1.5",
+          // Typography
+          "text-sm text-foreground",
+          // Focus and interaction states
+          "transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+          // Hover state
+          "hover:border-accent/50",
+          // Disabled state
+          "disabled:cursor-not-allowed disabled:opacity-50",
+          // Custom cursor
+          "cursor-pointer",
+          // Width
+          widthClasses[width],
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </select>
+    )
+  }
+)
+
+Select.displayName = "Select"

--- a/src/features/data-export/csv-export/csv-export-dialog-sections.tsx
+++ b/src/features/data-export/csv-export/csv-export-dialog-sections.tsx
@@ -1,4 +1,4 @@
-import { Input } from '@/components/ui';
+import { Input, Select } from '@/components/ui';
 import type { CsvDelimiter } from '@/features/data-import/csv-import/types';
 import type { CsvExportResult } from './csv-exporter';
 import { getExportStatsDisplay } from './csv-export-helpers';
@@ -24,16 +24,17 @@ export function ExportControls({
     <div className="flex items-center gap-4">
       <div className="flex items-center gap-2">
         <span className="text-sm text-muted-foreground">Delimiter:</span>
-        <select 
-          value={selectedDelimiter} 
+        <Select
+          value={selectedDelimiter}
           onChange={(e) => onDelimiterChange(e.target.value as CsvDelimiter)}
-          className="w-32 px-2 py-1 border rounded text-sm bg-background"
+          width="md"
+          aria-label="Select delimiter"
         >
           <option value="tab">Tab</option>
           <option value="comma">Comma</option>
           <option value="semicolon">Semicolon</option>
           <option value="custom">Custom</option>
-        </select>
+        </Select>
         {selectedDelimiter === 'custom' && (
           <Input
             placeholder="Enter delimiter"
@@ -50,9 +51,9 @@ export function ExportControls({
           id="includeAppFields"
           checked={includeAppFields}
           onChange={(e) => onIncludeAppFieldsChange(e.target.checked)}
-          className="w-4 h-4"
+          className="w-4 h-4 accent-accent cursor-pointer"
         />
-        <label htmlFor="includeAppFields" className="text-sm text-muted-foreground">
+        <label htmlFor="includeAppFields" className="text-sm text-muted-foreground cursor-pointer">
           Include Date/Time columns
         </label>
       </div>

--- a/src/features/data-export/csv-export/csv-exporter.ts
+++ b/src/features/data-export/csv-export/csv-exporter.ts
@@ -127,6 +127,8 @@ function detectDelimiterConflicts(
           value = run.fields[INTERNAL_FIELD_NAMES.NOTES]?.rawValue || '';
         } else if (fieldInfo.fieldName === INTERNAL_FIELD_NAMES.RUN_TYPE) {
           value = run.fields[INTERNAL_FIELD_NAMES.RUN_TYPE]?.rawValue || run.runType;
+        } else if (fieldInfo.fieldName === INTERNAL_FIELD_NAMES.RANK) {
+          value = run.fields[INTERNAL_FIELD_NAMES.RANK]?.rawValue || '';
         }
       } else {
         // Handle regular game fields (including battle_date)
@@ -215,6 +217,8 @@ export function exportToCsv(
           rawValue = run.fields[INTERNAL_FIELD_NAMES.NOTES]?.rawValue || '';
         } else if (fieldInfo.fieldName === INTERNAL_FIELD_NAMES.RUN_TYPE) {
           rawValue = run.fields[INTERNAL_FIELD_NAMES.RUN_TYPE]?.rawValue || run.runType;
+        } else if (fieldInfo.fieldName === INTERNAL_FIELD_NAMES.RANK) {
+          rawValue = run.fields[INTERNAL_FIELD_NAMES.RANK]?.rawValue || '';
         }
       } else {
         // Handle regular game fields (including battle_date)

--- a/src/features/data-import/csv-import/delimiter/delimiter-controls.tsx
+++ b/src/features/data-import/csv-import/delimiter/delimiter-controls.tsx
@@ -1,4 +1,4 @@
-import { Input } from '@/components/ui';
+import { Input, Select } from '@/components/ui';
 import type { CsvDelimiter } from '../types';
 
 interface DelimiterControlsProps {
@@ -17,16 +17,17 @@ export function DelimiterControls({
   return (
     <div className="flex items-center gap-2">
       <span className="text-sm text-muted-foreground">Delimiter:</span>
-      <select
+      <Select
         value={selectedDelimiter}
         onChange={(e) => onDelimiterChange(e.target.value as CsvDelimiter)}
-        className="w-32 px-2 py-1 border rounded text-sm bg-background"
+        width="md"
+        aria-label="Select delimiter"
       >
         <option value="tab">Tab</option>
         <option value="comma">Comma</option>
         <option value="semicolon">Semicolon</option>
         <option value="custom">Custom</option>
-      </select>
+      </Select>
 
       {selectedDelimiter === 'custom' && (
         <Input

--- a/src/features/data-import/manual-entry/data-input.tsx
+++ b/src/features/data-import/manual-entry/data-input.tsx
@@ -11,6 +11,7 @@ import { RunTypeSelector } from '@/shared/domain/run-types/run-type-selector';
 import { RunTypeFilter } from '@/features/analysis/shared/filtering/run-type-filter';
 import { RunType } from '@/shared/domain/run-types/types';
 import { NotesField } from '@/shared/domain/fields/notes-field';
+import { RankSelector } from '@/shared/domain/fields/rank-selector';
 
 interface DataInputProps {
   className?: string;
@@ -79,11 +80,24 @@ const DataInputComponent = function DataInput({ className }: DataInputProps) {
                 disabledReason={form.hasBattleDate ? "Using game timestamp" : undefined}
               />
               
-              <RunTypeSelector
-                selectedType={form.selectedRunType as RunTypeFilter}
-                onTypeChange={(type) => form.setSelectedRunType(type === 'all' ? RunType.FARM : type)}
-                mode="selection"
-              />
+              {/* Run Type and Rank - same row */}
+              <div className="flex items-start gap-6">
+                <RunTypeSelector
+                  selectedType={form.selectedRunType as RunTypeFilter}
+                  onTypeChange={(type) => form.handleRunTypeChange(type === 'all' ? RunType.FARM : type)}
+                  mode="selection"
+                />
+
+                {/* Rank selector - only shown for tournament runs */}
+                {form.selectedRunType === RunType.TOURNAMENT && (
+                  <RankSelector
+                    value={form.rank}
+                    onChange={form.setRank}
+                    showOptionalHint
+                  />
+                )}
+              </div>
+
               <FormField>
                 <FormLabel required>
                   Game Stats Data

--- a/src/features/game-runs/card-view/run-details.tsx
+++ b/src/features/game-runs/card-view/run-details.tsx
@@ -6,8 +6,11 @@ import { useData } from '@/shared/domain/use-data';
 import {
   createUpdatedNotesFields,
   createUpdatedRunTypeFields,
+  createUpdatedRankFields,
   extractNotesValue,
   extractRunTypeValue,
+  extractRankValue,
+  type RankValue,
 } from '../editing/field-update-logic';
 
 interface RunDetailsProps {
@@ -56,7 +59,7 @@ const STAT_GROUPS = {
     "commonModules", "rareModules"
   ],
   "__SKIP__": [
-    "_date", "_time", "_runType", "_notes", "battleDate"
+    "_date", "_time", "_runType", "_notes", "_rank", "battleDate"
   ]
 };
 
@@ -125,7 +128,7 @@ function StatGroup({ title, fields, run }: {
 export function RunDetails({ run }: RunDetailsProps) {
   const { updateRun } = useData();
 
-  const handleUserFieldsUpdate = (newNotes: string, newRunType: RunTypeValue) => {
+  const handleUserFieldsUpdate = (newNotes: string, newRunType: RunTypeValue, newRank: RankValue) => {
     let updatedFields = { ...run.fields };
 
     // Apply notes update if changed
@@ -139,7 +142,13 @@ export function RunDetails({ run }: RunDetailsProps) {
       updatedFields = createUpdatedRunTypeFields(updatedFields, newRunType);
     }
 
-    // Single update with both changes
+    // Apply rank update if changed
+    const currentRank = extractRankValue(run.fields);
+    if (newRank !== currentRank) {
+      updatedFields = createUpdatedRankFields(updatedFields, newRank);
+    }
+
+    // Single update with all changes
     updateRun(run.id, {
       fields: updatedFields,
       runType: newRunType  // Update cached property
@@ -164,12 +173,14 @@ export function RunDetails({ run }: RunDetailsProps) {
 
   const notes = extractNotesValue(run.fields);
   const runType = extractRunTypeValue(run);
+  const rank = extractRankValue(run.fields);
 
   return (
     <div className="space-y-6">
       <EditableUserFields
         notes={notes}
         runType={runType}
+        rank={rank}
         onSave={handleUserFieldsUpdate}
       />
 

--- a/src/features/game-runs/editing/clickable-field-display.tsx
+++ b/src/features/game-runs/editing/clickable-field-display.tsx
@@ -1,0 +1,105 @@
+import { cn } from '@/shared/lib/utils';
+
+interface ClickableFieldDisplayProps {
+  /** Label shown on the left side */
+  label: string;
+  /** Click handler to start editing */
+  onClick: () => void;
+  /** Content to display on the right side */
+  children: React.ReactNode;
+  /** Additional className for the container */
+  className?: string;
+  /** Layout variant */
+  variant?: 'inline' | 'stacked';
+}
+
+/**
+ * Reusable clickable field display component for read-only views
+ * Used in EditableUserFields for Run Type, Rank, and Notes displays
+ * Provides consistent hover states and keyboard accessibility
+ */
+export function ClickableFieldDisplay({
+  label,
+  onClick,
+  children,
+  className,
+  variant = 'inline',
+}: ClickableFieldDisplayProps) {
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      onClick();
+    }
+  };
+
+  if (variant === 'stacked') {
+    return (
+      <div
+        className={cn(
+          'cursor-pointer p-3 rounded-md',
+          'hover:bg-accent/5 hover:border-accent/20 border border-transparent',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50',
+          'transition-colors',
+          className
+        )}
+        onClick={onClick}
+        onKeyDown={handleKeyDown}
+        role="button"
+        tabIndex={0}
+        aria-label={`Click to edit ${label.toLowerCase()}`}
+      >
+        <div className="mb-2">
+          <span className="font-mono text-sm text-muted-foreground">{label}</span>
+        </div>
+        {children}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        'flex items-center gap-3 p-2 rounded-md cursor-pointer',
+        'hover:bg-accent/5 hover:border-accent/20 border border-transparent',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50',
+        'transition-colors',
+        className
+      )}
+      onClick={onClick}
+      role="button"
+      tabIndex={0}
+      onKeyDown={handleKeyDown}
+      aria-label={`Click to edit ${label.toLowerCase()}`}
+    >
+      <span className="font-mono text-sm text-muted-foreground min-w-[80px]">
+        {label}
+      </span>
+      {children}
+    </div>
+  );
+}
+
+interface FieldValueProps {
+  children: React.ReactNode;
+  /** Display as accent color (for values) or muted (for empty states) */
+  variant?: 'value' | 'empty';
+}
+
+/**
+ * Styled field value display, used within ClickableFieldDisplay
+ */
+export function FieldValue({ children, variant = 'value' }: FieldValueProps) {
+  if (variant === 'empty') {
+    return (
+      <span className="text-muted-foreground/50 italic text-sm font-normal">
+        {children}
+      </span>
+    );
+  }
+
+  return (
+    <span className="font-mono text-sm text-accent font-medium">
+      {children}
+    </span>
+  );
+}

--- a/src/features/game-runs/editing/field-update-logic.test.ts
+++ b/src/features/game-runs/editing/field-update-logic.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Tests for notes and run type field update logic
+ * Rank field tests are in rank-field-logic.test.ts
+ */
 import { describe, it, expect } from 'vitest';
 import type { ParsedGameRun, GameRunField } from '@/shared/types/game-run.types';
 import {

--- a/src/features/game-runs/editing/field-update-logic.ts
+++ b/src/features/game-runs/editing/field-update-logic.ts
@@ -59,3 +59,54 @@ export function extractNotesValue(fields: Record<string, GameRunField>): string 
 export function extractRunTypeValue(run: ParsedGameRun): RunTypeValue {
   return (run.fields._runType?.value || run.runType) as RunTypeValue;
 }
+
+/**
+ * Tournament rank value type - number 1-30 or empty string for "not set"
+ */
+export type RankValue = number | '';
+
+/**
+ * Creates updated fields object with new rank value
+ * Empty string clears the rank field
+ */
+export function createUpdatedRankFields(
+  currentFields: Record<string, GameRunField>,
+  newRank: RankValue
+): Record<string, GameRunField> {
+  // If clearing the rank, remove the field entirely
+  if (newRank === '') {
+    const { _rank: _removed, ...fieldsWithoutRank } = currentFields;
+    void _removed; // Explicitly mark as intentionally unused
+    return fieldsWithoutRank;
+  }
+
+  const rankField = currentFields._rank || {
+    originalKey: '_rank',
+    dataType: 'string' as const,
+  };
+
+  const rankString = String(newRank);
+
+  return {
+    ...currentFields,
+    _rank: {
+      ...rankField,
+      value: rankString,
+      rawValue: rankString,
+      displayValue: rankString,
+    },
+  };
+}
+
+/**
+ * Extracts rank value from run fields
+ * Returns empty string if not set
+ */
+export function extractRankValue(fields: Record<string, GameRunField>): RankValue {
+  const rankField = fields._rank;
+  if (!rankField || !rankField.displayValue || rankField.displayValue.trim() === '') {
+    return '';
+  }
+  const parsed = parseInt(rankField.displayValue, 10);
+  return isNaN(parsed) ? '' : parsed;
+}

--- a/src/features/game-runs/editing/rank-field-logic.test.ts
+++ b/src/features/game-runs/editing/rank-field-logic.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect } from 'vitest';
+import type { GameRunField } from '@/shared/types/game-run.types';
+import { createUpdatedRankFields, extractRankValue } from './field-update-logic';
+
+describe('rank-field-logic', () => {
+  describe('createUpdatedRankFields', () => {
+    it('should update existing rank field with numeric value', () => {
+      const currentFields: Record<string, GameRunField> = {
+        _rank: {
+          value: '5',
+          rawValue: '5',
+          displayValue: '5',
+          originalKey: '_rank',
+          dataType: 'string',
+        },
+        tier: {
+          value: 11,
+          rawValue: '11',
+          displayValue: '11',
+          originalKey: 'Tier',
+          dataType: 'number',
+        },
+      };
+
+      const result = createUpdatedRankFields(currentFields, 3);
+
+      expect(result._rank).toEqual({
+        value: '3',
+        rawValue: '3',
+        displayValue: '3',
+        originalKey: '_rank',
+        dataType: 'string',
+      });
+      expect(result.tier).toEqual(currentFields.tier);
+    });
+
+    it('should create rank field if it does not exist', () => {
+      const currentFields: Record<string, GameRunField> = {
+        tier: {
+          value: 11,
+          rawValue: '11',
+          displayValue: '11',
+          originalKey: 'Tier',
+          dataType: 'number',
+        },
+      };
+
+      const result = createUpdatedRankFields(currentFields, 7);
+
+      expect(result._rank).toEqual({
+        value: '7',
+        rawValue: '7',
+        displayValue: '7',
+        originalKey: '_rank',
+        dataType: 'string',
+      });
+      expect(result.tier).toEqual(currentFields.tier);
+    });
+
+    it('should remove rank field when value is empty string', () => {
+      const currentFields: Record<string, GameRunField> = {
+        _rank: {
+          value: '5',
+          rawValue: '5',
+          displayValue: '5',
+          originalKey: '_rank',
+          dataType: 'string',
+        },
+        tier: {
+          value: 11,
+          rawValue: '11',
+          displayValue: '11',
+          originalKey: 'Tier',
+          dataType: 'number',
+        },
+      };
+
+      const result = createUpdatedRankFields(currentFields, '');
+
+      expect(result._rank).toBeUndefined();
+      expect(result.tier).toEqual(currentFields.tier);
+    });
+
+    it('should handle all valid rank values 1-30', () => {
+      const currentFields: Record<string, GameRunField> = {};
+
+      const result1 = createUpdatedRankFields(currentFields, 1);
+      expect(result1._rank?.value).toBe('1');
+
+      const result15 = createUpdatedRankFields(currentFields, 15);
+      expect(result15._rank?.value).toBe('15');
+
+      const result30 = createUpdatedRankFields(currentFields, 30);
+      expect(result30._rank?.value).toBe('30');
+    });
+  });
+
+  describe('extractRankValue', () => {
+    it('should extract rank number from fields', () => {
+      const fields: Record<string, GameRunField> = {
+        _rank: {
+          value: '5',
+          rawValue: '5',
+          displayValue: '5',
+          originalKey: '_rank',
+          dataType: 'string',
+        },
+      };
+
+      const result = extractRankValue(fields);
+
+      expect(result).toBe(5);
+    });
+
+    it('should return empty string when rank field does not exist', () => {
+      const fields: Record<string, GameRunField> = {};
+
+      const result = extractRankValue(fields);
+
+      expect(result).toBe('');
+    });
+
+    it('should return empty string when rank displayValue is empty', () => {
+      const fields: Record<string, GameRunField> = {
+        _rank: {
+          value: '',
+          rawValue: '',
+          displayValue: '',
+          originalKey: '_rank',
+          dataType: 'string',
+        },
+      };
+
+      const result = extractRankValue(fields);
+
+      expect(result).toBe('');
+    });
+
+    it('should return empty string when rank displayValue is whitespace only', () => {
+      const fields: Record<string, GameRunField> = {
+        _rank: {
+          value: '   ',
+          rawValue: '   ',
+          displayValue: '   ',
+          originalKey: '_rank',
+          dataType: 'string',
+        },
+      };
+
+      const result = extractRankValue(fields);
+
+      expect(result).toBe('');
+    });
+
+    it('should return empty string for invalid numeric values', () => {
+      const fields: Record<string, GameRunField> = {
+        _rank: {
+          value: 'not a number',
+          rawValue: 'not a number',
+          displayValue: 'not a number',
+          originalKey: '_rank',
+          dataType: 'string',
+        },
+      };
+
+      const result = extractRankValue(fields);
+
+      expect(result).toBe('');
+    });
+
+    it('should parse valid rank values correctly', () => {
+      const createRankField = (value: string): Record<string, GameRunField> => ({
+        _rank: {
+          value,
+          rawValue: value,
+          displayValue: value,
+          originalKey: '_rank',
+          dataType: 'string',
+        },
+      });
+
+      expect(extractRankValue(createRankField('1'))).toBe(1);
+      expect(extractRankValue(createRankField('15'))).toBe(15);
+      expect(extractRankValue(createRankField('30'))).toBe(30);
+    });
+  });
+});

--- a/src/features/game-runs/table-variants/tournament-table-columns.tsx
+++ b/src/features/game-runs/table-variants/tournament-table-columns.tsx
@@ -94,11 +94,10 @@ export function createTournamentTableColumns(removeRun: (id: string) => void): C
     }),
     columnHelper.display({
       id: 'placement',
-      header: 'Placement',
+      header: 'Rank',
       cell: ({ row }) => {
-        // Empty for now - future enhancement for tournament placement data
-        const placement = getFieldValue<string>(row.original, 'placement');
-        return placement || '-';
+        const rank = getFieldValue<string>(row.original, '_rank');
+        return rank || '-';
       },
     }),
     columnHelper.display({

--- a/src/shared/domain/fields/internal-field-config.test.ts
+++ b/src/shared/domain/fields/internal-field-config.test.ts
@@ -16,6 +16,7 @@ describe('INTERNAL_FIELD_NAMES', () => {
     expect(INTERNAL_FIELD_NAMES.TIME).toBe('_time');
     expect(INTERNAL_FIELD_NAMES.NOTES).toBe('_notes');
     expect(INTERNAL_FIELD_NAMES.RUN_TYPE).toBe('_runType');
+    expect(INTERNAL_FIELD_NAMES.RANK).toBe('_rank');
   });
 
   it('should be readonly at compile time', () => {
@@ -30,6 +31,7 @@ describe('INTERNAL_FIELD_MAPPINGS', () => {
     expect(INTERNAL_FIELD_MAPPINGS[INTERNAL_FIELD_NAMES.TIME]).toBe('_Time');
     expect(INTERNAL_FIELD_MAPPINGS[INTERNAL_FIELD_NAMES.NOTES]).toBe('_Notes');
     expect(INTERNAL_FIELD_MAPPINGS[INTERNAL_FIELD_NAMES.RUN_TYPE]).toBe('_Run Type');
+    expect(INTERNAL_FIELD_MAPPINGS[INTERNAL_FIELD_NAMES.RANK]).toBe('_Rank');
   });
 
   it('should have all internal fields mapped', () => {
@@ -41,11 +43,12 @@ describe('INTERNAL_FIELD_MAPPINGS', () => {
 
 describe('INTERNAL_FIELD_ORDER', () => {
   it('should define order for all internal fields', () => {
-    expect(INTERNAL_FIELD_ORDER).toHaveLength(4);
+    expect(INTERNAL_FIELD_ORDER).toHaveLength(5);
     expect(INTERNAL_FIELD_ORDER[0]).toBe(INTERNAL_FIELD_NAMES.DATE);
     expect(INTERNAL_FIELD_ORDER[1]).toBe(INTERNAL_FIELD_NAMES.TIME);
     expect(INTERNAL_FIELD_ORDER[2]).toBe(INTERNAL_FIELD_NAMES.NOTES);
     expect(INTERNAL_FIELD_ORDER[3]).toBe(INTERNAL_FIELD_NAMES.RUN_TYPE);
+    expect(INTERNAL_FIELD_ORDER[4]).toBe(INTERNAL_FIELD_NAMES.RANK);
   });
 
   it('should be readonly array', () => {
@@ -61,10 +64,16 @@ describe('LEGACY_FIELD_MIGRATIONS', () => {
     expect(LEGACY_FIELD_MIGRATIONS['notes']).toBe(INTERNAL_FIELD_NAMES.NOTES);
     expect(LEGACY_FIELD_MIGRATIONS['runType']).toBe(INTERNAL_FIELD_NAMES.RUN_TYPE);
     expect(LEGACY_FIELD_MIGRATIONS['run_type']).toBe(INTERNAL_FIELD_NAMES.RUN_TYPE);
+    expect(LEGACY_FIELD_MIGRATIONS['rank']).toBe(INTERNAL_FIELD_NAMES.RANK);
+    expect(LEGACY_FIELD_MIGRATIONS['placement']).toBe(INTERNAL_FIELD_NAMES.RANK);
   });
 
   it('should handle both camelCase and snake_case variants', () => {
     expect(LEGACY_FIELD_MIGRATIONS['runType']).toBe(LEGACY_FIELD_MIGRATIONS['run_type']);
+  });
+
+  it('should map both rank and placement to _rank', () => {
+    expect(LEGACY_FIELD_MIGRATIONS['rank']).toBe(LEGACY_FIELD_MIGRATIONS['placement']);
   });
 });
 
@@ -74,6 +83,7 @@ describe('isInternalField', () => {
     expect(isInternalField('_time')).toBe(true);
     expect(isInternalField('_notes')).toBe(true);
     expect(isInternalField('_runType')).toBe(true);
+    expect(isInternalField('_rank')).toBe(true);
   });
 
   it('should return false for non-internal fields', () => {
@@ -96,6 +106,8 @@ describe('isLegacyField', () => {
     expect(isLegacyField('notes')).toBe(true);
     expect(isLegacyField('runType')).toBe(true);
     expect(isLegacyField('run_type')).toBe(true);
+    expect(isLegacyField('rank')).toBe(true);
+    expect(isLegacyField('placement')).toBe(true);
   });
 
   it('should return false for non-legacy fields', () => {
@@ -124,11 +136,12 @@ describe('getInternalFieldNamesSet', () => {
   it('should return set of all internal field names', () => {
     const set = getInternalFieldNamesSet();
     expect(set).toBeInstanceOf(Set);
-    expect(set.size).toBe(4);
+    expect(set.size).toBe(5);
     expect(set.has('_date')).toBe(true);
     expect(set.has('_time')).toBe(true);
     expect(set.has('_notes')).toBe(true);
     expect(set.has('_runType')).toBe(true);
+    expect(set.has('_rank')).toBe(true);
   });
 
   it('should allow O(1) lookup', () => {

--- a/src/shared/domain/fields/internal-field-config.ts
+++ b/src/shared/domain/fields/internal-field-config.ts
@@ -19,7 +19,8 @@ export const INTERNAL_FIELD_NAMES = {
   DATE: '_date',
   TIME: '_time',
   NOTES: '_notes',
-  RUN_TYPE: '_runType'
+  RUN_TYPE: '_runType',
+  RANK: '_rank'
 } as const;
 
 /**
@@ -36,7 +37,8 @@ export const INTERNAL_FIELD_MAPPINGS: Record<InternalFieldName, string> = {
   [INTERNAL_FIELD_NAMES.DATE]: '_Date',
   [INTERNAL_FIELD_NAMES.TIME]: '_Time',
   [INTERNAL_FIELD_NAMES.NOTES]: '_Notes',
-  [INTERNAL_FIELD_NAMES.RUN_TYPE]: '_Run Type'
+  [INTERNAL_FIELD_NAMES.RUN_TYPE]: '_Run Type',
+  [INTERNAL_FIELD_NAMES.RANK]: '_Rank'
 };
 
 /**
@@ -47,7 +49,8 @@ export const INTERNAL_FIELD_ORDER: readonly InternalFieldName[] = [
   INTERNAL_FIELD_NAMES.DATE,
   INTERNAL_FIELD_NAMES.TIME,
   INTERNAL_FIELD_NAMES.NOTES,
-  INTERNAL_FIELD_NAMES.RUN_TYPE
+  INTERNAL_FIELD_NAMES.RUN_TYPE,
+  INTERNAL_FIELD_NAMES.RANK
 ] as const;
 
 /**
@@ -59,7 +62,9 @@ export const LEGACY_FIELD_MIGRATIONS: Record<string, InternalFieldName> = {
   'time': INTERNAL_FIELD_NAMES.TIME,
   'notes': INTERNAL_FIELD_NAMES.NOTES,
   'runType': INTERNAL_FIELD_NAMES.RUN_TYPE,
-  'run_type': INTERNAL_FIELD_NAMES.RUN_TYPE
+  'run_type': INTERNAL_FIELD_NAMES.RUN_TYPE,
+  'rank': INTERNAL_FIELD_NAMES.RANK,
+  'placement': INTERNAL_FIELD_NAMES.RANK
 };
 
 /**

--- a/src/shared/domain/fields/rank-selector.tsx
+++ b/src/shared/domain/fields/rank-selector.tsx
@@ -1,0 +1,88 @@
+import { FormControl, Select } from '@/components/ui';
+import * as Tooltip from '@radix-ui/react-tooltip';
+import { TooltipContentWrapper } from '@/components/ui/tooltip-content';
+import { HelpCircle } from 'lucide-react';
+import type { RankValue } from '@/features/game-runs/editing/field-update-logic';
+
+interface RankSelectorProps {
+  value: RankValue;
+  onChange: (value: RankValue) => void;
+  className?: string;
+  /** When true, shows "(optional)" hint */
+  showOptionalHint?: boolean;
+}
+
+const RANK_OPTIONS = Array.from({ length: 30 }, (_, i) => i + 1);
+
+/**
+ * Dropdown selector for tournament placement rank (1-30)
+ * Includes tooltip explaining where to find historical rank data in the game
+ */
+export function RankSelector({
+  value,
+  onChange,
+  className,
+  showOptionalHint = false,
+}: RankSelectorProps) {
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const selectedValue = e.target.value;
+    if (selectedValue === '') {
+      onChange('');
+    } else {
+      onChange(parseInt(selectedValue, 10));
+    }
+  };
+
+  return (
+    <Tooltip.Provider delayDuration={400}>
+      <FormControl label="Rank" className={className}>
+        <div className="flex items-center gap-2">
+          <Select
+            value={value === '' ? '' : String(value)}
+            onChange={handleChange}
+            width="lg"
+            aria-label="Select tournament rank"
+          >
+            <option value="">Select rank...</option>
+            {RANK_OPTIONS.map((rank) => (
+              <option key={rank} value={rank}>
+                {rank}
+              </option>
+            ))}
+          </Select>
+
+          {showOptionalHint && (
+            <span className="text-xs text-muted-foreground/70 whitespace-nowrap">
+              (optional)
+            </span>
+          )}
+
+          <Tooltip.Root>
+            <Tooltip.Trigger asChild>
+              <button
+                type="button"
+                className="p-1 rounded text-muted-foreground/60 hover:text-muted-foreground hover:bg-accent/10 transition-colors"
+                aria-label="Where to find rank"
+              >
+                <HelpCircle className="h-4 w-4" />
+              </button>
+            </Tooltip.Trigger>
+            <Tooltip.Portal>
+              <Tooltip.Content side="top" sideOffset={8} className="z-50">
+                <TooltipContentWrapper>
+                  <p className="text-sm font-medium text-slate-100">
+                    Where to find your rank:
+                  </p>
+                  <p className="text-sm mt-1.5 text-slate-300">
+                    In The Tower, go to Tournament → Tournament History to view your past placements.
+                  </p>
+                </TooltipContentWrapper>
+                <Tooltip.Arrow className="fill-slate-950" />
+              </Tooltip.Content>
+            </Tooltip.Portal>
+          </Tooltip.Root>
+        </div>
+      </FormControl>
+    </Tooltip.Provider>
+  );
+}


### PR DESCRIPTION
## Summary
Tournament players can now record their placement rank (1-30) after completing a tournament. Since tournament results have a 4-5 hour delay before prizes are awarded, users need to return later to update their rank when it becomes available. The rank field appears conditionally only for tournament-type runs, both when adding new runs and when editing existing ones.

## Technical Details
- Added `RankSelector` component with 1-30 dropdown and tooltip explaining where to find rank in-game
- Created `Select` UI component for consistent styled dropdowns across the app
- Added `ClickableFieldDisplay` component to reduce duplication in editable fields
- Integrated rank field into `EditableUserFields` with conditional visibility for tournament runs
- Added rank to `useDataInputForm` hook with automatic clearing when switching away from tournament type
- Extended `INTERNAL_FIELD_NAMES` and field config with `_rank` field and legacy migrations
- Updated CSV exporter to include rank field in exports
- Changed tournament table "Placement" column to display rank from `_rank` field
- Added comprehensive unit tests for rank field logic (`createUpdatedRankFields`, `extractRankValue`)