### PR TITLE
BUG: Fix Add Game Run screen not defaulting to correct run type

### DIFF
--- a/src/shared/domain/run-types/use-run-type-context.test.tsx
+++ b/src/shared/domain/run-types/use-run-type-context.test.tsx
@@ -1,7 +1,6 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook } from '@testing-library/react'
 import { useRunTypeContext } from './use-run-type-context'
-import { RunTypeValue } from './types'
 import * as TanStackRouter from '@tanstack/react-router'
 
 // Mock TanStack Router hooks
@@ -9,155 +8,90 @@ vi.mock('@tanstack/react-router', async () => {
   const actual = await vi.importActual('@tanstack/react-router')
   return {
     ...actual,
-    useLocation: vi.fn(),
+    useMatchRoute: vi.fn(),
   }
 })
 
 describe('useRunTypeContext', () => {
-  const mockUseLocation = vi.mocked(TanStackRouter.useLocation)
+  const mockUseMatchRoute = TanStackRouter.useMatchRoute as ReturnType<typeof vi.fn>
 
-  it('should return "tournament" when on /runs page with type=tournament', () => {
-    mockUseLocation.mockReturnValue({
-      pathname: '/runs',
-      search: { type: 'tournament' },
-    } as ReturnType<typeof TanStackRouter.useLocation>)
+  // Helper to create a mock matchRoute function that matches specific routes
+  function createMatchRouteMock(activeRoute: string | null) {
+    return () => (opts: { to: string }) => {
+      return activeRoute === opts.to ? {} : false
+    }
+  }
 
-    const { result } = renderHook(() => useRunTypeContext())
-
-    expect(result.current).toBe('tournament')
+  beforeEach(() => {
+    vi.clearAllMocks()
   })
 
-  it('should return "milestone" when on /runs page with type=milestone', () => {
-    mockUseLocation.mockReturnValue({
-      pathname: '/runs',
-      search: { type: 'milestone' },
-    } as ReturnType<typeof TanStackRouter.useLocation>)
+  describe('path-based routing', () => {
+    it('should return "farm" when on /runs/farm route', () => {
+      mockUseMatchRoute.mockImplementation(createMatchRouteMock('/runs/farm'))
 
-    const { result } = renderHook(() => useRunTypeContext())
+      const { result } = renderHook(() => useRunTypeContext())
 
-    expect(result.current).toBe('milestone')
-  })
+      expect(result.current).toBe('farm')
+    })
 
-  it('should return RunType.FARM when on /runs page with type=farm', () => {
-    mockUseLocation.mockReturnValue({
-      pathname: '/runs',
-      search: { type: 'farm' },
-    } as ReturnType<typeof TanStackRouter.useLocation>)
-
-    const { result } = renderHook(() => useRunTypeContext())
-
-    expect(result.current).toBe('farm')
-  })
-
-  it('should return "farm" when on /runs page without type parameter', () => {
-    mockUseLocation.mockReturnValue({
-      pathname: '/runs',
-      search: {},
-    } as ReturnType<typeof TanStackRouter.useLocation>)
-
-    const { result } = renderHook(() => useRunTypeContext())
-
-    expect(result.current).toBe('farm')
-  })
-
-  it('should return "farm" when on /runs page with invalid type parameter', () => {
-    mockUseLocation.mockReturnValue({
-      pathname: '/runs',
-      search: { type: 'invalid' as unknown as RunTypeValue },
-    } as ReturnType<typeof TanStackRouter.useLocation>)
-
-    const { result } = renderHook(() => useRunTypeContext())
-
-    expect(result.current).toBe('farm')
-  })
-
-  it('should return "farm" when not on /runs page', () => {
-    mockUseLocation.mockReturnValue({
-      pathname: '/dashboard',
-      search: {},
-    } as ReturnType<typeof TanStackRouter.useLocation>)
-
-    const { result } = renderHook(() => useRunTypeContext())
-
-    expect(result.current).toBe('farm')
-  })
-
-  it('should return "farm" when on home page', () => {
-    mockUseLocation.mockReturnValue({
-      pathname: '/',
-      search: {},
-    } as ReturnType<typeof TanStackRouter.useLocation>)
-
-    const { result } = renderHook(() => useRunTypeContext())
-
-    expect(result.current).toBe('farm')
-  })
-
-  it('should ignore type parameter when not on /runs page', () => {
-    mockUseLocation.mockReturnValue({
-      pathname: '/dashboard',
-      search: { type: 'tournament' },
-    } as ReturnType<typeof TanStackRouter.useLocation>)
-
-    const { result } = renderHook(() => useRunTypeContext())
-
-    expect(result.current).toBe('farm')
-  })
-
-  describe('production environment (with base path)', () => {
-    it('should return "tournament" when on /TowerOfTracking/runs page with type=tournament', () => {
-      mockUseLocation.mockReturnValue({
-        pathname: '/TowerOfTracking/runs',
-        search: { type: 'tournament' },
-      } as ReturnType<typeof TanStackRouter.useLocation>)
+    it('should return "tournament" when on /runs/tournament route', () => {
+      mockUseMatchRoute.mockImplementation(createMatchRouteMock('/runs/tournament'))
 
       const { result } = renderHook(() => useRunTypeContext())
 
       expect(result.current).toBe('tournament')
     })
 
-    it('should return "milestone" when on /TowerOfTracking/runs page with type=milestone', () => {
-      mockUseLocation.mockReturnValue({
-        pathname: '/TowerOfTracking/runs',
-        search: { type: 'milestone' },
-      } as ReturnType<typeof TanStackRouter.useLocation>)
+    it('should return "milestone" when on /runs/milestone route', () => {
+      mockUseMatchRoute.mockImplementation(createMatchRouteMock('/runs/milestone'))
 
       const { result } = renderHook(() => useRunTypeContext())
 
       expect(result.current).toBe('milestone')
     })
+  })
 
-    it('should return "farm" when on /TowerOfTracking/runs page with type=farm', () => {
-      mockUseLocation.mockReturnValue({
-        pathname: '/TowerOfTracking/runs',
-        search: { type: 'farm' },
-      } as ReturnType<typeof TanStackRouter.useLocation>)
-
-      const { result } = renderHook(() => useRunTypeContext())
-
-      expect(result.current).toBe('farm')
-    })
-
-    it('should return "farm" when on /TowerOfTracking/runs page without type parameter', () => {
-      mockUseLocation.mockReturnValue({
-        pathname: '/TowerOfTracking/runs',
-        search: {},
-      } as ReturnType<typeof TanStackRouter.useLocation>)
+  describe('non-runs routes default to farm', () => {
+    it('should return "farm" when on charts route', () => {
+      mockUseMatchRoute.mockImplementation(createMatchRouteMock('/charts/coins'))
 
       const { result } = renderHook(() => useRunTypeContext())
 
       expect(result.current).toBe('farm')
     })
 
-    it('should ignore type parameter when on /TowerOfTracking/dashboard', () => {
-      mockUseLocation.mockReturnValue({
-        pathname: '/TowerOfTracking/dashboard',
-        search: { type: 'tournament' },
-      } as ReturnType<typeof TanStackRouter.useLocation>)
+    it('should return "farm" when on home page', () => {
+      mockUseMatchRoute.mockImplementation(createMatchRouteMock('/'))
 
       const { result } = renderHook(() => useRunTypeContext())
 
       expect(result.current).toBe('farm')
+    })
+
+    it('should return "farm" when no route matches', () => {
+      mockUseMatchRoute.mockImplementation(createMatchRouteMock(null))
+
+      const { result } = renderHook(() => useRunTypeContext())
+
+      expect(result.current).toBe('farm')
+    })
+  })
+
+  describe('useMatchRoute handles basepath automatically', () => {
+    // Note: useMatchRoute from TanStack Router automatically handles basepath
+    // (e.g., /TowerOfTracking/runs/tournament in production).
+    // We don't need separate tests for basepath since the router normalizes routes internally.
+    // The mock tests above verify the hook correctly uses the matchRoute function.
+
+    it('should match routes correctly regardless of basepath (handled by router)', () => {
+      // When the router is configured with basepath, matchRoute({ to: '/runs/tournament' })
+      // will match both /runs/tournament (local) and /TowerOfTracking/runs/tournament (production)
+      mockUseMatchRoute.mockImplementation(createMatchRouteMock('/runs/tournament'))
+
+      const { result } = renderHook(() => useRunTypeContext())
+
+      expect(result.current).toBe('tournament')
     })
   })
 })

--- a/src/shared/domain/run-types/use-run-type-context.ts
+++ b/src/shared/domain/run-types/use-run-type-context.ts
@@ -1,27 +1,22 @@
-import { useLocation } from '@tanstack/react-router'
-import { mapUrlTypeToRunType } from '../run-types/run-type-defaults'
+import { useMatchRoute } from '@tanstack/react-router'
+import { RUNS_TABS } from '@/features/navigation/runs-navigation/runs-tabs-config'
 import { RunType, RunTypeValue } from './types'
 
-interface RunsSearchParams {
-  type?: RunTypeValue
-}
-
 /**
- * Hook to determine the default run type based on current URL context
- * Reads the type parameter from /runs route if available, otherwise defaults to RunType.FARM
+ * Hook to determine the default run type based on current URL context.
+ * Uses useMatchRoute() to detect which runs route is active (handles basepath automatically).
+ * Returns the matching run type, or defaults to RunType.FARM.
  */
 export function useRunTypeContext(): RunTypeValue {
-  const location = useLocation()
+  const matchRoute = useMatchRoute()
 
-  // Check if we're on the runs page and extract type parameter
-  // Use endsWith to support both local (/runs) and production (/TowerOfTracking/runs) paths
-  const isRunsPage = location.pathname.endsWith('/runs')
-
-  if (isRunsPage) {
-    const searchParams = location.search as RunsSearchParams
-    return mapUrlTypeToRunType(searchParams.type)
+  // Check each runs tab route to find the active one
+  for (const tab of RUNS_TABS) {
+    if (matchRoute({ to: tab.route })) {
+      return tab.runType
+    }
   }
 
-  // Default to farm for all other pages
+  // Default to farm for all other pages (including non-runs routes)
   return RunType.FARM
 }


### PR DESCRIPTION
## Summary
Fixed a bug where the "Add Game Run" dialog was always defaulting to "farm" run type regardless of which tab the user was on. When viewing tournament or milestone runs and clicking to add a new run, the form should now correctly default to the matching run type.

This regression occurred after migrating from query parameter-based routing (`/runs?type=tournament`) to path-based routing (`/runs/tournament`). The hook responsible for detecting the current context was still looking for query parameters that no longer exist.

## Technical Details
- Replaced `useLocation()` with `useMatchRoute()` from TanStack Router
- Leveraged existing `RUNS_TABS` configuration to iterate over known routes
- `useMatchRoute()` automatically handles basepath differences between local dev and production environments
- Simplified tests from 155 lines to 90 lines by removing redundant basepath-specific test cases
- Removed now-unused `mapUrlTypeToRunType()` import

## Context
The route migration in commit 98d4dfc converted analytics and runs pages to path-based navigation but did not update this context-detection hook.