### PR TITLE
BUG: Fix Source Analysis page sorting for sources with equal percentages

### DIFF
--- a/src/features/analysis/source-analysis/calculations/period-grouping.ts
+++ b/src/features/analysis/source-analysis/calculations/period-grouping.ts
@@ -19,6 +19,7 @@ import type {
 import {
   extractFieldValue,
   calculatePercentage,
+  sortSourceSummaryByPercentage,
 } from './source-extraction';
 import {
   getPeriodKey,
@@ -121,10 +122,10 @@ export function calculateSummary(
     percentage: calculatePercentage(sourceTotals.get(source.fieldName) || 0, grandTotal)
   }));
 
-  // Sort by percentage descending and filter non-zero
-  const sortedSources = sources
-    .filter(s => s.totalValue > 0)
-    .sort((a, b) => b.percentage - a.percentage);
+  // Sort by percentage descending (with totalValue tiebreaker) and filter non-zero
+  const sortedSources = sortSourceSummaryByPercentage(
+    sources.filter(s => s.totalValue > 0)
+  );
 
   return {
     totalValue: grandTotal,

--- a/src/features/analysis/source-analysis/calculations/sorting-functions.test.ts
+++ b/src/features/analysis/source-analysis/calculations/sorting-functions.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for Source Sorting Functions
+ *
+ * Tests for sortSourceSummaryByPercentage and sortSourcesByValue functions
+ * which provide stable sorting for source analysis data.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  sortSourceSummaryByPercentage,
+  sortSourcesByValue,
+} from './source-extraction';
+
+describe('sortSourceSummaryByPercentage', () => {
+  it('sorts by percentage descending', () => {
+    const sources = [
+      { fieldName: 'a', displayName: 'A', color: '#000', totalValue: 100, percentage: 10 },
+      { fieldName: 'b', displayName: 'B', color: '#000', totalValue: 500, percentage: 50 },
+      { fieldName: 'c', displayName: 'C', color: '#000', totalValue: 200, percentage: 20 },
+    ];
+
+    const sorted = sortSourceSummaryByPercentage(sources);
+
+    expect(sorted.map(s => s.fieldName)).toEqual(['b', 'c', 'a']);
+  });
+
+  it('uses totalValue as tiebreaker when percentages are equal', () => {
+    const sources = [
+      { fieldName: 'a', displayName: 'A', color: '#000', totalValue: 1e21, percentage: 0 },  // 1 sextillion
+      { fieldName: 'b', displayName: 'B', color: '#000', totalValue: 1e24, percentage: 0 },  // 1 septillion (larger)
+      { fieldName: 'c', displayName: 'C', color: '#000', totalValue: 1e18, percentage: 0 },  // 1 quintillion
+    ];
+
+    const sorted = sortSourceSummaryByPercentage(sources);
+
+    // Should be sorted by totalValue descending: b (1e24), a (1e21), c (1e18)
+    expect(sorted.map(s => s.fieldName)).toEqual(['b', 'a', 'c']);
+    expect(sorted.map(s => s.totalValue)).toEqual([1e24, 1e21, 1e18]);
+  });
+
+  it('handles mix of equal and different percentages', () => {
+    const sources = [
+      { fieldName: 'a', displayName: 'A', color: '#000', totalValue: 100, percentage: 0 },
+      { fieldName: 'b', displayName: 'B', color: '#000', totalValue: 500, percentage: 5 },
+      { fieldName: 'c', displayName: 'C', color: '#000', totalValue: 200, percentage: 0 },
+      { fieldName: 'd', displayName: 'D', color: '#000', totalValue: 300, percentage: 5 },
+    ];
+
+    const sorted = sortSourceSummaryByPercentage(sources);
+
+    // 5% items first (b=500 before d=300), then 0% items (c=200 before a=100)
+    expect(sorted.map(s => s.fieldName)).toEqual(['b', 'd', 'c', 'a']);
+    expect(sorted.map(s => s.totalValue)).toEqual([500, 300, 200, 100]);
+  });
+
+  it('does not mutate original array', () => {
+    const sources = [
+      { fieldName: 'a', displayName: 'A', color: '#000', totalValue: 100, percentage: 10 },
+      { fieldName: 'b', displayName: 'B', color: '#000', totalValue: 500, percentage: 50 },
+    ];
+
+    sortSourceSummaryByPercentage(sources);
+
+    expect(sources[0].fieldName).toBe('a');
+  });
+
+  it('handles empty array', () => {
+    const sorted = sortSourceSummaryByPercentage([]);
+    expect(sorted).toEqual([]);
+  });
+});
+
+describe('sortSourcesByValue', () => {
+  it('sorts by value descending', () => {
+    const sources = [
+      { fieldName: 'a', displayName: 'A', color: '#000', value: 10, percentage: 10 },
+      { fieldName: 'b', displayName: 'B', color: '#000', value: 50, percentage: 50 },
+      { fieldName: 'c', displayName: 'C', color: '#000', value: 30, percentage: 30 },
+    ];
+
+    const sorted = sortSourcesByValue(sources);
+
+    expect(sorted.map(s => s.fieldName)).toEqual(['b', 'c', 'a']);
+  });
+
+  it('correctly sorts large numbers with different scales', () => {
+    const sources = [
+      { fieldName: 'a', displayName: 'A', color: '#000', value: 5.5e21, percentage: 0 },  // 5.5 sextillion
+      { fieldName: 'b', displayName: 'B', color: '#000', value: 35.3e24, percentage: 0 }, // 35.3 septillion (largest)
+      { fieldName: 'c', displayName: 'C', color: '#000', value: 460.1e24, percentage: 0 }, // 460.1 septillion (even larger)
+    ];
+
+    const sorted = sortSourcesByValue(sources);
+
+    // c (460.1S) > b (35.3S) > a (5.5s)
+    expect(sorted.map(s => s.fieldName)).toEqual(['c', 'b', 'a']);
+  });
+
+  it('does not mutate original array', () => {
+    const sources = [
+      { fieldName: 'a', displayName: 'A', color: '#000', value: 10, percentage: 10 },
+      { fieldName: 'b', displayName: 'B', color: '#000', value: 50, percentage: 50 },
+    ];
+
+    sortSourcesByValue(sources);
+
+    expect(sources[0].fieldName).toBe('a');
+  });
+
+  it('handles empty array', () => {
+    const sorted = sortSourcesByValue([]);
+    expect(sorted).toEqual([]);
+  });
+});

