### PR TITLE
BUG: Fix tab navigation basepath handling in production

### DIFF
--- a/src/features/navigation/tabs-navigation/tabs-navigation.tsx
+++ b/src/features/navigation/tabs-navigation/tabs-navigation.tsx
@@ -1,4 +1,4 @@
-import { Link, useRouterState } from '@tanstack/react-router'
+import { Link, useMatchRoute } from '@tanstack/react-router'
 import { cn } from '@/shared/lib/utils'
 
 export interface TabConfig {
@@ -18,16 +18,6 @@ interface TabsNavigationProps {
 }
 
 /**
- * Extract the route path from the current location, accounting for basepath.
- * Uses router state which provides the href without basepath prefix.
- */
-function useCurrentRoutePath(): string {
-  const routerState = useRouterState()
-  // location.href gives us the path as the router sees it (without basepath)
-  return routerState.location.href.split('?')[0].split('#')[0]
-}
-
-/**
  * Shared route-based tabs navigation component.
  * Renders a grid of Link components that navigate to different routes.
  */
@@ -38,7 +28,8 @@ export function TabsNavigation({
   columns = tabs.length,
   renderTabContent,
 }: TabsNavigationProps) {
-  const currentPath = useCurrentRoutePath()
+  // useMatchRoute handles basepath automatically, matching how Link's activeProps works
+  const matchRoute = useMatchRoute()
 
   // Determine grid columns class based on count
   const getGridColsClass = () => {
@@ -66,7 +57,7 @@ export function TabsNavigation({
         aria-label={ariaLabel}
       >
         {tabs.map((tab) => {
-          const isActive = currentPath === tab.route
+          const isActive = !!matchRoute({ to: tab.route })
 
           return (
             <Link


### PR DESCRIPTION
## Summary
Fixes tab navigation not highlighting the active tab when deployed to GitHub Pages. The previous fix (commit cf7f0c5) incorrectly assumed that `useRouterState().location.href` returns paths without the basepath prefix, but in production with basepath `/TowerOfTracking/`, the path comparison failed silently.

## Technical Details
- Replaced custom `useCurrentRoutePath()` helper with TanStack Router's `useMatchRoute()` hook
- `useMatchRoute()` handles basepath normalization automatically, matching how `Link`'s `activeProps` works internally
- Simplified active state detection from string comparison to `!!matchRoute({ to: tab.route })`
- Removed 10 lines of unnecessary custom logic

## Context
This is a follow-up fix to #114. The root cause was that `location.href` in production includes the basepath (`/TowerOfTracking/runs`) while the tab routes are defined without it (`/runs`), causing the equality check to always fail.