### PR TITLE
IMPROVE: Add vertical label layout support to analytics filter selectors

### DIFF
--- a/src/components/ui/form-field-types.ts
+++ b/src/components/ui/form-field-types.ts
@@ -1,0 +1,33 @@
+/**
+ * Form Field Layout Types
+ *
+ * Shared styling types for form controls and selector components.
+ * These are UI-layer concerns used across multiple domain selectors.
+ */
+
+/**
+ * Available accent colors for selector components
+ * Provides visual theming for different feature areas
+ */
+type AccentColor = 'orange' | 'purple' | 'cyan'
+
+/**
+ * Layout direction for selector label placement
+ * - 'horizontal': Label and control on same row
+ * - 'vertical': Label above control
+ * - 'auto': Vertical on mobile, horizontal on desktop
+ */
+export type SelectorLayout = 'horizontal' | 'vertical' | 'auto'
+
+/**
+ * Common styling props shared across all selector components
+ * Provides consistent visual configuration options
+ */
+export interface SelectorStyleProps {
+  /** Optional className for the wrapper */
+  className?: string
+  /** Accent color theme. Defaults to 'orange'. */
+  accentColor?: AccentColor
+  /** Label layout direction. Defaults to 'auto' (horizontal on desktop, vertical on mobile). */
+  layout?: SelectorLayout
+}

--- a/src/components/ui/form-field.tsx
+++ b/src/components/ui/form-field.tsx
@@ -1,4 +1,5 @@
 import { cn } from "../../shared/lib/utils"
