### PR TITLE
IMPROVE: Add Mini Coverage Report to run details for at-a-glance metrics

### DIFF
--- a/src/features/analysis/coverage-report/coverage-config.ts
+++ b/src/features/analysis/coverage-report/coverage-config.ts
@@ -64,7 +64,7 @@ const COVERAGE_METRICS: readonly CoverageMetricDefinition[] = [
   },
   {
     fieldName: 'destroyedByOrbs',
-    label: 'Orb Kills',
+    label: 'Orbs',
     category: 'combat',
     color: COLORS.orbKills,
   },

--- a/src/features/analysis/coverage-report/filters/metric-toggle-selector.tsx
+++ b/src/features/analysis/coverage-report/filters/metric-toggle-selector.tsx
@@ -16,6 +16,7 @@ interface MetricToggleSelectorProps {
 
 interface MetricColumnProps {
   title: string
+  subtitle: string
   metrics: CoverageMetricDefinition[]
   selectedMetrics: Set<CoverageFieldName>
   onToggleMetric: (fieldName: CoverageFieldName) => void
@@ -23,15 +24,19 @@ interface MetricColumnProps {
 
 function MetricColumn({
   title,
+  subtitle,
   metrics,
   selectedMetrics,
   onToggleMetric,
 }: MetricColumnProps) {
   return (
     <div className="space-y-2">
-      <span className="text-xs font-medium text-slate-400 uppercase tracking-wider">
-        {title}
-      </span>
+      <div>
+        <span className="text-xs font-medium text-slate-400 uppercase tracking-wider">
+          {title}
+        </span>
+        <p className="text-[11px] text-muted-foreground/50">{subtitle}</p>
+      </div>
       <div className="flex flex-wrap gap-1.5">
         {metrics.map((metric) => {
           const isSelected = selectedMetrics.has(metric.fieldName)
@@ -74,12 +79,14 @@ export function MetricToggleSelector({
     <div className="flex flex-col sm:flex-row gap-4 sm:gap-8">
       <MetricColumn
         title="Economic"
+        subtitle="Tagged, killed in range, or summoned"
         metrics={economicMetrics}
         selectedMetrics={selectedMetrics}
         onToggleMetric={onToggleMetric}
       />
       <MetricColumn
         title="Combat"
+        subtitle="Kills (or Hits where specified)"
         metrics={combatMetrics}
         selectedMetrics={selectedMetrics}
         onToggleMetric={onToggleMetric}

--- a/src/features/game-runs/card-view/coverage-report/mini-coverage-bar.tsx
+++ b/src/features/game-runs/card-view/coverage-report/mini-coverage-bar.tsx
@@ -1,0 +1,59 @@
+/**
+ * Coverage Bar Component
+ *
+ * Horizontal bar chart for displaying a single coverage metric.
+ * Shows label, visual bar with gradient fill, and value/percentage.
+ */
+
+import type { MetricCoverage } from '@/features/analysis/coverage-report/types'
+import { formatLargeNumber, formatPercentage } from '@/shared/formatting/number-scale'
+
+interface CoverageBarProps {
+  metric: MetricCoverage
+}
+
+/** Minimum visual bar width percentage for small percentages to remain visible */
+const MIN_BAR_WIDTH_PERCENT = 2
+
+export function CoverageBar({ metric }: CoverageBarProps) {
+  const { label, color, percentage, affectedCount } = metric
+
+  // Cap visual width at 100%, but show actual percentage in text
+  const visualPercentage = Math.min(percentage, 100)
+
+  // Ensure minimum visibility for non-zero percentages
+  const barWidth = percentage > 0
+    ? Math.max(visualPercentage, MIN_BAR_WIDTH_PERCENT)
+    : 0
+
+  return (
+    <div className="flex items-center gap-2 sm:gap-3">
+      {/* Label - responsive width for alignment */}
+      <span className="text-xs text-muted-foreground w-20 sm:w-28 truncate flex-shrink-0" title={label}>
+        {label}
+      </span>
+
+      {/* Value and percentage - responsive width for alignment */}
+      <div className="flex items-center gap-1 sm:gap-1.5 text-xs flex-shrink-0 w-20 sm:w-24 justify-end">
+        <span className="text-muted-foreground font-mono text-[11px] sm:text-xs">
+          {formatLargeNumber(affectedCount)}
+        </span>
+        <span className="font-semibold text-[11px] sm:text-xs" style={{ color }}>
+          {formatPercentage(percentage)}
+        </span>
+      </div>
+
+      {/* Bar container - uses Tailwind height class for consistency */}
+      <div className="flex-1 relative h-6 rounded-sm overflow-hidden bg-muted/30">
+        {/* Filled bar with gradient */}
+        <div
+          className="absolute inset-y-0 left-0 rounded-sm transition-all duration-300 ease-out"
+          style={{
+            width: `${barWidth}%`,
+            background: `linear-gradient(90deg, ${color} 0%, ${color}99 50%, ${color}55 100%)`,
+          }}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/features/game-runs/card-view/coverage-report/mini-coverage-calculations.test.ts
+++ b/src/features/game-runs/card-view/coverage-report/mini-coverage-calculations.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Mini Coverage Calculations Tests
+ */
+
+import { describe, it, expect } from 'vitest'
+import type { ParsedGameRun, GameRunField } from '@/shared/types/game-run.types'
+import { calculateMiniCoverageData, hasValidCoverageData } from './mini-coverage-calculations'
+
+/**
+ * Helper to create a mock game run with specified fields
+ */
+function createMockRun(
+  fields: Record<string, number>,
+  overrides?: Partial<ParsedGameRun>
+): ParsedGameRun {
+  const runFields: Record<string, GameRunField> = {}
+
+  for (const [key, value] of Object.entries(fields)) {
+    runFields[key] = {
+      value,
+      rawValue: String(value),
+      displayValue: String(value),
+      originalKey: key,
+      dataType: 'number',
+    }
+  }
+
+  return {
+    id: 'test-run',
+    timestamp: new Date('2024-03-15'),
+    fields: runFields,
+    tier: 11,
+    wave: 1000,
+    coinsEarned: 100000,
+    cellsEarned: 50,
+    realTime: 3600,
+    runType: 'farm',
+    ...overrides,
+  }
+}
+
+describe('hasValidCoverageData', () => {
+  it('returns true when totalEnemies > 0', () => {
+    const run = createMockRun({ totalEnemies: 5000 })
+    expect(hasValidCoverageData(run)).toBe(true)
+  })
+
+  it('returns false when totalEnemies = 0', () => {
+    const run = createMockRun({ totalEnemies: 0 })
+    expect(hasValidCoverageData(run)).toBe(false)
+  })
+
+  it('returns false when totalEnemies missing', () => {
+    const run = createMockRun({})
+    expect(hasValidCoverageData(run)).toBe(false)
+  })
+})
+
+describe('calculateMiniCoverageData', () => {
+  it('returns null when run has no totalEnemies', () => {
+    const run = createMockRun({})
+    expect(calculateMiniCoverageData(run)).toBeNull()
+  })
+
+  it('returns null when totalEnemies = 0', () => {
+    const run = createMockRun({ totalEnemies: 0 })
+    expect(calculateMiniCoverageData(run)).toBeNull()
+  })
+
+  it('returns null when all metrics have zero values', () => {
+    const run = createMockRun({
+      totalEnemies: 1000,
+      // All coverage metrics are 0 or missing
+    })
+    expect(calculateMiniCoverageData(run)).toBeNull()
+  })
+
+  it('returns data with only economic metrics when combat metrics are zero', () => {
+    const run = createMockRun({
+      totalEnemies: 1000,
+      taggedByDeathwave: 800,
+      destroyedInSpotlight: 600,
+    })
+
+    const result = calculateMiniCoverageData(run)
+
+    expect(result).not.toBeNull()
+    expect(result!.economicMetrics).toHaveLength(2)
+    expect(result!.combatMetrics).toHaveLength(0)
+  })
+
+  it('returns data with only combat metrics when economic metrics are zero', () => {
+    const run = createMockRun({
+      totalEnemies: 1000,
+      enemiesHitByOrbs: 900,
+      destroyedByOrbs: 700,
+    })
+
+    const result = calculateMiniCoverageData(run)
+
+    expect(result).not.toBeNull()
+    expect(result!.economicMetrics).toHaveLength(0)
+    expect(result!.combatMetrics).toHaveLength(2)
+  })
+
+  it('returns all 9 metrics when all have values', () => {
+    const run = createMockRun({
+      totalEnemies: 1000,
+      // Economic (4)
+      taggedByDeathwave: 800,
+      destroyedInSpotlight: 600,
+      destroyedInGoldenBot: 400,
+      summonedEnemies: 200,
+      // Combat (5)
+      enemiesHitByOrbs: 900,
+      destroyedByOrbs: 700,
+      destroyedByDeathRay: 500,
+      destroyedByThorns: 300,
+      destroyedByLandMine: 100,
+    })
+
+    const result = calculateMiniCoverageData(run)
+
+    expect(result).not.toBeNull()
+    expect(result!.economicMetrics).toHaveLength(4)
+    expect(result!.combatMetrics).toHaveLength(5)
+  })
+
+  it('calculates correct percentages', () => {
+    const run = createMockRun({
+      totalEnemies: 1000,
+      taggedByDeathwave: 850,
+    })
+
+    const result = calculateMiniCoverageData(run)
+
+    expect(result).not.toBeNull()
+    expect(result!.economicMetrics[0].percentage).toBe(85)
+    expect(result!.economicMetrics[0].affectedCount).toBe(850)
+    expect(result!.economicMetrics[0].totalEnemies).toBe(1000)
+  })
+
+  it('sorts metrics by percentage descending', () => {
+    const run = createMockRun({
+      totalEnemies: 1000,
+      taggedByDeathwave: 200, // 20%
+      destroyedInSpotlight: 800, // 80%
+      destroyedInGoldenBot: 500, // 50%
+    })
+
+    const result = calculateMiniCoverageData(run)
+
+    expect(result).not.toBeNull()
+    expect(result!.economicMetrics[0].label).toBe('Spotlight')
+    expect(result!.economicMetrics[1].label).toBe('Golden Bot')
+    expect(result!.economicMetrics[2].label).toBe('Death Wave')
+  })
+
+  it('filters out metrics with zero values', () => {
+    const run = createMockRun({
+      totalEnemies: 1000,
+      taggedByDeathwave: 800,
+      destroyedInSpotlight: 0, // Should be filtered out
+      destroyedInGoldenBot: 500,
+    })
+
+    const result = calculateMiniCoverageData(run)
+
+    expect(result).not.toBeNull()
+    expect(result!.economicMetrics).toHaveLength(2)
+    expect(result!.economicMetrics.some((m) => m.label === 'Spotlight')).toBe(false)
+  })
+
+  it('handles coverage greater than 100% (orbs can hit enemies multiple times)', () => {
+    const run = createMockRun({
+      totalEnemies: 1000,
+      enemiesHitByOrbs: 1500, // 150% - orbs can hit same enemy multiple times
+    })
+
+    const result = calculateMiniCoverageData(run)
+
+    expect(result).not.toBeNull()
+    expect(result!.combatMetrics[0].percentage).toBe(150)
+  })
+
+  it('includes metric metadata (label and color)', () => {
+    const run = createMockRun({
+      totalEnemies: 1000,
+      taggedByDeathwave: 800,
+    })
+
+    const result = calculateMiniCoverageData(run)
+
+    expect(result).not.toBeNull()
+    const deathWaveMetric = result!.economicMetrics[0]
+    expect(deathWaveMetric.fieldName).toBe('taggedByDeathwave')
+    expect(deathWaveMetric.label).toBe('Death Wave')
+    expect(deathWaveMetric.color).toBe('#ef4444')
+  })
+})

--- a/src/features/game-runs/card-view/coverage-report/mini-coverage-calculations.ts
+++ b/src/features/game-runs/card-view/coverage-report/mini-coverage-calculations.ts
@@ -1,0 +1,67 @@
+/**
+ * Mini Coverage Report Calculations
+ *
+ * Pure functions for calculating coverage metrics for a single run.
+ * Composes existing coverage calculation functions from the analysis feature.
+ */
+
+import type { ParsedGameRun } from '@/shared/types/game-run.types'
+import type { MetricCoverage, MetricCategory } from '@/features/analysis/coverage-report/types'
+import {
+  hasValidCoverageData,
+  calculateMetricCoverageForRun,
+  filterNonZeroCoverage,
+  sortMetricsByPercentage,
+} from '@/features/analysis/coverage-report/calculations/coverage-calculations'
+import {
+  getEconomicMetrics,
+  getCombatMetrics,
+} from '@/features/analysis/coverage-report/coverage-config'
+
+export { hasValidCoverageData }
+
+/**
+ * Coverage data grouped by category for display
+ */
+export interface MiniCoverageData {
+  economicMetrics: MetricCoverage[]
+  combatMetrics: MetricCoverage[]
+}
+
+/**
+ * Calculate coverage metrics for a category from a single run
+ * Returns metrics sorted by percentage descending, filtered to non-zero values
+ */
+function calculateCategoryMetrics(
+  run: ParsedGameRun,
+  category: MetricCategory
+): MetricCoverage[] {
+  const metricDefinitions = category === 'economic' ? getEconomicMetrics() : getCombatMetrics()
+
+  const metrics = metricDefinitions.map((metric) => calculateMetricCoverageForRun(run, metric))
+
+  return sortMetricsByPercentage(filterNonZeroCoverage(metrics))
+}
+
+/**
+ * Calculate all coverage metrics for a single run
+ * Returns null if the run has no valid coverage data (no totalEnemies)
+ */
+export function calculateMiniCoverageData(run: ParsedGameRun): MiniCoverageData | null {
+  if (!hasValidCoverageData(run)) {
+    return null
+  }
+
+  const economicMetrics = calculateCategoryMetrics(run, 'economic')
+  const combatMetrics = calculateCategoryMetrics(run, 'combat')
+
+  // Return null if both categories are empty (all metrics zero)
+  if (economicMetrics.length === 0 && combatMetrics.length === 0) {
+    return null
+  }
+
+  return {
+    economicMetrics,
+    combatMetrics,
+  }
+}

--- a/src/features/game-runs/card-view/coverage-report/mini-coverage-report.tsx
+++ b/src/features/game-runs/card-view/coverage-report/mini-coverage-report.tsx
@@ -1,0 +1,80 @@
+/**
+ * Mini Coverage Report Component
+ *
+ * Compact coverage report for run details.
+ * Displays 9 coverage metrics in a two-column layout (Economic / Combat).
+ */
+
+import type { ParsedGameRun } from '@/shared/types/game-run.types'
+import type { MetricCoverage } from '@/features/analysis/coverage-report/types'
+import { useMiniCoverageReport } from './use-mini-coverage-report'
+import { CoverageBar } from './mini-coverage-bar'
+
+interface MiniCoverageReportProps {
+  run: ParsedGameRun
+}
+
+interface CoverageColumnProps {
+  title: string
+  subtitle: string
+  metrics: MetricCoverage[]
+}
+
+function CoverageColumn({ title, subtitle, metrics }: CoverageColumnProps) {
+  if (metrics.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-0.5">
+        <h6 className="text-xs text-muted-foreground uppercase tracking-wide font-medium">
+          {title}
+        </h6>
+        <p className="text-[11px] text-muted-foreground/50">{subtitle}</p>
+      </div>
+      <div className="space-y-2.5">
+        {metrics.map((metric) => (
+          <CoverageBar key={metric.fieldName} metric={metric} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export function MiniCoverageReport({ run }: MiniCoverageReportProps) {
+  const coverageData = useMiniCoverageReport(run)
+
+  // Don't render if no valid coverage data
+  if (!coverageData) {
+    return null
+  }
+
+  const { economicMetrics, combatMetrics } = coverageData
+
+  return (
+    <div className="space-y-4">
+      <div className="border-b border-border/40 pb-2">
+        <h5 className="font-semibold text-base text-primary">
+          Coverage Report
+        </h5>
+        <p className="text-xs text-muted-foreground/70 mt-0.5">
+          Percentage of enemies affected by each mechanic
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-6">
+        <CoverageColumn
+          title="Economic"
+          subtitle="Tagged, killed in range, or summoned"
+          metrics={economicMetrics}
+        />
+        <CoverageColumn
+          title="Combat"
+          subtitle="Kills (or Hits where specified)"
+          metrics={combatMetrics}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/features/game-runs/card-view/coverage-report/use-mini-coverage-report.ts
+++ b/src/features/game-runs/card-view/coverage-report/use-mini-coverage-report.ts
@@ -1,0 +1,17 @@
+/**
+ * Mini Coverage Report Hook
+ *
+ * Provides memoized coverage data for a single run.
+ */
+
+import { useMemo } from 'react'
+import type { ParsedGameRun } from '@/shared/types/game-run.types'
+import { calculateMiniCoverageData, type MiniCoverageData } from './mini-coverage-calculations'
+
+/**
+ * Calculate and memoize coverage data for a run
+ * Returns null if run has no valid coverage data
+ */
+export function useMiniCoverageReport(run: ParsedGameRun): MiniCoverageData | null {
+  return useMemo(() => calculateMiniCoverageData(run), [run])
+}

--- a/src/features/game-runs/card-view/run-details.tsx
+++ b/src/features/game-runs/card-view/run-details.tsx
@@ -2,6 +2,7 @@ import type { ParsedGameRun, RunTypeValue } from '@/shared/types/game-run.types'
 import { getFieldDisplayConfig } from '../fields/field-display-config';
 import { buildContainerClassName, buildValueClassName } from '../fields/field-rendering-utils';
 import { EditableUserFields } from '../editing/editable-user-fields';
+import { MiniCoverageReport } from './coverage-report/mini-coverage-report';
 import { useData } from '@/shared/domain/use-data';
 import {
   createUpdatedNotesFields,
@@ -183,6 +184,8 @@ export function RunDetails({ run }: RunDetailsProps) {
         rank={rank}
         onSave={handleUserFieldsUpdate}
       />
+
+      <MiniCoverageReport run={run} />
 
       {Object.entries(STAT_GROUPS).filter(([groupTitle]) => groupTitle !== "__SKIP__").map(([groupTitle, fields]) => (
         <StatGroup

--- a/src/features/game-runs/table/virtualized-desktop-row.tsx
+++ b/src/features/game-runs/table/virtualized-desktop-row.tsx
@@ -76,7 +76,7 @@ export function VirtualizedDesktopRow({
       {row.getIsExpanded() && (
         // eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
         <div
-          className="bg-muted/15 border-t border-border/50"
+          className="bg-muted/15 border-t border-border/50 cursor-default"
           onClick={(e) => e.stopPropagation()}
         >
           <div className="p-4 sm:p-5 md:p-6 space-y-4">{children}</div>


### PR DESCRIPTION
## Summary
Users can now see coverage percentages at a glance when viewing run details, without manually calculating or navigating away to the Analytics page. A new "Coverage Report" section displays 9 key metrics as horizontal bar charts organized into Economic (coin/cell income) and Combat (damage/destruction) columns.

## Technical Details
- Added `coverage-report/` directory under `src/features/game-runs/card-view/` with mini coverage components
- Created `mini-coverage-calculations.ts` with pure functions composing existing coverage calculation utilities
- Implemented div-based horizontal bars (not Recharts) for lightweight, fast rendering
- Added unit tests for all calculation edge cases (zero values, >100% coverage, missing fields)
- Renamed "Orb Kills" to "Orbs" for brevity in coverage config
- Added category subheadings ("Tagged, killed in range, or summoned" / "Kills (or Hits where specified)")
- Integrated into `run-details.tsx` between User Fields and Battle Report sections
- Added `cursor-default` to expanded row container to prevent pointer cursor on details area

## Context
Lazy rendering via existing `row.getIsExpanded()` pattern ensures no performance impact from rendering coverage bars for collapsed rows.