### PR TITLE
IMPROVE: Add locale-aware date/time formatting throughout application

### DIFF
--- a/src/features/analysis/source-analysis/calculations/period-formatting.ts
+++ b/src/features/analysis/source-analysis/calculations/period-formatting.ts
@@ -6,6 +6,11 @@
  */
 
 import type { SourceDuration } from '../types';
+import {
+  formatDisplayDate,
+  formatDisplayMonthDay,
+  formatDisplayMonth,
+} from '@/shared/formatting/date-formatters';
 
 /**
  * Get the period key for a timestamp based on duration
@@ -60,7 +65,7 @@ export function formatPeriodLabel(
       if (index !== undefined && totalRuns !== undefined) {
         return `Run #${totalRuns - index}`;
       }
-      return new Date(key).toLocaleDateString();
+      return formatDisplayDate(new Date(key));
     case 'daily':
       return formatDailyLabel(key);
     case 'weekly':
@@ -75,30 +80,32 @@ export function formatPeriodLabel(
 }
 
 /**
- * Format daily period key (YYYY-MM-DD) to display label (e.g., "Mar 15")
+ * Format daily period key (YYYY-MM-DD) to display label using user's locale
  */
 function formatDailyLabel(key: string): string {
   const [year, month, day] = key.split('-');
   const date = new Date(Number(year), Number(month) - 1, Number(day));
-  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  return formatDisplayMonthDay(date);
 }
 
 /**
- * Format weekly period key (YYYY-MM-DD) to display label (e.g., "Nov 17")
+ * Format weekly period key (YYYY-MM-DD) to display label using user's locale
  * Shows the Sunday date (start of the week).
  */
 function formatWeeklyLabel(key: string): string {
   // Key is now YYYY-MM-DD format (the Sunday date)
   const [year, month, day] = key.split('-');
   const date = new Date(Number(year), Number(month) - 1, Number(day));
-  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  return formatDisplayMonthDay(date);
 }
 
 /**
- * Format monthly period key (YYYY-MM) to display label (e.g., "Mar '24")
+ * Format monthly period key (YYYY-MM) to display label using user's locale
+ * Shows month abbreviation and 2-digit year (e.g., "Mar '24" or "März '24")
  */
 function formatMonthlyLabel(key: string): string {
   const [year, month] = key.split('-');
   const date = new Date(Number(year), Number(month) - 1);
-  return date.toLocaleDateString('en-US', { month: 'short', year: '2-digit' });
+  const yearSuffix = `'${year.slice(-2)}`;
+  return `${formatDisplayMonth(date)} ${yearSuffix}`;
 }

--- a/src/features/analysis/tier-stats/cells/tier-stats-cell-tooltip.tsx
+++ b/src/features/analysis/tier-stats/cells/tier-stats-cell-tooltip.tsx
@@ -1,7 +1,7 @@
-import { format } from 'date-fns'
 import type { CellTooltipData } from '../types'
 import { formatDuration } from '@/features/analysis/shared/parsing/data-parser'
 import { formatLargeNumber } from '@/shared/formatting/number-scale'