+import type { SelectorLayout } from "./form-field-types"
 
 interface FormFieldProps {
   children: React.ReactNode
@@ -20,7 +21,7 @@ interface FormControlProps {
   className?: string
   labelClassName?: string
   controlsClassName?: string
-  layout?: 'horizontal' | 'vertical' | 'auto'
+  layout?: SelectorLayout
   labelWidth?: string
 }
 

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -8,6 +8,7 @@ export * from "./chart";
 export * from "./dialog";
 export * from "./empty-state";
 export * from "./form-field";
+export * from "./form-field-types";
 export * from "./form-label";
 export * from "./info-box";
 export * from "./input";

--- a/src/features/analysis/coverage-report/filters/coverage-report-filters.tsx
+++ b/src/features/analysis/coverage-report/filters/coverage-report-filters.tsx
@@ -50,11 +50,12 @@ export function CoverageReportFiltersComponent({
       />
 
       {/* Row 2: Run Type + Tier */}
-      <div className="flex flex-wrap gap-4 items-center">
+      <div className="flex flex-wrap gap-4 items-end">
         <RunTypeSelector
           selectedType={filters.runType}
           onTypeChange={onRunTypeChange}
           accentColor="cyan"
+          layout="vertical"
         />
 
         <TierSelector
@@ -62,16 +63,18 @@ export function CoverageReportFiltersComponent({
           onTierChange={onTierChange}
           availableTiers={availableTiers}
           accentColor="cyan"
+          layout="vertical"
         />
       </div>
 
       {/* Row 3: Duration + Period Count */}
-      <div className="flex flex-wrap gap-4 items-center">
+      <div className="flex flex-wrap gap-4 items-end">
         <DurationSelector
           selectedDuration={filters.duration}
           onDurationChange={onDurationChange}
           availableDurations={availableDurations}
           accentColor="cyan"
+          layout="vertical"
         />
 
         <PeriodCountSelector
@@ -85,6 +88,7 @@ export function CoverageReportFiltersComponent({
           label={periodLabel}
           showAllOption={false}
           accentColor="cyan"
+          layout="vertical"
         />
       </div>
     </div>

--- a/src/features/analysis/source-analysis/filters/source-analysis-filters.tsx
+++ b/src/features/analysis/source-analysis/filters/source-analysis-filters.tsx
@@ -54,9 +54,9 @@ export function SourceAnalysisFiltersComponent({
 
   return (
     <div className="space-y-4">
-      {/* Row 1: Category + Run Type */}
-      <div className="flex flex-wrap gap-4 items-center">
-        <FormControl label="Category" layout="horizontal">
+      {/* Row 1: Category */}
+      <div className="flex flex-wrap gap-4 items-end">
+        <FormControl label="Category" layout="vertical">
           <SelectionButtonGroup<SourceCategory>
             options={categories.map(cat => ({ value: cat.id, label: cat.name }))}
             selectedValue={filters.category}
@@ -66,31 +66,34 @@ export function SourceAnalysisFiltersComponent({
             accentColor="purple"
           />
         </FormControl>
+      </div>
 
+      {/* Row 2: Run Type + Tier (related concepts) */}
+      <div className="flex flex-wrap gap-4 items-end">
         <RunTypeSelector
           selectedType={filters.runType}
           onTypeChange={onRunTypeChange}
           accentColor="purple"
+          layout="vertical"
         />
-      </div>
 
-      {/* Row 2: Tier (can grow with many options) */}
-      <div className="flex flex-wrap gap-4 items-center">
         <TierSelector
           selectedTier={filters.tier}
           onTierChange={onTierChange}
           availableTiers={availableTiers}
           accentColor="purple"
+          layout="vertical"
         />
       </div>
 
       {/* Row 3: Duration + Period Count */}
-      <div className="flex flex-wrap gap-4 items-center">
+      <div className="flex flex-wrap gap-4 items-end">
         <DurationSelector
           selectedDuration={unifiedDuration}
           onDurationChange={(duration) => onDurationChange(durationToString(duration) as SourceDuration)}
           availableDurations={availableDurations}
           accentColor="purple"
+          layout="vertical"
         />
 
         <PeriodCountSelector
@@ -105,6 +108,7 @@ export function SourceAnalysisFiltersComponent({
           label={periodLabel}
           showAllOption={false}
           accentColor="purple"
+          layout="vertical"
         />
       </div>
     </div>

--- a/src/features/analysis/tier-stats/config/tier-stats-config-panel.tsx
+++ b/src/features/analysis/tier-stats/config/tier-stats-config-panel.tsx
@@ -36,24 +36,22 @@ export function TierStatsConfigPanel({ config }: TierStatsConfigPanelProps) {
   return (
     <div className="space-y-4">
       {/* Aggregation Selector - Always Visible */}
-      <div className="space-y-1.5">
-        <FormControl label="Aggregation Method">
+      <div className="flex flex-wrap items-end justify-between gap-4">
+        <FormControl label="Aggregation Method" layout="vertical">
           <div className="flex flex-col gap-1.5">
-            <div className="flex flex-wrap items-center justify-between gap-2">
-              <SelectionButtonGroup<TierStatsAggregation>
-                options={getAggregationOptions()}
-                selectedValue={config.aggregationType}
-                onSelectionChange={config.setAggregationType}
-                size="sm"
-                fullWidthOnMobile={false}
-              />
-              <FarmingOnlyIndicator />
-            </div>
+            <SelectionButtonGroup<TierStatsAggregation>
+              options={getAggregationOptions()}
+              selectedValue={config.aggregationType}
+              onSelectionChange={config.setAggregationType}
+              size="sm"
+              fullWidthOnMobile={false}
+            />
             <p className="text-xs text-slate-400">
               {getAggregationTooltip(config.aggregationType)}
             </p>
           </div>
         </FormControl>
+        <FarmingOnlyIndicator />
       </div>
 
       {/* Enhanced Toggle Button with Visual Prominence */}

--- a/src/features/analysis/tier-trends/filters/tier-trends-controls.tsx
+++ b/src/features/analysis/tier-trends/filters/tier-trends-controls.tsx
@@ -31,10 +31,11 @@ export function TierTrendsControls({
   return (
     <div className="space-y-4">
       {/* Row 1: Run Type & Tier */}
-      <div className="flex flex-wrap gap-4 items-center">
+      <div className="flex flex-wrap gap-4 items-end">
         <RunTypeSelector
           selectedType={runTypeFilter}
           onTypeChange={onRunTypeChange}
+          layout="vertical"
         />
         <TierSelector
           selectedTier={zeroToAllTierAdapter(filters.tier)}
@@ -42,13 +43,14 @@ export function TierTrendsControls({
           availableTiers={availableTiers}
           tierCounts={tierCounts}
           showCounts={Boolean(tierCounts)}
+          layout="vertical"
         />
       </div>
 
       {/* Row 2: Duration, Quantity, Aggregation */}
-      <div className="flex flex-wrap gap-4 items-center">
+      <div className="flex flex-wrap gap-4 items-end">
         {/* Duration Selector */}
-        <FormControl label="Duration">
+        <FormControl label="Duration" layout="vertical">
           <SelectionButtonGroup<TrendsDuration>
             options={[
               { value: TrendsDuration.PER_RUN, label: 'Per Run' },
@@ -73,7 +75,7 @@ export function TierTrendsControls({
         </FormControl>
 
         {/* Quantity Selector */}
-        <FormControl label={`Last ${getQuantityLabel(filters.duration)}`}>
+        <FormControl label={`Last ${getQuantityLabel(filters.duration)}`} layout="vertical">
           <SelectionButtonGroup<number>
             options={[2, 3, 4, 5, 6, 7].map(count => ({ value: count, label: count.toString() }))}
             selectedValue={filters.quantity}
@@ -85,7 +87,7 @@ export function TierTrendsControls({
         </FormControl>
 
         {/* Aggregation Selector */}
-        <FormControl label="Aggregation">
+        <FormControl label="Aggregation" layout="vertical">
           <SelectionButtonGroup<TrendsAggregation>
             options={getAggregationOptions(filters.duration)}
             selectedValue={filters.aggregationType || getDefaultAggregationType(filters.duration)}

--- a/src/features/analysis/time-series/time-series-chart.tsx
+++ b/src/features/analysis/time-series/time-series-chart.tsx
@@ -103,7 +103,7 @@ export function TimeSeriesChart({
         )}
 
         {/* Filter controls row */}
-        <div className="flex flex-wrap items-start justify-between gap-x-6 gap-y-4">
+        <div className="flex flex-wrap items-end justify-between gap-4">
           {/* Left side: Duration selector */}
           <FormControl label="Duration" layout="vertical">
             <div className="flex flex-wrap items-center gap-1.5 sm:gap-2">
@@ -119,7 +119,7 @@ export function TimeSeriesChart({
           </FormControl>
 
           {/* Right side: Run type selector + Data points count */}
-          <div className="flex items-start gap-4">
+          <div className="flex items-end gap-4">
             {showRunTypeSelector && onRunTypeChange && (
               <RunTypeSelector
                 selectedType={runTypeFilter}

--- a/src/shared/domain/filters/duration/duration-selector.tsx
+++ b/src/shared/domain/filters/duration/duration-selector.tsx
@@ -8,18 +8,15 @@
 import { FormControl } from '@/components/ui/form-field'
 import { SelectionButtonGroup, type SelectionOption } from '@/components/ui'
 import { Duration, DURATION_LABELS } from '../types'
+import type { SelectorStyleProps } from '../types'
 
-interface DurationSelectorProps {
+interface DurationSelectorProps extends SelectorStyleProps {
   /** Currently selected duration */
   selectedDuration: Duration
   /** Callback when duration selection changes */
   onDurationChange: (duration: Duration) => void
   /** Available durations based on data span */
   availableDurations: Duration[]
-  /** Optional className for the wrapper */
-  className?: string
-  /** Accent color theme */
-  accentColor?: 'orange' | 'purple' | 'cyan'
   /** Label for the selector */
   label?: string
 }
@@ -42,12 +39,13 @@ export function DurationSelector({
   availableDurations,
   className,
   accentColor = 'orange',
-  label = 'Duration'
+  label = 'Duration',
+  layout = 'auto'
 }: DurationSelectorProps) {
   const options = buildDurationOptions(availableDurations)
 
   return (
-    <FormControl label={label} className={className}>
+    <FormControl label={label} className={className} layout={layout}>
       <SelectionButtonGroup<Duration>
         options={options}
         selectedValue={selectedDuration}

--- a/src/shared/domain/filters/index.ts
+++ b/src/shared/domain/filters/index.ts
@@ -5,7 +5,7 @@
  */
 
 // Types
-export { Duration,  PERIOD_UNIT_LABELS } from './types'
+export { Duration, PERIOD_UNIT_LABELS } from './types'
 
 // Tier filter - pure logic functions, hooks, and components
 export {

--- a/src/shared/domain/filters/period-count/period-count-selector.tsx
+++ b/src/shared/domain/filters/period-count/period-count-selector.tsx
@@ -7,9 +7,9 @@
 
 import { FormControl } from '@/components/ui/form-field'
 import { SelectionButtonGroup, type SelectionOption } from '@/components/ui'
-import type { PeriodCountFilter } from '../types'
+import type { PeriodCountFilter, SelectorStyleProps } from '../types'
 
-interface PeriodCountSelectorProps {
+interface PeriodCountSelectorProps extends SelectorStyleProps {
   /** Currently selected period count */
   selectedCount: PeriodCountFilter
   /** Callback when count selection changes */
@@ -20,10 +20,6 @@ interface PeriodCountSelectorProps {
   label: string
   /** Whether to include "All" option */
   showAllOption?: boolean
-  /** Optional className for the wrapper */
-  className?: string
-  /** Accent color theme */
-  accentColor?: 'orange' | 'purple' | 'cyan'
 }
 
 /**
@@ -53,12 +49,13 @@ export function PeriodCountSelector({
   label,
   showAllOption = true,
   className,
-  accentColor = 'orange'
+  accentColor = 'orange',
+  layout = 'auto'
 }: PeriodCountSelectorProps) {
   const options = buildCountOptions(countOptions, showAllOption)
 
   return (
-    <FormControl label={label} className={className}>
+    <FormControl label={label} className={className} layout={layout}>
       <SelectionButtonGroup<PeriodCountFilter>
         options={options}
         selectedValue={selectedCount}

--- a/src/shared/domain/filters/tier/tier-selector.tsx
+++ b/src/shared/domain/filters/tier/tier-selector.tsx
@@ -7,10 +7,10 @@
 
 import { FormControl } from '@/components/ui/form-field'
 import { SelectionButtonGroup, type SelectionOption } from '@/components/ui'
-import type { TierFilter } from '../types'
+import type { TierFilter, SelectorStyleProps } from '../types'
 import { formatTierLabel } from './tier-filter-logic'
 
-interface TierSelectorProps {
+interface TierSelectorProps extends SelectorStyleProps {
   /** Currently selected tier (number or 'all') */
   selectedTier: TierFilter
   /** Callback when tier selection changes */
@@ -23,10 +23,6 @@ interface TierSelectorProps {
   showCounts?: boolean
   /** Whether to include "All" option */
   showAllOption?: boolean
-  /** Optional className for the wrapper */
-  className?: string
-  /** Accent color theme */
-  accentColor?: 'orange' | 'purple' | 'cyan'
   /** Label for the selector */
   label?: string
 }
@@ -69,7 +65,8 @@ export function TierSelector({
   showAllOption = true,
   className,
   accentColor = 'orange',
-  label = 'Tier'
+  label = 'Tier',
+  layout = 'auto'
 }: TierSelectorProps) {
   const options = buildTierOptions(
     availableTiers,
@@ -79,7 +76,7 @@ export function TierSelector({
   )
 
   return (
-    <FormControl label={label} className={className}>
+    <FormControl label={label} className={className} layout={layout}>
       <SelectionButtonGroup<TierFilter>
         options={options}
         selectedValue={selectedTier}

--- a/src/shared/domain/filters/types.ts
+++ b/src/shared/domain/filters/types.ts
@@ -53,3 +53,9 @@ export const PERIOD_UNIT_LABELS: Record<Duration, PeriodUnitLabels> = {
   [Duration.MONTHLY]: { singular: 'Month', plural: 'Months' },
   [Duration.YEARLY]: { singular: 'Year', plural: 'Years' }
 }
+
+/**
+ * Re-export UI-layer styling types for backwards compatibility
+ * These types are owned by the UI layer but re-exported here for convenience
+ */
+export type {   SelectorStyleProps } from '@/components/ui/form-field-types'

--- a/src/shared/domain/run-types/run-type-selector.tsx
+++ b/src/shared/domain/run-types/run-type-selector.tsx
@@ -1,18 +1,14 @@
 import { FormControl, SelectionButtonGroup } from '@/components/ui'
 import { RunTypeFilter } from '@/features/analysis/shared/filtering/run-type-filter'
 import { getOptionsForMode, RunTypeSelectorMode, RunTypeCounts } from '../run-types/run-type-selector-options'
+import type { SelectorStyleProps } from '@/components/ui/form-field-types'
 
-interface RunTypeSelectorProps {
+interface RunTypeSelectorProps extends SelectorStyleProps {
   selectedType: RunTypeFilter
   onTypeChange: (type: RunTypeFilter) => void
-  className?: string
   mode?: RunTypeSelectorMode
   /** Optional counts per run type for display */
   counts?: RunTypeCounts
-  /** Accent color theme. Defaults to 'orange'. */
-  accentColor?: 'orange' | 'purple' | 'cyan'
-  /** Label layout direction. Defaults to 'auto' (horizontal on desktop, vertical on mobile). */
-  layout?: 'horizontal' | 'vertical' | 'auto'
 }
 
 export function RunTypeSelector({


### PR DESCRIPTION
## Summary
Filter selectors across analytics pages now support a configurable layout prop for label placement. This standardizes the visual appearance of filters by using vertical labels (label above control) consistently across tier-stats, tier-trends, source-analysis, and coverage-report pages. The change also reduces code duplication by extracting common styling props into a shared interface.

## Technical Details
- Created `SelectorStyleProps` interface in `form-field-types.ts` with `className`, `accentColor`, and `layout` props
- Added `layout` prop to `TierSelector`, `DurationSelector`, `PeriodCountSelector`, and `RunTypeSelector`
- Applied `layout="vertical"` across all analytics filter pages for consistent label placement
- Changed filter row alignment from `items-center` to `items-end` for proper vertical label alignment
- Restructured source-analysis filters to group RunType+Tier together (related concepts)
- Repositioned `FarmingOnlyIndicator` badge to right edge on tier-stats config panel
- Fixed gap and alignment inconsistencies in time-series-chart filter controls
- Re-exported styling types from filters index for backwards compatibility