### PR TITLE
IMPROVE: Add support for Electrons Damage field in analytics and run details

### DIFF
--- a/sampleData/supportedFields.json
+++ b/sampleData/supportedFields.json
@@ -39,6 +39,7 @@
     "deathWaveDamage",
     "swampDamage",
     "blackHoleDamage",
+    "electronsDamage",
     "wavesSkipped",
     "recoveryPackages",
     "freeAttackUpgrade",

--- a/src/features/analysis/source-analysis/category-config.ts
+++ b/src/features/analysis/source-analysis/category-config.ts
@@ -35,6 +35,7 @@ const SOURCE_COLORS = {
   projectilesDamage: '#e879f9', // Fuchsia-400 - Pink-ish (Lighter than Black Hole)
   lifesteal: '#f43f5e', // Rose-500 - Red/Pink
   flameBotDamage: '#fca5a5', // Red-300 - Light Red
+  electronsDamage: '#0ED1EB', // Turquoise - Matches in-game electron color
 
   // Coin sources - Aligned with source themes where possible
   coinsFromGoldenTower: '#eab308', // Yellow-500 - Pure Gold
@@ -98,6 +99,7 @@ const DAMAGE_DEALT_CATEGORY: CategoryDefinition = {
     { fieldName: 'projectilesDamage', displayName: 'Projectiles Damage', color: SOURCE_COLORS.projectilesDamage },
     { fieldName: 'lifesteal', displayName: 'Lifesteal', color: SOURCE_COLORS.lifesteal },
     { fieldName: 'flameBotDamage', displayName: 'Flame Bot Damage', color: SOURCE_COLORS.flameBotDamage },
+    { fieldName: 'electronsDamage', displayName: 'Electrons Damage', color: SOURCE_COLORS.electronsDamage },
   ]
 };
 

--- a/src/features/game-runs/card-view/run-details.tsx
+++ b/src/features/game-runs/card-view/run-details.tsx
@@ -25,12 +25,12 @@ const STAT_GROUPS = {
     "gemBlocksTapped", "cellsEarned", "rerollShardsEarned"
   ],
   "Combat": [
-    "damageDealt","damageTaken", "damageTakenWall", "damageTakenWhileBerserked", "damageGainFromBerserk", "deathDefy", 
+    "damageDealt","damageTaken", "damageTakenWall", "damageTakenWhileBerserked", "damageGainFromBerserk", "deathDefy",
     "lifesteal", "projectilesDamage", "projectilesCount", "thornDamage",
-    "orbHits","orbDamage", "enemiesHitByOrbs", 
-    "landMineDamage", "landMinesSpawned", "rendArmorDamage", "deathRayDamage", 
-    "smartMissileDamage", "innerLandMineDamage", "chainLightningDamage", 
-    "deathWaveDamage", "taggedByDeathwave" ,"swampDamage", "blackHoleDamage", 
+    "orbHits","orbDamage", "enemiesHitByOrbs",
+    "landMineDamage", "landMinesSpawned", "rendArmorDamage", "deathRayDamage",
+    "smartMissileDamage", "innerLandMineDamage", "chainLightningDamage",
+    "deathWaveDamage", "taggedByDeathwave" ,"swampDamage", "blackHoleDamage", "electronsDamage",
   ],
   "Utility": [     
     "wavesSkipped", "recoveryPackages", 


### PR DESCRIPTION
## Summary
Adds support for the new "Electrons Damage" game field that was recently added to The Tower. Players can now see their electron damage stats in run details and analyze electron damage contribution in source analysis charts.

## Technical Details
- Added `electronsDamage` to Combat stats group in `run-details.tsx` for display in expandable run details
- Added turquoise color (`#0ED1EB`) matching in-game electron visual to `category-config.ts`
- Added `electronsDamage` as a source in the Damage Dealt category for source analysis charts
- Updated `supportedFields.json` documentation with the new field