+import { formatDisplayShortDate, formatDisplayTime } from '@/shared/formatting/date-formatters'
 import { TooltipContentWrapper } from '@/components/ui/tooltip-content'
 
 interface TierStatsCellTooltipProps {
@@ -69,7 +69,7 @@ export function TierStatsCellTooltip({ data }: TierStatsCellTooltipProps) {
           <div className="flex justify-between items-center gap-4">
             <span className="text-xs text-slate-300">Date:</span>
             <span className="text-sm font-mono text-white font-medium">
-              {format(data.timestamp, 'MM/dd \'at\' h:mm a')}
+              {formatDisplayShortDate(data.timestamp)} at {formatDisplayTime(data.timestamp)}
             </span>
           </div>
         </div>

--- a/src/features/analysis/tier-trends/calculations/period-grouping.ts
+++ b/src/features/analysis/tier-trends/calculations/period-grouping.ts
@@ -1,6 +1,11 @@
 import type { ParsedGameRun, TierTrendsFilters } from '../types';
 import { TrendsDuration } from '../types';
 import { createEnhancedRunHeader } from './run-header-formatting';
+import {
+  formatDisplayShortDate,
+  formatWeekOfLabel,
+  formatDisplayMonth,
+} from '@/shared/formatting/date-formatters';
 
 /**
  * Represents data for a specific time period with associated runs
@@ -103,7 +108,7 @@ export function getPeriodBounds(
       return {
         startDate,
         endDate,
-        label: targetDate.toLocaleDateString('en-US', { month: 'numeric', day: 'numeric' })
+        label: formatDisplayShortDate(targetDate)
       };
     }
 
@@ -124,7 +129,7 @@ export function getPeriodBounds(
       return {
         startDate,
         endDate,
-        label: `Week of ${startDate.toLocaleDateString('en-US', { month: 'numeric', day: 'numeric' })}`
+        label: formatWeekOfLabel(startDate)
       };
     }
 
@@ -138,7 +143,7 @@ export function getPeriodBounds(
       return {
         startDate,
         endDate,
-        label: targetDate.toLocaleDateString('en-US', { month: 'short' })
+        label: formatDisplayMonth(targetDate)
       };
     }
 

--- a/src/features/analysis/tier-trends/calculations/run-header-formatting.ts
+++ b/src/features/analysis/tier-trends/calculations/run-header-formatting.ts
@@ -1,4 +1,5 @@
 import type { ParsedGameRun } from '@/shared/types/game-run.types'
+import { formatDisplayShortDateTime } from '@/shared/formatting/date-formatters'
 
 // ============================================================================
 // Main Header Creation Functions
@@ -59,19 +60,10 @@ export function formatDurationHoursMinutes(durationSeconds: number): string {
 
 /**
  * Formats a timestamp to a date/time string for display
- * Example: Date(2024-08-17T15:45:00Z) -> "8/17 3:45 PM"
+ * Uses user's locale setting for format (e.g., "8/17 3:45 PM" or "17/8 15:45")
  */
 export function formatTimestampDisplay(timestamp: Date): string {
-  const date = timestamp.toLocaleDateString('en-US', { 
-    month: 'numeric', 
-    day: 'numeric' 
-  })
-  const time = timestamp.toLocaleTimeString('en-US', { 
-    hour: 'numeric', 
-    minute: '2-digit',
-    hour12: true 
-  })
-  return `${date} ${time}`
+  return formatDisplayShortDateTime(timestamp)
 }
 
 /**

--- a/src/features/analysis/time-series/field-aggregation.ts
+++ b/src/features/analysis/time-series/field-aggregation.ts
@@ -3,6 +3,10 @@ import { ParsedGameRun } from '@/shared/types/game-run.types'
 import { ChartDataPoint } from '@/features/analysis/time-series/chart-types'
 import { extractFieldValue } from './field-extraction'
 import { groupRunsByDateKey } from './date-aggregation'
+import {
+  formatDisplayMonthDay,
+  formatDisplayMonth,
+} from '@/shared/formatting/date-formatters'
 
 /**
  * Field aggregation functions
@@ -20,7 +24,7 @@ export function prepareFieldPerRunData(
     .map(run => {
       const value = extractFieldValue(run, fieldKey)
       return {
-        date: format(run.timestamp, 'MMM dd'),
+        date: formatDisplayMonthDay(run.timestamp),
         value: value ?? 0,
         timestamp: run.timestamp,
       }
@@ -41,7 +45,7 @@ export function prepareFieldPerHourData(
       const value = extractFieldValue(run, fieldKey)
       const hourlyRate = ((value ?? 0) / run.realTime) * 3600
       return {
-        date: format(run.timestamp, 'MMM dd'),
+        date: formatDisplayMonthDay(run.timestamp),
         value: hourlyRate,
         timestamp: run.timestamp,
       }
@@ -71,7 +75,7 @@ export function prepareFieldPerDayData(
     const timestamp = startOfDay(dayRuns[0].timestamp)
 
     dailyData.push({
-      date: format(timestamp, 'MMM dd'),
+      date: formatDisplayMonthDay(timestamp),
       value: total,
       timestamp,
     })
@@ -102,7 +106,7 @@ export function prepareFieldPerWeekData(
     const timestamp = startOfWeek(weekRuns[0].timestamp, { weekStartsOn: 0 })
 
     weeklyData.push({
-      date: format(timestamp, 'MMM dd'),
+      date: formatDisplayMonthDay(timestamp),
       value: total,
       timestamp,
     })
@@ -133,7 +137,7 @@ export function prepareFieldPerMonthData(
     const timestamp = startOfMonth(monthRuns[0].timestamp)
 
     monthlyData.push({
-      date: format(timestamp, 'MMM yyyy'),
+      date: `${formatDisplayMonth(timestamp)} ${timestamp.getFullYear()}`,
       value: total,
       timestamp,
     })

--- a/src/features/data-import/manual-entry/data-input-datetime-section.tsx
+++ b/src/features/data-import/manual-entry/data-input-datetime-section.tsx
@@ -1,5 +1,5 @@
 import { Button, Calendar, Popover, PopoverContent, PopoverTrigger, Input, FormControl } from '@/components/ui';
-import { format } from 'date-fns';
+import { formatDisplayDate } from '@/shared/formatting/date-formatters';
 import { CalendarIcon, Clock } from 'lucide-react';
 
 interface DataInputDateTimeSectionProps {
@@ -37,7 +37,7 @@ export function DataInputDateTimeSection({
               disabled={disabled}
             >
               <CalendarIcon className="h-4 w-4 text-muted-foreground" />
-              <span className="text-foreground">{format(selectedDate, "MMM d, yyyy")}</span>
+              <span className="text-foreground">{formatDisplayDate(selectedDate)}</span>
             </Button>
           </PopoverTrigger>
           <PopoverContent className="w-auto p-0" align="start">

--- a/src/features/data-import/manual-entry/data-input-preview.tsx
+++ b/src/features/data-import/manual-entry/data-input-preview.tsx
@@ -1,7 +1,7 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui';
-import { format } from 'date-fns';
 import { formatNumber, formatDuration, calculatePerHour, formatTierLabel } from '@/features/analysis/shared/parsing/data-parser';
 import { getFieldValue, getFieldRaw } from '@/features/analysis/shared/parsing/field-utils';
+import { formatDisplayDateTime } from '@/shared/formatting/date-formatters';
 import { capitalizeFirst } from '../../../shared/formatting/string-formatters';
 import { ParsedGameRun } from '@/shared/types/game-run.types';
 import { RunType } from '@/shared/domain/run-types/types';
@@ -81,7 +81,7 @@ export function DataInputPreview({ previewData, selectedRunType }: DataInputPrev
               )}
               <div className="flex items-center gap-2 pt-1 border-t border-border/50">
                 <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground/70">Timestamp:</span>
-                <span className="text-foreground text-xs">{format(previewData.timestamp, "PPp")}</span>
+                <span className="text-foreground text-xs">{formatDisplayDateTime(previewData.timestamp)}</span>
               </div>
             </div>
           </div>

--- a/src/features/game-runs/card-view/run-card-utils.test.ts
+++ b/src/features/game-runs/card-view/run-card-utils.test.ts
@@ -28,6 +28,12 @@ vi.mock('@/features/analysis/shared/parsing/field-utils', () => ({
   },
 }));
 
+// Mock the date formatters to return predictable values
+vi.mock('@/shared/formatting/date-formatters', () => ({
+  formatDisplayDate: (date: Date) => `${date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}`,
+  formatDisplayTime: (date: Date) => date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' }),
+}));
+
 const createMockRun = (overrides: Partial<ParsedGameRun> = {}): ParsedGameRun => ({
   id: 'test-id',
   timestamp: new Date('2024-01-15T14:30:00Z'),
@@ -60,10 +66,11 @@ describe('extractCardHeaderData', () => {
   it('should format complete header data', () => {
     const run = createMockRun();
     const result = extractCardHeaderData(run);
-    
+
     expect(result.shortDuration).toBe('2h');
-    expect(result.dateStr).toBe(run.timestamp.toLocaleDateString());
-    expect(result.timeStr).toBe(run.timestamp.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }));
+    // Date and time are now formatted using locale-aware formatters from date-formatters.ts
+    expect(result.dateStr).toBe(run.timestamp.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }));
+    expect(result.timeStr).toBe(run.timestamp.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' }));
     expect(result.hasNotes).toBe(true);
   });
 
@@ -165,11 +172,12 @@ describe('extractRunCardData', () => {
   it('should combine all data extraction functions', () => {
     const run = createMockRun();
     const result = extractRunCardData(run);
-    
+
+    // Date and time are now formatted using locale-aware formatters from date-formatters.ts
     expect(result.header).toEqual({
       shortDuration: '2h',
-      dateStr: run.timestamp.toLocaleDateString(),
-      timeStr: run.timestamp.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+      dateStr: run.timestamp.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }),
+      timeStr: run.timestamp.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' }),
       hasNotes: true,
     });
     

--- a/src/features/game-runs/card-view/run-card-utils.ts
+++ b/src/features/game-runs/card-view/run-card-utils.ts
@@ -1,5 +1,6 @@
 import { formatNumber, formatDuration, calculatePerHour } from '@/features/analysis/shared/parsing/data-parser';
 import { getFieldValue } from '@/features/analysis/shared/parsing/field-utils';
+import { formatDisplayDate, formatDisplayTime } from '@/shared/formatting/date-formatters';
 import type { ParsedGameRun } from '@/shared/types/game-run.types';
 
 /**
@@ -7,8 +8,8 @@ import type { ParsedGameRun } from '@/shared/types/game-run.types';
  */
 export function extractCardHeaderData(run: ParsedGameRun) {
   const shortDuration = run.realTime ? formatDuration(run.realTime).replace(/(\d+)s?$/, '') : '-';
-  const dateStr = run.timestamp.toLocaleDateString();
-  const timeStr = run.timestamp.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  const dateStr = formatDisplayDate(run.timestamp);
+  const timeStr = formatDisplayTime(run.timestamp);
 
   return {
     shortDuration,

--- a/src/features/game-runs/table-variants/shared-column-definitions.tsx
+++ b/src/features/game-runs/table-variants/shared-column-definitions.tsx
@@ -5,6 +5,7 @@
 import { createColumnHelper, type ColumnDef } from '@tanstack/react-table';
 import { formatDuration } from '@/features/analysis/shared/parsing/data-parser';
 import { formatLargeNumber } from '@/shared/formatting/number-scale';
+import { formatDisplayNumericDate, formatDisplayTime } from '@/shared/formatting/date-formatters';
 import { getFieldValue } from '@/features/analysis/shared/parsing/field-utils';
 import type { ParsedGameRun } from '@/shared/types/game-run.types';
 import { StickyNote } from 'lucide-react';
@@ -71,11 +72,12 @@ export function createNotesColumn(): ColumnDef<ParsedGameRun> {
 
 /**
  * Creates the date column.
+ * Uses numeric-only format (11/30/2025 or 30/11/2025) respecting locale day/month order.
  */
 export function createDateColumn(): ColumnDef<ParsedGameRun> {
   return columnHelper.accessor('timestamp', {
     header: 'Date',
-    cell: (info) => info.getValue().toLocaleDateString(),
+    cell: (info) => formatDisplayNumericDate(info.getValue()),
     sortingFn: 'datetime',
     size: COLUMN_SIZES.date,
   }) as ColumnDef<ParsedGameRun>;
@@ -88,11 +90,7 @@ export function createTimeColumn(): ColumnDef<ParsedGameRun> {
   return columnHelper.accessor('timestamp', {
     id: 'time',
     header: 'Time',
-    cell: (info) =>
-      info.getValue().toLocaleTimeString([], {
-        hour: '2-digit',
-        minute: '2-digit',
-      }),
+    cell: (info) => formatDisplayTime(info.getValue()),
     size: COLUMN_SIZES.time,
   }) as ColumnDef<ParsedGameRun>;
 }

--- a/src/features/settings/locale-settings/locale-settings-content.tsx
+++ b/src/features/settings/locale-settings/locale-settings-content.tsx
@@ -11,6 +11,19 @@ import { Download, Globe } from 'lucide-react';
 import { useLocaleSettings } from './use-locale-settings';
 
 /**
+ * A single row in the locale preview definition list.
+ * Displays a label and formatted value with consistent styling.
+ */
+function PreviewRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex justify-between">
+      <dt className="text-muted-foreground">{label}:</dt>
+      <dd className="font-mono text-foreground">{value}</dd>
+    </div>
+  );
+}
+
+/**
  * Content component for the /settings/locale route.
  * Two-column layout separating import format (parsing) from display locale (rendering).
  */
@@ -48,7 +61,7 @@ export function LocaleSettingsContent() {
           {/* Decimal Separator */}
           <div className="space-y-3">
             <div className="space-y-1">
-              <h3 className="text-sm font-medium text-slate-200">
+              <h3 className="text-sm font-medium text-foreground">
                 Decimal Separator
               </h3>
               <p className="text-xs text-muted-foreground">
@@ -66,12 +79,12 @@ export function LocaleSettingsContent() {
             />
           </div>
 
-          <div className="border-t border-slate-700/50" />
+          <div className="border-t border-muted" />
 
           {/* Thousands Separator */}
           <div className="space-y-3">
             <div className="space-y-1">
-              <h3 className="text-sm font-medium text-slate-200">
+              <h3 className="text-sm font-medium text-foreground">
                 Thousands Separator
               </h3>
               <p className="text-xs text-muted-foreground">
@@ -89,12 +102,12 @@ export function LocaleSettingsContent() {
             />
           </div>
 
-          <div className="border-t border-slate-700/50" />
+          <div className="border-t border-muted" />
 
           {/* Date Format */}
           <div className="space-y-3">
             <div className="space-y-1">
-              <h3 className="text-sm font-medium text-slate-200">Date Format</h3>
+              <h3 className="text-sm font-medium text-foreground">Date Format</h3>
               <p className="text-xs text-muted-foreground">
                 How dates appear in your game data.
               </p>
@@ -126,7 +139,7 @@ export function LocaleSettingsContent() {
           {/* Locale Dropdown */}
           <div className="space-y-3">
             <div className="space-y-1">
-              <h3 className="text-sm font-medium text-slate-200">Locale</h3>
+              <h3 className="text-sm font-medium text-foreground">Locale</h3>
               <p className="text-xs text-muted-foreground">
                 Select your preferred display format.
               </p>
@@ -145,44 +158,27 @@ export function LocaleSettingsContent() {
             </Select>
           </div>
 
-          <div className="border-t border-slate-700/50" />
+          <div className="border-t border-muted" />
 
           {/* Preview */}
           <div className="space-y-3">
             <div className="space-y-1">
-              <h3 className="text-sm font-medium text-slate-200">Preview</h3>
+              <h3 className="text-sm font-medium text-foreground">Preview</h3>
               <p className="text-xs text-muted-foreground">
                 See how values will be displayed with your selected locale.
               </p>
             </div>
-            <div className="rounded-md border border-slate-700 bg-slate-800/50 p-4">
+            <div className="rounded-lg bg-muted/30 border border-muted p-4 transition-all duration-200 hover:bg-muted/40 hover:border-primary/20">
               <dl className="space-y-2 text-sm">
-                <div className="flex justify-between">
-                  <dt className="text-slate-400">Number:</dt>
-                  <dd className="font-mono text-slate-200">{preview.number}</dd>
-                </div>
-                <div className="flex justify-between">
-                  <dt className="text-slate-400">Large Number:</dt>
-                  <dd className="font-mono text-slate-200">
-                    {preview.largeNumber}
-                  </dd>
-                </div>
-                <div className="flex justify-between">
-                  <dt className="text-slate-400">Percentage:</dt>
-                  <dd className="font-mono text-slate-200">
-                    {preview.percentage}
-                  </dd>
-                </div>
-                <div className="flex justify-between">
-                  <dt className="text-slate-400">Date:</dt>
-                  <dd className="font-mono text-slate-200">{preview.date}</dd>
-                </div>
-                <div className="flex justify-between">
-                  <dt className="text-slate-400">Date & Time:</dt>
-                  <dd className="font-mono text-slate-200">
-                    {preview.dateTime}
-                  </dd>
-                </div>
+                <PreviewRow label="Number" value={preview.number} />
+                <PreviewRow label="Large Number" value={preview.largeNumber} />
+                <PreviewRow label="Percentage" value={preview.percentage} />
+                <PreviewRow label="Date" value={preview.date} />
+                <PreviewRow label="Numeric Date" value={preview.numericDate} />
+                <PreviewRow label="Short Date" value={preview.shortDate} />
+                <PreviewRow label="Month Format" value={preview.monthDay} />
+                <PreviewRow label="Time" value={preview.time} />
+                <PreviewRow label="Date & Time" value={preview.dateTime} />
               </dl>
             </div>
           </div>

--- a/src/features/settings/locale-settings/use-locale-settings.ts
+++ b/src/features/settings/locale-settings/use-locale-settings.ts
@@ -16,6 +16,10 @@ import {
   getNumberFormatter,
   getDateFormatter,
   getDateTimeFormatter,
+  getShortDateFormatter,
+  getNumericDateFormatter,
+  getTimeFormatter,
+  getMonthDayFormatter,
 } from '@/shared/locale/locale-store';
 import type { SelectionOption } from '@/components/ui/selection-button-group';
 
@@ -69,6 +73,14 @@ interface LocalePreview {
   percentage: string;
   /** Example date: Nov 20, 2025 */
   date: string;
+  /** Example short date without year: 11/20 or 20/11 */
+  shortDate: string;
+  /** Example numeric date with year: 11/20/2025 or 20/11/2025 */
+  numericDate: string;
+  /** Example month+day: Nov 20 or 20 Nov */
+  monthDay: string;
+  /** Example time: 10:28 PM or 22:28 */
+  time: string;
   /** Example datetime: Nov 20, 2025, 22:28 */
   dateTime: string;
 }
@@ -80,6 +92,10 @@ function generatePreview(): LocalePreview {
   const numberFormatter = getNumberFormatter();
   const dateFormatter = getDateFormatter();
   const dateTimeFormatter = getDateTimeFormatter();
+  const shortDateFormatter = getShortDateFormatter();
+  const numericDateFormatter = getNumericDateFormatter();
+  const timeFormatter = getTimeFormatter();
+  const monthDayFormatter = getMonthDayFormatter();
 
   // Use a sample date for preview
   const sampleDate = new Date(2025, 10, 20, 22, 28, 0); // Nov 20, 2025 22:28
@@ -94,6 +110,10 @@ function generatePreview(): LocalePreview {
     largeNumber: largeFormatted,
     percentage: numberFormatter.format(45.3) + '%',
     date: dateFormatter.format(sampleDate),
+    shortDate: shortDateFormatter.format(sampleDate),
+    numericDate: numericDateFormatter.format(sampleDate),
+    monthDay: monthDayFormatter.format(sampleDate),
+    time: timeFormatter.format(sampleDate),
     dateTime: dateTimeFormatter.format(sampleDate),
   };
 }

--- a/src/shared/domain/duplicate-detection/duplicate-info.tsx
+++ b/src/shared/domain/duplicate-detection/duplicate-info.tsx
@@ -1,6 +1,7 @@
 import { Card, CardContent } from '@/components/ui';
 import type { BatchDuplicateDetectionResult, DuplicateDetectionResult } from './duplicate-detection';
 import type { ParsedGameRun } from '@/shared/types/game-run.types';
+import { formatDisplayDate } from '@/shared/formatting/date-formatters';
 
 export type DuplicateResolution = 'new-only' | 'overwrite';
 
@@ -106,7 +107,7 @@ export function DuplicateInfo({
                 { label: 'Tier', newVal: newRun.tier.toString(), existingVal: singleResult.existingRun.tier.toString() },
                 { label: 'Wave', newVal: newRun.wave.toString(), existingVal: singleResult.existingRun.wave.toString() },
                 { label: 'Duration', newVal: formatDuration(newRun.realTime), existingVal: formatDuration(singleResult.existingRun.realTime) },
-                { label: 'Import Date', newVal: newRun.timestamp.toLocaleDateString(), existingVal: singleResult.existingRun.timestamp.toLocaleDateString() }
+                { label: 'Import Date', newVal: formatDisplayDate(newRun.timestamp), existingVal: formatDisplayDate(singleResult.existingRun.timestamp) }
               ].map((row, i) => (
                 <div key={i} className="grid grid-cols-3 gap-4 py-2 px-3 text-sm">
                   <div className="font-medium">{row.label}</div>

--- a/src/shared/formatting/date-formatters-display.test.ts
+++ b/src/shared/formatting/date-formatters-display.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  formatDisplayDate,
+  formatDisplayDateTime,
+  formatDisplayShortDate,
+  formatDisplayNumericDate,
+  formatDisplayTime,
+  formatDisplayMonthDay,
+  formatDisplayMonth,
+  formatWeekOfLabel,
+  formatDisplayShortDateTime,
+} from './date-formatters';
+import { __resetForTesting, __setStateForTesting } from '../locale/locale-store';
+
+// Test helpers to reduce boilerplate
+const setLocale = (locale: 'en-US' | 'de-DE' | 'pl-PL') => {
+  const configs = {
+    'en-US': { decimalSeparator: '.', thousandsSeparator: ',', dateFormat: 'month-first' },
+    'de-DE': { decimalSeparator: ',', thousandsSeparator: '.', dateFormat: 'month-first' },
+    'pl-PL': { decimalSeparator: ',', thousandsSeparator: ' ', dateFormat: 'month-first' },
+  } as const;
+  __setStateForTesting({ importFormat: configs[locale], displayLocale: locale });
+};
+
+describe('date display formatters', () => {
+  const testDate = new Date(2025, 10, 30, 15, 45, 0); // Nov 30, 2025 15:45
+  afterEach(() => __resetForTesting());
+
+  describe('formatDisplayDate', () => {
+    it('formats date using en-US locale', () => {
+      setLocale('en-US');
+      const result = formatDisplayDate(testDate);
+      expect(result).toContain('Nov');
+      expect(result).toContain('30');
+      expect(result).toContain('2025');
+    });
+
+    it('formats date using de-DE locale', () => {
+      setLocale('de-DE');
+      const result = formatDisplayDate(testDate);
+      expect(result).toContain('30');
+      expect(result).toContain('2025');
+    });
+  });
+
+  describe('formatDisplayDateTime', () => {
+    it('formats date and time using en-US locale', () => {
+      setLocale('en-US');
+      const result = formatDisplayDateTime(testDate);
+      expect(result).toContain('Nov');
+      expect(result).toContain('30');
+      expect(result).toContain('2025');
+      expect(result).toMatch(/15:45|3:45/);
+    });
+
+    it('formats date and time using de-DE locale', () => {
+      setLocale('de-DE');
+      const result = formatDisplayDateTime(testDate);
+      expect(result).toContain('30');
+      expect(result).toContain('2025');
+      expect(result).toMatch(/15:45/);
+    });
+  });
+
+  describe('formatDisplayShortDate', () => {
+    it('formats short date using en-US locale (MM/DD)', () => {
+      setLocale('en-US');
+      expect(formatDisplayShortDate(testDate)).toMatch(/11.*30|30.*11/);
+    });
+
+    it('formats short date using de-DE locale (DD.MM.)', () => {
+      setLocale('de-DE');
+      const result = formatDisplayShortDate(testDate);
+      expect(result).toContain('30');
+      expect(result).toContain('11');
+    });
+  });
+
+  describe('formatDisplayNumericDate', () => {
+    it('formats numeric date using en-US locale (MM/DD/YYYY)', () => {
+      setLocale('en-US');
+      const result = formatDisplayNumericDate(testDate);
+      expect(result).toContain('11');
+      expect(result).toContain('30');
+      expect(result).toContain('2025');
+      expect(result).not.toMatch(/nov/i);
+    });
+
+    it('formats numeric date using de-DE locale (DD.MM.YYYY)', () => {
+      setLocale('de-DE');
+      const result = formatDisplayNumericDate(testDate);
+      expect(result).toContain('30');
+      expect(result).toContain('11');
+      expect(result).toContain('2025');
+      expect(result).not.toMatch(/nov/i);
+    });
+
+    it('formats numeric date using pl-PL locale (DD.MM.YYYY)', () => {
+      setLocale('pl-PL');
+      const result = formatDisplayNumericDate(testDate);
+      expect(result).toContain('30');
+      expect(result).toContain('11');
+      expect(result).toContain('2025');
+      expect(result).not.toMatch(/lis|nov/i);
+    });
+  });
+
+  describe('formatDisplayTime', () => {
+    it('formats time using en-US locale', () => {
+      setLocale('en-US');
+      expect(formatDisplayTime(testDate)).toMatch(/3:45.*PM|15:45/);
+    });
+
+    it('formats time using de-DE locale (24-hour)', () => {
+      setLocale('de-DE');
+      const result = formatDisplayTime(testDate);
+      expect(result).toContain('15');
+      expect(result).toContain('45');
+    });
+
+    it('handles midnight correctly', () => {
+      setLocale('en-US');
+      const midnight = new Date(2025, 10, 30, 0, 0, 0);
+      expect(formatDisplayTime(midnight)).toMatch(/12:00.*AM|0:00|00:00/);
+    });
+
+    it('handles noon correctly', () => {
+      setLocale('en-US');
+      const noon = new Date(2025, 10, 30, 12, 0, 0);
+      expect(formatDisplayTime(noon)).toMatch(/12:00.*PM|12:00/);
+    });
+  });
+
+  describe('formatDisplayMonthDay', () => {
+    it('formats month and day using en-US locale', () => {
+      setLocale('en-US');
+      const result = formatDisplayMonthDay(testDate);
+      expect(result).toContain('Nov');
+      expect(result).toContain('30');
+    });
+
+    it('formats month and day using de-DE locale (day-first)', () => {
+      setLocale('de-DE');
+      expect(formatDisplayMonthDay(testDate)).toContain('30');
+    });
+  });
+
+  describe('formatDisplayMonth', () => {
+    it('formats month using en-US locale', () => {
+      setLocale('en-US');
+      expect(formatDisplayMonth(testDate).toLowerCase()).toContain('nov');
+    });
+
+    it('formats month using de-DE locale', () => {
+      setLocale('de-DE');
+      expect(formatDisplayMonth(testDate).toLowerCase()).toContain('nov');
+    });
+
+    it('formats different months correctly', () => {
+      setLocale('en-US');
+      expect(formatDisplayMonth(new Date(2025, 0, 15)).toLowerCase()).toContain('jan');
+      expect(formatDisplayMonth(new Date(2025, 6, 15)).toLowerCase()).toContain('jul');
+      expect(formatDisplayMonth(new Date(2025, 11, 15)).toLowerCase()).toContain('dec');
+    });
+  });
+
+  describe('formatWeekOfLabel', () => {
+    it('formats week label using en-US locale', () => {
+      setLocale('en-US');
+      const result = formatWeekOfLabel(testDate);
+      expect(result).toContain('Week of');
+      expect(result).toMatch(/11.*30|30.*11/);
+    });
+
+    it('formats week label using de-DE locale', () => {
+      setLocale('de-DE');
+      const result = formatWeekOfLabel(testDate);
+      expect(result).toContain('Week of');
+      expect(result).toContain('30');
+      expect(result).toContain('11');
+    });
+  });
+
+  describe('formatDisplayShortDateTime', () => {
+    it('combines short date and time using en-US locale', () => {
+      setLocale('en-US');
+      const result = formatDisplayShortDateTime(testDate);
+      expect(result).toMatch(/11.*30|30.*11/);
+      expect(result).toMatch(/3:45.*PM|15:45/);
+    });
+
+    it('combines short date and time using de-DE locale', () => {
+      setLocale('de-DE');
+      const result = formatDisplayShortDateTime(testDate);
+      expect(result).toContain('30');
+      expect(result).toContain('15');
+      expect(result).toContain('45');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles year boundaries', () => {
+      setLocale('en-US');
+      const result = formatDisplayDate(new Date(2025, 11, 31, 23, 59, 59));
+      expect(result).toContain('Dec');
+      expect(result).toContain('31');
+      expect(result).toContain('2025');
+    });
+
+    it('handles leap year dates', () => {
+      setLocale('en-US');
+      const result = formatDisplayDate(new Date(2024, 1, 29, 12, 0, 0));
+      expect(result).toContain('Feb');
+      expect(result).toContain('29');
+      expect(result).toContain('2024');
+    });
+
+    it('handles single digit dates', () => {
+      setLocale('en-US');
+      const result = formatDisplayDate(new Date(2025, 0, 5, 8, 5, 0));
+      expect(result).toContain('Jan');
+      expect(result).toContain('5');
+    });
+  });
+});

--- a/src/shared/formatting/date-formatters.ts
+++ b/src/shared/formatting/date-formatters.ts
@@ -10,7 +10,16 @@
 
 import type { DateFormat } from '@/shared/locale/types';
 import { MONTH_MAPPINGS } from '@/shared/locale/locale-config';
-import { getImportFormat } from '@/shared/locale/locale-store';
+import {
+  getImportFormat,
+  getDateFormatter,
+  getDateTimeFormatter,
+  getShortDateFormatter,
+  getNumericDateFormatter,
+  getTimeFormatter,
+  getMonthDayFormatter,
+  getMonthFormatter,
+} from '@/shared/locale/locale-store';
 
 // ============================================================================
 // ISO format functions (locale-independent, for data storage/keys)
@@ -250,4 +259,154 @@ export function parseTimestampFromFields(
 
   // Priority 3: Fallback to provided date or current time
   return fallbackDate || new Date();
+}
+
+// ============================================================================
+// Display format functions (locale-aware, for UI rendering)
+// ============================================================================
+
+/**
+ * Format date for display using user's locale (e.g., Nov 20, 2025 or 20 nov. 2025)
+ *
+ * @param date - Date to format
+ * @returns Locale-formatted date string
+ *
+ * @example
+ * // With en-US locale
+ * formatDisplayDate(new Date('2025-11-20')) // 'Nov 20, 2025'
+ * // With de-DE locale
+ * formatDisplayDate(new Date('2025-11-20')) // '20. Nov. 2025'
+ */
+export function formatDisplayDate(date: Date): string {
+  return getDateFormatter().format(date);
+}
+
+/**
+ * Format date and time for display using user's locale
+ *
+ * @param date - Date to format
+ * @returns Locale-formatted date+time string
+ *
+ * @example
+ * // With en-US locale
+ * formatDisplayDateTime(new Date('2025-11-20T15:45')) // 'Nov 20, 2025, 15:45'
+ * // With de-DE locale
+ * formatDisplayDateTime(new Date('2025-11-20T15:45')) // '20. Nov. 2025, 15:45'
+ */
+export function formatDisplayDateTime(date: Date): string {
+  return getDateTimeFormatter().format(date);
+}
+
+/**
+ * Format short date without year using user's locale (e.g., 11/30 or 30/11)
+ *
+ * @param date - Date to format
+ * @returns Locale-formatted short date string
+ *
+ * @example
+ * // With en-US locale
+ * formatDisplayShortDate(new Date('2025-11-30')) // '11/30'
+ * // With de-DE locale
+ * formatDisplayShortDate(new Date('2025-11-30')) // '30.11.'
+ */
+export function formatDisplayShortDate(date: Date): string {
+  return getShortDateFormatter().format(date);
+}
+
+/**
+ * Format date with year in numeric-only format using user's locale (e.g., 11/30/2025 or 30/11/2025)
+ * Uses locale conventions for day/month order but only numeric components (no month names)
+ *
+ * @param date - Date to format
+ * @returns Locale-formatted numeric date string with year
+ *
+ * @example
+ * // With en-US locale
+ * formatDisplayNumericDate(new Date('2025-11-30')) // '11/30/2025'
+ * // With de-DE locale
+ * formatDisplayNumericDate(new Date('2025-11-30')) // '30.11.2025'
+ */
+export function formatDisplayNumericDate(date: Date): string {
+  return getNumericDateFormatter().format(date);
+}
+
+/**
+ * Format time only using user's locale (e.g., 3:45 PM or 15:45)
+ *
+ * @param date - Date to extract and format time from
+ * @returns Locale-formatted time string
+ *
+ * @example
+ * // With en-US locale
+ * formatDisplayTime(new Date('2025-11-20T15:45')) // '3:45 PM'
+ * // With de-DE locale
+ * formatDisplayTime(new Date('2025-11-20T15:45')) // '15:45'
+ */
+export function formatDisplayTime(date: Date): string {
+  return getTimeFormatter().format(date);
+}
+
+/**
+ * Format month and day using user's locale (e.g., NOV 30 or 30 NOV)
+ *
+ * @param date - Date to format
+ * @returns Locale-formatted month+day string
+ *
+ * @example
+ * // With en-US locale
+ * formatDisplayMonthDay(new Date('2025-11-30')) // 'Nov 30'
+ * // With de-DE locale
+ * formatDisplayMonthDay(new Date('2025-11-30')) // '30. Nov.'
+ */
+export function formatDisplayMonthDay(date: Date): string {
+  return getMonthDayFormatter().format(date);
+}
+
+/**
+ * Format month only using user's locale (e.g., Nov or nov.)
+ *
+ * @param date - Date to format
+ * @returns Locale-formatted month string
+ *
+ * @example
+ * // With en-US locale
+ * formatDisplayMonth(new Date('2025-11-20')) // 'Nov'
+ * // With de-DE locale
+ * formatDisplayMonth(new Date('2025-11-20')) // 'Nov.'
+ */
+export function formatDisplayMonth(date: Date): string {
+  return getMonthFormatter().format(date);
+}
+
+/**
+ * Format week label using user's locale (e.g., "Week of 11/30" or "Week of 30/11")
+ *
+ * @param date - Start date of the week
+ * @returns Formatted week label string
+ *
+ * @example
+ * // With en-US locale
+ * formatWeekOfLabel(new Date('2025-11-30')) // 'Week of 11/30'
+ * // With de-DE locale
+ * formatWeekOfLabel(new Date('2025-11-30')) // 'Week of 30.11.'
+ */
+export function formatWeekOfLabel(date: Date): string {
+  return `Week of ${formatDisplayShortDate(date)}`;
+}
+
+/**
+ * Format short date and time together (e.g., "11/30 3:45 PM" or "30/11 15:45")
+ * Used for per-run tier trends column headers
+ *
+ * @param date - Date to format
+ * @returns Locale-formatted short date + time string
+ *
+ * @example
+ * // With en-US locale
+ * formatDisplayShortDateTime(new Date('2025-11-30T15:45')) // '11/30 3:45 PM'
+ * // With de-DE locale
+ * formatDisplayShortDateTime(new Date('2025-11-30T15:45')) // '30.11. 15:45'
+ */
+export function formatDisplayShortDateTime(date: Date): string {
+  return `${formatDisplayShortDate(date)} ${formatDisplayTime(date)}`;
 }

--- a/src/shared/locale/locale-options.ts
+++ b/src/shared/locale/locale-options.ts
@@ -21,51 +21,45 @@ interface DisplayLocaleOption {
 
 /**
  * Common display locale options covering major regions.
- * Ordered by rough population/usage.
+ * Sorted alphabetically by language name.
  */
 export const DISPLAY_LOCALE_OPTIONS: readonly DisplayLocaleOption[] = [
-  // Americas
-  { value: 'en-US', label: 'English (US)', example: '1,234.56' },
-  { value: 'en-CA', label: 'English (Canada)', example: '1,234.56' },
-  { value: 'es-MX', label: 'Spanish (Mexico)', example: '1,234.56' },
-  { value: 'pt-BR', label: 'Portuguese (Brazil)', example: '1.234,56' },
-  { value: 'es-AR', label: 'Spanish (Argentina)', example: '1.234,56' },
-
-  // Europe
-  { value: 'en-GB', label: 'English (UK)', example: '1,234.56' },
-  { value: 'de-DE', label: 'German (Germany)', example: '1.234,56' },
-  { value: 'fr-FR', label: 'French (France)', example: '1 234,56' },
-  { value: 'es-ES', label: 'Spanish (Spain)', example: '1.234,56' },
-  { value: 'it-IT', label: 'Italian (Italy)', example: '1.234,56' },
-  { value: 'nl-NL', label: 'Dutch (Netherlands)', example: '1.234,56' },
-  { value: 'pl-PL', label: 'Polish (Poland)', example: '1 234,56' },
-  { value: 'ru-RU', label: 'Russian (Russia)', example: '1 234,56' },
-  { value: 'uk-UA', label: 'Ukrainian (Ukraine)', example: '1 234,56' },
-  { value: 'cs-CZ', label: 'Czech (Czechia)', example: '1 234,56' },
-  { value: 'sv-SE', label: 'Swedish (Sweden)', example: '1 234,56' },
-  { value: 'da-DK', label: 'Danish (Denmark)', example: '1.234,56' },
-  { value: 'fi-FI', label: 'Finnish (Finland)', example: '1 234,56' },
-  { value: 'nb-NO', label: 'Norwegian (Norway)', example: '1 234,56' },
-  { value: 'el-GR', label: 'Greek (Greece)', example: '1.234,56' },
-  { value: 'pt-PT', label: 'Portuguese (Portugal)', example: '1 234,56' },
-  { value: 'tr-TR', label: 'Turkish (Turkey)', example: '1.234,56' },
-
-  // Asia Pacific
-  { value: 'ja-JP', label: 'Japanese (Japan)', example: '1,234.56' },
-  { value: 'ko-KR', label: 'Korean (Korea)', example: '1,234.56' },
+  { value: 'ar-SA', label: 'Arabic (Saudi Arabia)', example: '1,234.56' },
+  { value: 'bg-BG', label: 'Bulgarian (Bulgaria)', example: '1 234,56' },
   { value: 'zh-CN', label: 'Chinese (China)', example: '1,234.56' },
   { value: 'zh-TW', label: 'Chinese (Taiwan)', example: '1,234.56' },
-  { value: 'th-TH', label: 'Thai (Thailand)', example: '1,234.56' },
-  { value: 'vi-VN', label: 'Vietnamese (Vietnam)', example: '1.234,56' },
-  { value: 'id-ID', label: 'Indonesian (Indonesia)', example: '1.234,56' },
+  { value: 'cs-CZ', label: 'Czech (Czechia)', example: '1 234,56' },
+  { value: 'da-DK', label: 'Danish (Denmark)', example: '1.234,56' },
+  { value: 'nl-NL', label: 'Dutch (Netherlands)', example: '1.234,56' },
   { value: 'en-AU', label: 'English (Australia)', example: '1,234.56' },
+  { value: 'en-CA', label: 'English (Canada)', example: '1,234.56' },
   { value: 'en-NZ', label: 'English (New Zealand)', example: '1,234.56' },
-  { value: 'hi-IN', label: 'Hindi (India)', example: '1,23,456.78' },
-
-  // Middle East & Africa
-  { value: 'ar-SA', label: 'Arabic (Saudi Arabia)', example: '1,234.56' },
-  { value: 'he-IL', label: 'Hebrew (Israel)', example: '1,234.56' },
   { value: 'en-ZA', label: 'English (South Africa)', example: '1 234,56' },
+  { value: 'en-GB', label: 'English (UK)', example: '1,234.56' },
+  { value: 'en-US', label: 'English (US)', example: '1,234.56' },
+  { value: 'fi-FI', label: 'Finnish (Finland)', example: '1 234,56' },
+  { value: 'fr-FR', label: 'French (France)', example: '1 234,56' },
+  { value: 'de-DE', label: 'German (Germany)', example: '1.234,56' },
+  { value: 'el-GR', label: 'Greek (Greece)', example: '1.234,56' },
+  { value: 'he-IL', label: 'Hebrew (Israel)', example: '1,234.56' },
+  { value: 'hi-IN', label: 'Hindi (India)', example: '1,23,456.78' },
+  { value: 'id-ID', label: 'Indonesian (Indonesia)', example: '1.234,56' },
+  { value: 'it-IT', label: 'Italian (Italy)', example: '1.234,56' },
+  { value: 'ja-JP', label: 'Japanese (Japan)', example: '1,234.56' },
+  { value: 'ko-KR', label: 'Korean (Korea)', example: '1,234.56' },
+  { value: 'nb-NO', label: 'Norwegian (Norway)', example: '1 234,56' },
+  { value: 'pl-PL', label: 'Polish (Poland)', example: '1 234,56' },
+  { value: 'pt-BR', label: 'Portuguese (Brazil)', example: '1.234,56' },
+  { value: 'pt-PT', label: 'Portuguese (Portugal)', example: '1 234,56' },
+  { value: 'ru-RU', label: 'Russian (Russia)', example: '1 234,56' },
+  { value: 'es-AR', label: 'Spanish (Argentina)', example: '1.234,56' },
+  { value: 'es-MX', label: 'Spanish (Mexico)', example: '1,234.56' },
+  { value: 'es-ES', label: 'Spanish (Spain)', example: '1.234,56' },
+  { value: 'sv-SE', label: 'Swedish (Sweden)', example: '1 234,56' },
+  { value: 'th-TH', label: 'Thai (Thailand)', example: '1,234.56' },
+  { value: 'tr-TR', label: 'Turkish (Turkey)', example: '1.234,56' },
+  { value: 'uk-UA', label: 'Ukrainian (Ukraine)', example: '1 234,56' },
+  { value: 'vi-VN', label: 'Vietnamese (Vietnam)', example: '1.234,56' },
 ] as const;
 
 /**

--- a/src/shared/locale/locale-store.ts
+++ b/src/shared/locale/locale-store.ts
@@ -41,6 +41,11 @@ let state: LocaleStoreState = getInitialState();
 let numberFormatter: Intl.NumberFormat | null = null;
 let dateFormatter: Intl.DateTimeFormat | null = null;
 let dateTimeFormatter: Intl.DateTimeFormat | null = null;
+let shortDateFormatter: Intl.DateTimeFormat | null = null;
+let numericDateFormatter: Intl.DateTimeFormat | null = null;
+let timeFormatter: Intl.DateTimeFormat | null = null;
+let monthDayFormatter: Intl.DateTimeFormat | null = null;
+let monthFormatter: Intl.DateTimeFormat | null = null;
 
 // Subscription listeners for React reactivity
 const listeners = new Set<() => void>();
@@ -180,6 +185,36 @@ function createFormatters(locale: DisplayLocale): void {
       minute: '2-digit',
       hour12: false, // 24-hour time as per user requirement
     });
+
+    // Short date formatter for date without year (e.g., 11/30 or 30/11)
+    shortDateFormatter = new Intl.DateTimeFormat(locale, {
+      month: 'numeric',
+      day: 'numeric',
+    });
+
+    // Numeric date formatter for date with year in numeric format (e.g., 11/30/2025 or 30/11/2025)
+    numericDateFormatter = new Intl.DateTimeFormat(locale, {
+      year: 'numeric',
+      month: 'numeric',
+      day: 'numeric',
+    });
+
+    // Time formatter for time only (e.g., 3:45 PM or 15:45)
+    timeFormatter = new Intl.DateTimeFormat(locale, {
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+
+    // Month + day formatter (e.g., NOV 30 or 30 NOV)
+    monthDayFormatter = new Intl.DateTimeFormat(locale, {
+      month: 'short',
+      day: 'numeric',
+    });
+
+    // Month-only formatter (e.g., Nov or nov.)
+    monthFormatter = new Intl.DateTimeFormat(locale, {
+      month: 'short',
+    });
   } catch (error) {
     console.error('[LocaleStore] Failed to create formatters:', error);
     // Fallback to en-US if locale is invalid
@@ -199,6 +234,26 @@ function createFormatters(locale: DisplayLocale): void {
       minute: '2-digit',
       hour12: false,
     });
+    shortDateFormatter = new Intl.DateTimeFormat('en-US', {
+      month: 'numeric',
+      day: 'numeric',
+    });
+    numericDateFormatter = new Intl.DateTimeFormat('en-US', {
+      year: 'numeric',
+      month: 'numeric',
+      day: 'numeric',
+    });
+    timeFormatter = new Intl.DateTimeFormat('en-US', {
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+    monthDayFormatter = new Intl.DateTimeFormat('en-US', {
+      month: 'short',
+      day: 'numeric',
+    });
+    monthFormatter = new Intl.DateTimeFormat('en-US', {
+      month: 'short',
+    });
   }
 }
 
@@ -209,6 +264,11 @@ function invalidateFormatters(): void {
   numberFormatter = null;
   dateFormatter = null;
   dateTimeFormatter = null;
+  shortDateFormatter = null;
+  numericDateFormatter = null;
+  timeFormatter = null;
+  monthDayFormatter = null;
+  monthFormatter = null;
 }
 
 // ============================================================================
@@ -280,6 +340,56 @@ export function getDateTimeFormatter(): Intl.DateTimeFormat {
     createFormatters(state.displayLocale);
   }
   return dateTimeFormatter!;
+}
+
+/**
+ * Get cached short date formatter (date without year, e.g., 11/30 or 30/11).
+ */
+export function getShortDateFormatter(): Intl.DateTimeFormat {
+  if (!shortDateFormatter) {
+    createFormatters(state.displayLocale);
+  }
+  return shortDateFormatter!;
+}
+
+/**
+ * Get cached numeric date formatter (date with year in numeric format, e.g., 11/30/2025 or 30/11/2025).
+ */
+export function getNumericDateFormatter(): Intl.DateTimeFormat {
+  if (!numericDateFormatter) {
+    createFormatters(state.displayLocale);
+  }
+  return numericDateFormatter!;
+}
+
+/**
+ * Get cached time formatter (time only, e.g., 3:45 PM or 15:45).
+ */
+export function getTimeFormatter(): Intl.DateTimeFormat {
+  if (!timeFormatter) {
+    createFormatters(state.displayLocale);
+  }
+  return timeFormatter!;
+}
+
+/**
+ * Get cached month+day formatter (e.g., NOV 30 or 30 NOV).
+ */
+export function getMonthDayFormatter(): Intl.DateTimeFormat {
+  if (!monthDayFormatter) {
+    createFormatters(state.displayLocale);
+  }
+  return monthDayFormatter!;
+}
+
+/**
+ * Get cached month-only formatter (e.g., Nov or nov.).
+ */
+export function getMonthFormatter(): Intl.DateTimeFormat {
+  if (!monthFormatter) {
+    createFormatters(state.displayLocale);
+  }
+  return monthFormatter!;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
Users who configure non-US display locales now see dates and times formatted according to their preference throughout the application. Previously, all dates displayed in US format (MM/DD/YYYY, 12-hour time) regardless of locale settings. This change centralizes date formatting through the existing locale store pattern, matching how number formatting already works.

## Technical Details
- Extended `locale-store.ts` with 4 new cached `Intl.DateTimeFormat` instances: short date, numeric date, time-only, month/day, and month-only formatters
- Added 8 locale-aware display functions to `date-formatters.ts`: `formatDisplayDate`, `formatDisplayDateTime`, `formatDisplayShortDate`, `formatDisplayNumericDate`, `formatDisplayTime`, `formatDisplayMonthDay`, `formatDisplayMonth`, `formatWeekOfLabel`, `formatDisplayShortDateTime`
- Replaced hardcoded `'en-US'` and `date-fns format()` calls across 9 files:
  - `period-formatting.ts`, `tier-stats-cell-tooltip.tsx`, `period-grouping.ts`
  - `run-header-formatting.ts`, `field-aggregation.ts`, `data-input-datetime-section.tsx`
  - `data-input-preview.tsx`, `run-card-utils.ts`, `shared-column-definitions.tsx`, `duplicate-info.tsx`
- Updated Settings locale preview to show all date format variants (numeric date, short date, month format, time)
- Added comprehensive test suite in `date-formatters-display.test.ts` covering en-US, de-DE, and pl-PL locales