--- a/src/features/analysis/source-analysis/calculations/source-extraction.ts
+++ b/src/features/analysis/source-analysis/calculations/source-extraction.ts
@@ -5,7 +5,7 @@
  */
 
 import type { ParsedGameRun } from '@/shared/types/game-run.types';
-import type { CategoryDefinition, SourceFieldDefinition, SourceValue } from '../types';
+import type { CategoryDefinition, SourceFieldDefinition, SourceValue, SourceSummaryValue } from '../types';
 import { FIELD_ALIASES } from '../category-config';
 
 /**
@@ -119,6 +119,30 @@ export function sortByPercentageDescending<T extends { percentage: number }>(
   items: T[]
 ): T[] {
   return [...items].sort((a, b) => b.percentage - a.percentage);
+}
+
+/**
+ * Sort summary sources by percentage descending, with totalValue as tiebreaker.
+ * Ensures stable ordering when percentages are equal (e.g., when many sources
+ * round to 0.0% because one source dominates).
+ */
+export function sortSourceSummaryByPercentage(
+  sources: SourceSummaryValue[]
+): SourceSummaryValue[] {
+  return [...sources].sort((a, b) => {
+    const percentDiff = b.percentage - a.percentage;
+    if (percentDiff !== 0) return percentDiff;
+    // When percentages are equal, sort by totalValue descending
+    return b.totalValue - a.totalValue;
+  });
+}
+
+/**
+ * Sort period sources by value descending.
+ * Uses actual numeric value (not percentage) for stable ordering in tooltips.
+ */
+export function sortSourcesByValue(sources: SourceValue[]): SourceValue[] {
+  return [...sources].sort((a, b) => b.value - a.value);
 }
 
 /**

--- a/src/features/analysis/source-analysis/charts/source-bar-chart.tsx
+++ b/src/features/analysis/source-analysis/charts/source-bar-chart.tsx
@@ -17,7 +17,7 @@ import {
   LabelList,
 } from 'recharts'
 import type { SourceSummaryValue } from '../types'
-import { sortByPercentageDescending } from '../calculations/source-extraction'
+import { sortSourceSummaryByPercentage } from '../calculations/source-extraction'
 import { getGradientConfig, type GradientConfig } from '../category-config'
 import { formatLargeNumber } from '@/shared/formatting/number-scale'
 
@@ -117,8 +117,9 @@ export function SourceBarChart({
   onSourceHover,
 }: SourceBarChartProps) {
   // Memoize sorted sources to prevent label re-renders on hover state changes
+  // Uses totalValue as tiebreaker when percentages are equal for stable ordering
   const sortedSources = useMemo(
-    () => sortByPercentageDescending(sources),
+    () => sortSourceSummaryByPercentage(sources),
     [sources]
   )
 


### PR DESCRIPTION
## Summary
Fixed sorting inconsistencies on the Source Analysis page where sources with identical percentages (particularly when rounding to 0.0%) appeared in arbitrary order. Also fixed the timeline tooltip which was missing some sources. Now sources like `35.3S` (septillion) correctly appear above `5.5s` (sextillion) even when both round to 0.0%.

## Technical Details
- Added `sortSourceSummaryByPercentage()` - sorts by percentage with totalValue as tiebreaker for stable ordering
- Added `sortSourcesByValue()` - sorts by actual numeric value for tooltip display
- Updated `calculateSummary()` in period-grouping.ts to use new sorting function
- Updated bar chart to use percentage+totalValue sorting
- Rewrote timeline tooltip to use `period.sources` directly instead of Recharts payload (which only included stacked area entries)
- Added comprehensive unit tests for both new sorting functions

## Context
This bug affected Farm and Milestone run types where one source dominates (99%+), causing other sources to all round to 0.0% and sort arbitrarily. Tournament runs were unaffected due to more balanced distributions.