### PR TITLE
REFACTOR: Unify field configuration for Run Details and Source Analysis

### DIFF
--- a/src/features/analysis/source-analysis/category-config.ts
+++ b/src/features/analysis/source-analysis/category-config.ts
@@ -2,52 +2,15 @@
  * Category Configuration for Source Analysis
  *
  * Defines the mapping between aggregate totals and their constituent sources.
- * This configuration-based approach enables easy addition of new categories.
+ * Uses shared field configurations to ensure consistency with Run Details.
  */
 
 import type { CategoryDefinition, SourceCategory } from './types';
-
-/**
- * Color palette for source visualization
- *
- * Design principles:
- * - Vibrant but not garish: Medium saturation with good luminance
- * - Highly distinguishable: Colors span the entire hue spectrum
- * - Dark theme optimized: Colors pop against slate-800/900 backgrounds
- * - Gradient-ready: Each color has a base (solid) and can generate gradients
- *
- * The palette uses distinct hues to ensure each source is easily identifiable,
- * even when many sources are stacked together.
- */
-const SOURCE_COLORS = {
-  // Damage sources - Game-aligned palette (Iteration 2)
-  orbDamage: '#ffe4e6', // Rose-100 - White with a hint of red
-  thornDamage: '#22d3ee', // Cyan-400 - Teal-ish (Bright)
-  landMineDamage: '#9333ea', // Purple-600 - Purple-ish (Deep)
-  deathRayDamage: '#ff5722', // Deep Orange - Orangish Red
-  chainLightningDamage: '#3b82f6', // Blue-500 - Electric Blue
-  deathWaveDamage: '#ef4444', // Red-500 - Reddish (Standard)
-  blackHoleDamage: '#d946ef', // Fuchsia-500 - Purple-ish (Vibrant)
-  smartMissileDamage: '#14b8a6', // Teal-500 - Tech Green
-  swampDamage: '#84cc16', // Lime-500 - Toxic Green
-  innerLandMineDamage: '#f59e0b', // Amber-500 - Gold/Orange
-  rendArmorDamage: '#f472b6', // Pink-400 - Light Pink
-  projectilesDamage: '#e879f9', // Fuchsia-400 - Pink-ish (Lighter than Black Hole)
-  lifesteal: '#f43f5e', // Rose-500 - Red/Pink
-  flameBotDamage: '#fca5a5', // Red-300 - Light Red
-  electronsDamage: '#0ED1EB', // Turquoise - Matches in-game electron color
-
-  // Coin sources - Aligned with source themes where possible
-  coinsFromGoldenTower: '#eab308', // Yellow-500 - Pure Gold
-  coinsFromBlackHole: '#e879f9', // Fuchsia-400 - Matches Black Hole theme (Lighter)
-  coinsFromSpotlight: '#facc15', // Yellow-400 - Bright Light
-  coinsFromOrbs: '#fda4af', // Rose-300 - Matches Orb theme (Darker than damage for visibility)
-  coinsFromCoinBonuses: '#4ade80', // Green-400 - Money Green
-  coinsFromDeathWave: '#f87171', // Red-400 - Matches Death Wave theme
-  goldenBotCoinsEarned: '#fbbf24', // Amber-400 - Warm Gold
-  coinsFromCoinUpgrade: '#22d3ee', // Cyan-400 - Digital/Future money
-  coinsFetched: '#10b981', // Emerald-500 - Guardian wealth/emerald theme
-};
+import {
+  DAMAGE_DEALT_CATEGORY as SHARED_DAMAGE_CATEGORY,
+  COINS_EARNED_CATEGORY as SHARED_COINS_CATEGORY,
+  COIN_FIELD_ALIASES,
+} from '@/shared/domain/fields/breakdown-sources';
 
 /**
  * Gradient definitions for enhanced visual depth
@@ -69,71 +32,49 @@ export function getGradientConfig(fieldName: string, color: string): GradientCon
   return {
     id: `gradient-${fieldName}`,
     startColor: color,
-    startOpacity: 0.85, // Slightly reduced from 0.9 for less harsh top edge
+    startOpacity: 0.85,
     endColor: color,
-    endOpacity: 0.15, // Significantly reduced from 0.4 for better fade-out
+    endOpacity: 0.15,
   };
 }
 
-
 /**
  * Damage Dealt category definition
+ * Derived from shared configuration for consistency with Run Details
  */
 const DAMAGE_DEALT_CATEGORY: CategoryDefinition = {
   id: 'damageDealt',
-  name: 'Damage Dealt',
-  description: 'Breakdown of damage sources contributing to total damage dealt',
-  totalField: 'damageDealt',
-  sources: [
-    { fieldName: 'orbDamage', displayName: 'Orb Damage', color: SOURCE_COLORS.orbDamage },
-    { fieldName: 'thornDamage', displayName: 'Thorn Damage', color: SOURCE_COLORS.thornDamage },
-    { fieldName: 'landMineDamage', displayName: 'Land Mine Damage', color: SOURCE_COLORS.landMineDamage },
-    { fieldName: 'deathRayDamage', displayName: 'Death Ray Damage', color: SOURCE_COLORS.deathRayDamage },
-    { fieldName: 'chainLightningDamage', displayName: 'Chain Lightning', color: SOURCE_COLORS.chainLightningDamage },
-    { fieldName: 'deathWaveDamage', displayName: 'Death Wave Damage', color: SOURCE_COLORS.deathWaveDamage },
-    { fieldName: 'blackHoleDamage', displayName: 'Black Hole Damage', color: SOURCE_COLORS.blackHoleDamage },
-    { fieldName: 'smartMissileDamage', displayName: 'Smart Missile Damage', color: SOURCE_COLORS.smartMissileDamage },
-    { fieldName: 'swampDamage', displayName: 'Swamp Damage', color: SOURCE_COLORS.swampDamage },
-    { fieldName: 'innerLandMineDamage', displayName: 'Inner Land Mine', color: SOURCE_COLORS.innerLandMineDamage },
-    { fieldName: 'rendArmorDamage', displayName: 'Rend Armor Damage', color: SOURCE_COLORS.rendArmorDamage },
-    { fieldName: 'projectilesDamage', displayName: 'Projectiles Damage', color: SOURCE_COLORS.projectilesDamage },
-    { fieldName: 'lifesteal', displayName: 'Lifesteal', color: SOURCE_COLORS.lifesteal },
-    { fieldName: 'flameBotDamage', displayName: 'Flame Bot Damage', color: SOURCE_COLORS.flameBotDamage },
-    { fieldName: 'electronsDamage', displayName: 'Electrons Damage', color: SOURCE_COLORS.electronsDamage },
-  ]
+  name: SHARED_DAMAGE_CATEGORY.name,
+  description: SHARED_DAMAGE_CATEGORY.description ?? 'Breakdown of damage sources contributing to total damage dealt',
+  totalField: SHARED_DAMAGE_CATEGORY.totalField!,
+  sources: SHARED_DAMAGE_CATEGORY.fields.map((f) => ({
+    fieldName: f.fieldName,
+    displayName: f.displayName,
+    color: f.color,
+  })),
 };
 
 /**
  * Coin Income category definition
- * Handles field name variations (e.g., coinsFromBlackHole vs coinsFromBlackhole)
+ * Derived from shared configuration for consistency with Run Details
  */
 const COIN_INCOME_CATEGORY: CategoryDefinition = {
   id: 'coinIncome',
-  name: 'Coin Income',
-  description: 'Breakdown of coin income sources',
-  totalField: 'coinsEarned',
-  sources: [
-    { fieldName: 'coinsFromGoldenTower', displayName: 'Golden Tower', color: SOURCE_COLORS.coinsFromGoldenTower },
-    { fieldName: 'coinsFromBlackHole', displayName: 'Black Hole', color: SOURCE_COLORS.coinsFromBlackHole },
-    { fieldName: 'coinsFromSpotlight', displayName: 'Spotlight', color: SOURCE_COLORS.coinsFromSpotlight },
-    { fieldName: 'coinsFromOrbs', displayName: 'Orbs', color: SOURCE_COLORS.coinsFromOrbs },
-    { fieldName: 'coinsFromCoinBonuses', displayName: 'Coin Bonuses', color: SOURCE_COLORS.coinsFromCoinBonuses },
-    { fieldName: 'coinsFromDeathWave', displayName: 'Death Wave', color: SOURCE_COLORS.coinsFromDeathWave },
-    { fieldName: 'goldenBotCoinsEarned', displayName: 'Golden Bot', color: SOURCE_COLORS.goldenBotCoinsEarned },
-    { fieldName: 'coinsFromCoinUpgrade', displayName: 'Coin Upgrade', color: SOURCE_COLORS.coinsFromCoinUpgrade },
-    { fieldName: 'coinsFetched', displayName: 'Coins Fetched', color: SOURCE_COLORS.coinsFetched },
-  ]
+  name: SHARED_COINS_CATEGORY.name,
+  description: SHARED_COINS_CATEGORY.description ?? 'Breakdown of coin income sources',
+  totalField: SHARED_COINS_CATEGORY.totalField!,
+  sources: SHARED_COINS_CATEGORY.fields.map((f) => ({
+    fieldName: f.fieldName,
+    displayName: f.displayName,
+    color: f.color,
+  })),
 };
 
 /**
  * Field name aliases to handle variations in game data
+ * Derived from shared configuration
  */
-export const FIELD_ALIASES: Record<string, string[]> = {
-  coinsFromGoldenTower: ['cashFromGoldenTower'],
-  coinsFromBlackHole: ['coinsFromBlackhole'],
-  coinsFromOrbs: ['coinsFromOrb'],
-  coinsFromCoinBonuses: ['coinsFromCoinUpgrade'],
-};
+export const FIELD_ALIASES: Record<string, string[]> = COIN_FIELD_ALIASES;
 
 /**
  * All category definitions

--- a/src/features/game-runs/card-view/run-details/section-config.ts
+++ b/src/features/game-runs/card-view/run-details/section-config.ts
@@ -9,6 +9,10 @@ import type {
   BreakdownConfig,
   PlainFieldsConfig,
 } from './types'
+import {
+  DAMAGE_DEALT_CATEGORY,
+  COINS_EARNED_CATEGORY,
+} from '@/shared/domain/fields/breakdown-sources'
 
 // =============================================================================
 // Battle Report Section
@@ -41,26 +45,13 @@ export const BATTLE_REPORT_MISCELLANEOUS: PlainFieldsConfig = {
 // =============================================================================
 
 export const DAMAGE_DEALT_CONFIG: BreakdownConfig = {
-  totalField: 'damageDealt',
-  label: 'DAMAGE DEALT',
-  sources: [
-    { fieldName: 'deathWaveDamage', displayName: 'Death Wave', color: '#ef4444' },
-    { fieldName: 'chainLightningDamage', displayName: 'Chain Lightning', color: '#3b82f6' },
-    { fieldName: 'thornDamage', displayName: 'Thorn', color: '#22d3ee' },
-    { fieldName: 'orbDamage', displayName: 'Orb', color: '#f87171' },
-    { fieldName: 'flameBotDamage', displayName: 'Flame Bot Damage', color: '#fbbf24' },
-    { fieldName: 'damage', displayName: 'Guardian Damage', color: '#a855f7' },
-    { fieldName: 'landMineDamage', displayName: 'Land Mine', color: '#9333ea' },
-    { fieldName: 'deathRayDamage', displayName: 'Death Ray', color: '#ff5722' },
-    { fieldName: 'smartMissileDamage', displayName: 'Smart Missile', color: '#64748b' },
-    { fieldName: 'innerLandMineDamage', displayName: 'Inner Land Mine', color: '#7c3aed' },
-    { fieldName: 'swampDamage', displayName: 'Swamp', color: '#22c55e' },
-    { fieldName: 'blackHoleDamage', displayName: 'Black Hole', color: '#475569' },
-    { fieldName: 'electronsDamage', displayName: 'Electrons', color: '#06b6d4' },
-    { fieldName: 'projectilesDamage', displayName: 'Projectiles', color: '#f59e0b' },
-    { fieldName: 'rendArmorDamage', displayName: 'Rend Armor', color: '#dc2626' },
-    { fieldName: 'lifesteal', displayName: 'Lifesteal', color: '#f43f5e' }
-  ],
+  totalField: DAMAGE_DEALT_CATEGORY.totalField!,
+  label: DAMAGE_DEALT_CATEGORY.name.toUpperCase(),
+  sources: DAMAGE_DEALT_CATEGORY.fields.map((f) => ({
+    fieldName: f.fieldName,
+    displayName: f.displayName,
+    color: f.color,
+  })),
 }
 
 export const DAMAGE_TAKEN_CONFIG: PlainFieldsConfig = {
@@ -132,22 +123,14 @@ export const ENEMIES_AFFECTED_BY_CONFIG: BreakdownConfig = {
 // =============================================================================
 
 export const COINS_EARNED_CONFIG: BreakdownConfig = {
-  totalField: 'coinsEarned',
-  label: 'COINS EARNED',
-  perHourField: 'coinsPerHour',
-  sources: [
-    { fieldName: 'coinsFromDeathWave', displayName: 'Death Wave', color: '#ef4444' },
-    { fieldName: 'coinsFromGoldenTower', displayName: 'Golden Tower', color: '#fbbf24' },    
-    { fieldName: 'coinsFromSpotlight', displayName: 'Spotlight', color: '#e2e8f0' },
-    { fieldName: 'goldenBotCoinsEarned', displayName: 'Golden Bot', color: '#fbbf24' },
-    { fieldName: 'guardianCoinsStolen', displayName: 'Guardian Stolen', color: '#a855f7' },
-    { fieldName: 'coinsStolen', displayName: 'Coins Stolen', color: '#8b5cf6' },
-    { fieldName: 'coinsFetched', displayName: 'Guardian Fetched', color: '#7c3aed' },
-    { fieldName: 'coinsFromBlackHole', displayName: 'Black Hole', color: '#475569' },
-    { fieldName: 'coinsFromBlackhole', displayName: 'Black Hole', color: '#475569' },
-    { fieldName: 'coinsFromCoinUpgrade', displayName: 'Coin Upgrade', color: '#f59e0b' },
-    { fieldName: 'coinsFromCoinBonuses', displayName: 'Coin Bonuses', color: '#fb923c' },
-  ],
+  totalField: COINS_EARNED_CATEGORY.totalField!,
+  label: COINS_EARNED_CATEGORY.name.toUpperCase(),
+  perHourField: COINS_EARNED_CATEGORY.perHourField,
+  sources: COINS_EARNED_CATEGORY.fields.map((f) => ({
+    fieldName: f.fieldName,
+    displayName: f.displayName,
+    color: f.color,
+  })),
 }
 
 export const OTHER_EARNINGS_CONFIG: PlainFieldsConfig = {

--- a/src/shared/domain/fields/breakdown-sources/breakdown-sources.test.ts
+++ b/src/shared/domain/fields/breakdown-sources/breakdown-sources.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DAMAGE_FIELDS,
+  COIN_FIELDS,
+  DAMAGE_DEALT_CATEGORY,
+  COINS_EARNED_CATEGORY,
+  COIN_FIELD_ALIASES,
+  DAMAGE_FIELD_ALIASES,
+  buildFieldAliasMap,
+} from './index';
+import type { FieldConfig } from './types';
+
+describe('Damage Fields Configuration', () => {
+  it('should have 16 damage sources', () => {
+    expect(DAMAGE_FIELDS).toHaveLength(16);
+  });
+
+  it('should have all required properties for each field', () => {
+    for (const field of DAMAGE_FIELDS) {
+      expect(field.fieldName).toBeTruthy();
+      expect(field.displayName).toBeTruthy();
+      expect(field.color).toMatch(/^#[0-9a-fA-F]{6}$/);
+    }
+  });
+
+  it('should have no duplicate field names', () => {
+    const fieldNames = DAMAGE_FIELDS.map((f) => f.fieldName);
+    const uniqueNames = new Set(fieldNames);
+    expect(uniqueNames.size).toBe(fieldNames.length);
+  });
+
+  it('should include Guardian Damage (damage field)', () => {
+    const guardianDamage = DAMAGE_FIELDS.find((f) => f.fieldName === 'damage');
+    expect(guardianDamage).toBeDefined();
+    expect(guardianDamage?.displayName).toBe('Guardian Damage');
+  });
+
+  it('should use clean display names without suffixes', () => {
+    const deathWave = DAMAGE_FIELDS.find(
+      (f) => f.fieldName === 'deathWaveDamage'
+    );
+    expect(deathWave?.displayName).toBe('Death Wave');
+
+    const orb = DAMAGE_FIELDS.find((f) => f.fieldName === 'orbDamage');
+    expect(orb?.displayName).toBe('Orb');
+  });
+});
+
+describe('Coin Fields Configuration', () => {
+  it('should have 11 coin sources', () => {
+    expect(COIN_FIELDS).toHaveLength(11);
+  });
+
+  it('should have all required properties for each field', () => {
+    for (const field of COIN_FIELDS) {
+      expect(field.fieldName).toBeTruthy();
+      expect(field.displayName).toBeTruthy();
+      expect(field.color).toMatch(/^#[0-9a-fA-F]{6}$/);
+    }
+  });
+
+  it('should have no duplicate field names', () => {
+    const fieldNames = COIN_FIELDS.map((f) => f.fieldName);
+    const uniqueNames = new Set(fieldNames);
+    expect(uniqueNames.size).toBe(fieldNames.length);
+  });
+
+  it('should include guardianCoinsStolen', () => {
+    const guardianStolen = COIN_FIELDS.find(
+      (f) => f.fieldName === 'guardianCoinsStolen'
+    );
+    expect(guardianStolen).toBeDefined();
+    expect(guardianStolen?.displayName).toBe('Guardian Stolen');
+  });
+
+  it('should include coinsStolen', () => {
+    const coinsStolen = COIN_FIELDS.find((f) => f.fieldName === 'coinsStolen');
+    expect(coinsStolen).toBeDefined();
+    expect(coinsStolen?.displayName).toBe('Coins Stolen');
+  });
+
+  it('should include coinsFromOrbs', () => {
+    const coinsFromOrbs = COIN_FIELDS.find(
+      (f) => f.fieldName === 'coinsFromOrb'
+    );
+    expect(coinsFromOrbs).toBeDefined();
+    expect(coinsFromOrbs?.displayName).toBe('Orbs');
+  });
+
+  it('should have alias for coinsFromBlackHole (casing variation)', () => {
+    const blackHole = COIN_FIELDS.find(
+      (f) => f.fieldName === 'coinsFromBlackHole'
+    );
+    expect(blackHole?.aliases).toContain('coinsFromBlackhole');
+  });
+
+  it('should have alias for coinsFromOrbs (singular variation)', () => {
+    const orbs = COIN_FIELDS.find((f) => f.fieldName === 'coinsFromOrb');
+    expect(orbs?.aliases).toContain('coinsFromOrbs');
+  });
+
+  it('should NOT have cashFromGoldenTower as an alias (separate currency)', () => {
+    const goldenTower = COIN_FIELDS.find(
+      (f) => f.fieldName === 'coinsFromGoldenTower'
+    );
+    expect(goldenTower?.aliases).toBeUndefined();
+  });
+});
+
+describe('Damage Dealt Category', () => {
+  it('should have correct id', () => {
+    expect(DAMAGE_DEALT_CATEGORY.id).toBe('damageDealt');
+  });
+
+  it('should have correct name', () => {
+    expect(DAMAGE_DEALT_CATEGORY.name).toBe('Damage Dealt');
+  });
+
+  it('should have totalField set to damageDealt', () => {
+    expect(DAMAGE_DEALT_CATEGORY.totalField).toBe('damageDealt');
+  });
+
+  it('should have all damage fields', () => {
+    expect(DAMAGE_DEALT_CATEGORY.fields).toHaveLength(16);
+  });
+
+  it('should not have perHourField', () => {
+    expect(DAMAGE_DEALT_CATEGORY.perHourField).toBeUndefined();
+  });
+});
+
+describe('Coins Earned Category', () => {
+  it('should have correct id', () => {
+    expect(COINS_EARNED_CATEGORY.id).toBe('coinsEarned');
+  });
+
+  it('should have correct name', () => {
+    expect(COINS_EARNED_CATEGORY.name).toBe('Coins Earned');
+  });
+
+  it('should have totalField set to coinsEarned', () => {
+    expect(COINS_EARNED_CATEGORY.totalField).toBe('coinsEarned');
+  });
+
+  it('should have perHourField set to coinsPerHour', () => {
+    expect(COINS_EARNED_CATEGORY.perHourField).toBe('coinsPerHour');
+  });
+
+  it('should have all coin fields', () => {
+    expect(COINS_EARNED_CATEGORY.fields).toHaveLength(11);
+  });
+});
+
+describe('Field Alias Maps', () => {
+  it('should build coin aliases correctly', () => {
+    expect(COIN_FIELD_ALIASES).toEqual({
+      coinsFromBlackHole: ['coinsFromBlackhole'],
+      coinsFromOrb: ['coinsFromOrbs'],
+    });
+  });
+
+  it('should have empty damage aliases (no aliases defined)', () => {
+    expect(DAMAGE_FIELD_ALIASES).toEqual({});
+  });
+
+  describe('buildFieldAliasMap', () => {
+    it('should return empty object for fields without aliases', () => {
+      const fields: FieldConfig[] = [
+        { fieldName: 'test1', displayName: 'Test 1', color: '#000000' },
+        { fieldName: 'test2', displayName: 'Test 2', color: '#ffffff' },
+      ];
+      expect(buildFieldAliasMap(fields)).toEqual({});
+    });
+
+    it('should include only fields with aliases', () => {
+      const fields: FieldConfig[] = [
+        { fieldName: 'test1', displayName: 'Test 1', color: '#000000' },
+        {
+          fieldName: 'test2',
+          displayName: 'Test 2',
+          color: '#ffffff',
+          aliases: ['alias2'],
+        },
+        { fieldName: 'test3', displayName: 'Test 3', color: '#aaaaaa' },
+      ];
+      expect(buildFieldAliasMap(fields)).toEqual({
+        test2: ['alias2'],
+      });
+    });
+
+    it('should handle multiple aliases per field', () => {
+      const fields: FieldConfig[] = [
+        {
+          fieldName: 'test',
+          displayName: 'Test',
+          color: '#000000',
+          aliases: ['alias1', 'alias2'],
+        },
+      ];
+      expect(buildFieldAliasMap(fields)).toEqual({
+        test: ['alias1', 'alias2'],
+      });
+    });
+  });
+});

--- a/src/shared/domain/fields/breakdown-sources/coin-sources.ts
+++ b/src/shared/domain/fields/breakdown-sources/coin-sources.ts
@@ -1,0 +1,44 @@
+/**
+ * Coin Source Field Definitions
+ *
+ * All coin source fields with their display names, colors, and aliases.
+ * Merged from both Run Details and Source Analysis configurations.
+ *
+ * Note: Cash (cashFromGoldenTower) is a completely separate currency and
+ * is NOT included here. This is strictly coin-related income sources.
+ */
+
+import type { FieldConfig } from './types';
+
+/**
+ * All coin source fields
+ *
+ * These are the individual sources that contribute to the total coins earned.
+ * Used by both Run Details (breakdown bars) and Source Analysis (charts).
+ *
+ * Aliases are only used for true data variations (e.g., casing differences),
+ * NOT for different fields that happen to have similar names.
+ */
+export const COIN_FIELDS: FieldConfig[] = [
+  { fieldName: 'coinsFromDeathWave', displayName: 'Death Wave', color: '#ef4444' },
+  { fieldName: 'coinsFromGoldenTower', displayName: 'Golden Tower', color: '#fbbf24' },
+  { fieldName: 'coinsFromSpotlight', displayName: 'Spotlight', color: '#e2e8f0' },
+  { fieldName: 'goldenBotCoinsEarned', displayName: 'Golden Bot', color: '#fbbf24' },
+  { fieldName: 'guardianCoinsStolen', displayName: 'Guardian Stolen', color: '#a855f7' },
+  { fieldName: 'coinsStolen', displayName: 'Coins Stolen', color: '#8b5cf6' },
+  { fieldName: 'coinsFetched', displayName: 'Guardian Fetched', color: '#7c3aed' },
+  {
+    fieldName: 'coinsFromBlackHole',
+    displayName: 'Black Hole',
+    color: '#475569',
+    aliases: ['coinsFromBlackhole'], // Casing variation in some data exports
+  },
+  { fieldName: 'coinsFromCoinUpgrade', displayName: 'Coin Upgrade', color: '#f59e0b' },
+  { fieldName: 'coinsFromCoinBonuses', displayName: 'Coin Bonuses', color: '#fb923c' },
+  {
+    fieldName: 'coinsFromOrb',
+    displayName: 'Orbs',
+    color: '#fda4af',
+    aliases: ['coinsFromOrbs'], // Singular/plural variation
+  },
+];

--- a/src/shared/domain/fields/breakdown-sources/damage-sources.ts
+++ b/src/shared/domain/fields/breakdown-sources/damage-sources.ts
@@ -1,0 +1,33 @@
+/**
+ * Damage Source Field Definitions
+ *
+ * All damage source fields with their display names and colors.
+ * Order matches the Run Details display order.
+ */
+
+import type { FieldConfig } from './types';
+
+/**
+ * All damage source fields
+ *
+ * These are the individual sources that contribute to the total damage dealt.
+ * Used by both Run Details (breakdown bars) and Source Analysis (charts).
+ */
+export const DAMAGE_FIELDS: FieldConfig[] = [
+  { fieldName: 'deathWaveDamage', displayName: 'Death Wave', color: '#ef4444' },
+  { fieldName: 'chainLightningDamage', displayName: 'Chain Lightning', color: '#3b82f6' },
+  { fieldName: 'thornDamage', displayName: 'Thorn', color: '#22d3ee' },
+  { fieldName: 'orbDamage', displayName: 'Orb', color: '#f87171' },
+  { fieldName: 'flameBotDamage', displayName: 'Flame Bot Damage', color: '#fbbf24' },
+  { fieldName: 'damage', displayName: 'Guardian Damage', color: '#a855f7' },
+  { fieldName: 'landMineDamage', displayName: 'Land Mine', color: '#9333ea' },
+  { fieldName: 'deathRayDamage', displayName: 'Death Ray', color: '#ff5722' },
+  { fieldName: 'smartMissileDamage', displayName: 'Smart Missile', color: '#64748b' },
+  { fieldName: 'innerLandMineDamage', displayName: 'Inner Land Mine', color: '#7c3aed' },
+  { fieldName: 'swampDamage', displayName: 'Swamp', color: '#22c55e' },
+  { fieldName: 'blackHoleDamage', displayName: 'Black Hole', color: '#475569' },
+  { fieldName: 'electronsDamage', displayName: 'Electrons', color: '#06b6d4' },
+  { fieldName: 'projectilesDamage', displayName: 'Projectiles', color: '#f59e0b' },
+  { fieldName: 'rendArmorDamage', displayName: 'Rend Armor', color: '#dc2626' },
+  { fieldName: 'lifesteal', displayName: 'Lifesteal', color: '#f43f5e' },
+];

--- a/src/shared/domain/fields/breakdown-sources/field-aliases.ts
+++ b/src/shared/domain/fields/breakdown-sources/field-aliases.ts
@@ -1,0 +1,50 @@
+/**
+ * Field Alias Utilities
+ *
+ * Utilities for building and working with field alias maps.
+ * Used by Source Analysis to handle data variations (e.g., casing differences).
+ */
+
+import type { FieldConfig } from './types';
+import { DAMAGE_FIELDS } from './damage-sources';
+import { COIN_FIELDS } from './coin-sources';
+
+/**
+ * Build a lookup map of field aliases from field configurations
+ *
+ * Returns a map where keys are canonical field names and values are
+ * arrays of alternative names that should resolve to the same field.
+ *
+ * @example
+ * // Input: [{ fieldName: 'coinsFromBlackHole', aliases: ['coinsFromBlackhole'] }]
+ * // Output: { coinsFromBlackHole: ['coinsFromBlackhole'] }
+ */
+export function buildFieldAliasMap(
+  fields: FieldConfig[]
+): Record<string, string[]> {
+  return fields.reduce(
+    (map, field) => {
+      if (field.aliases?.length) {
+        map[field.fieldName] = field.aliases;
+      }
+      return map;
+    },
+    {} as Record<string, string[]>
+  );
+}
+
+/**
+ * Pre-built alias map for coin fields
+ *
+ * Includes aliases for:
+ * - coinsFromBlackHole → coinsFromBlackhole (casing variation)
+ * - coinsFromOrbs → coinsFromOrb (singular/plural variation)
+ */
+export const COIN_FIELD_ALIASES = buildFieldAliasMap(COIN_FIELDS);
+
+/**
+ * Pre-built alias map for damage fields
+ *
+ * Currently empty, but ready for future aliases if needed.
+ */
+export const DAMAGE_FIELD_ALIASES = buildFieldAliasMap(DAMAGE_FIELDS);

--- a/src/shared/domain/fields/breakdown-sources/index.ts
+++ b/src/shared/domain/fields/breakdown-sources/index.ts
@@ -1,0 +1,68 @@
+/**
+ * Breakdown Sources - Shared Field Configuration
+ *
+ * Central configuration for field definitions used across Run Details,
+ * Source Analysis, and other views that display field breakdowns.
+ *
+ * Usage:
+ * ```typescript
+ * import {
+ *   DAMAGE_DEALT_CATEGORY,
+ *   COINS_EARNED_CATEGORY,
+ *   COIN_FIELD_ALIASES
+ * } from '@/shared/domain/fields/breakdown-sources';
+ * ```
+ */
+
+
+// Field arrays (for direct field iteration)
+export { DAMAGE_FIELDS } from './damage-sources';
+export { COIN_FIELDS } from './coin-sources';
+
+// Alias utilities
+export {
+  buildFieldAliasMap,
+  COIN_FIELD_ALIASES,
+  DAMAGE_FIELD_ALIASES,
+} from './field-aliases';
+
+// Category configurations
+import type { FieldCategory } from './types';
+import { DAMAGE_FIELDS } from './damage-sources';
+import { COIN_FIELDS } from './coin-sources';
+
+/**
+ * Damage Dealt category configuration
+ *
+ * 16 damage sources that contribute to total damage dealt.
+ * Includes sources like Death Wave, Chain Lightning, Thorn, etc.
+ */
+export const DAMAGE_DEALT_CATEGORY: FieldCategory = {
+  id: 'damageDealt',
+  name: 'Damage Dealt',
+  description: 'Breakdown of damage dealt by source',
+  totalField: 'damageDealt',
+  fields: DAMAGE_FIELDS,
+};
+
+/**
+ * Coins Earned category configuration
+ *
+ * 11 coin sources that contribute to total coins earned.
+ * Includes sources like Death Wave coins, Golden Tower, Spotlight, etc.
+ *
+ * Note: Cash is a separate currency and is NOT included here.
+ */
+export const COINS_EARNED_CATEGORY: FieldCategory = {
+  id: 'coinsEarned',
+  name: 'Coins Earned',
+  description: 'Breakdown of coins earned by source',
+  totalField: 'coinsEarned',
+  perHourField: 'coinsPerHour',
+  fields: COIN_FIELDS,
+};
+
+// Future categories will follow the same pattern:
+// export const ENEMIES_DESTROYED_CATEGORY: FieldCategory = { ... };
+// export const ENEMIES_AFFECTED_BY_CATEGORY: FieldCategory = { ... };
+// export const UPGRADE_SHARDS_CATEGORY: FieldCategory = { ... };

--- a/src/shared/domain/fields/breakdown-sources/types.ts
+++ b/src/shared/domain/fields/breakdown-sources/types.ts
@@ -1,0 +1,60 @@
+/**
+ * Shared Field Configuration Types
+ *
+ * Extensible types for defining field configurations that can be reused
+ * across different views (Run Details, Source Analysis, etc.).
+ *
+ * Design goals:
+ * - Single source of truth for field definitions
+ * - Extensible to any category (damage, coins, enemies, modules, etc.)
+ * - Support both breakdown categories (with totals) and plain groupings
+ */
+
+/**
+ * Single field definition - the atomic unit of configuration
+ *
+ * Used everywhere a field needs consistent identity (name, display, color).
+ * This is the building block that ensures the same field looks identical
+ * across all views in the application.
+ */
+export interface FieldConfig {
+  /** camelCase key in ParsedGameRun.fields */
+  fieldName: string;
+
+  /** Human-readable display name (e.g., "Death Wave", not "Death Wave Damage") */
+  displayName: string;
+
+  /** Hex color for visualization (e.g., "#ef4444") */
+  color: string;
+
+  /** Alternative field names for data variations (e.g., casing differences like "coinsFromBlackhole") */
+  aliases?: string[];
+}
+
+/**
+ * Category that groups related fields with an optional aggregate total
+ *
+ * Examples:
+ * - Damage Dealt: has totalField='damageDealt', fields are damage sources
+ * - Enemies Destroyed: has totalField='totalEnemies', fields are enemy types
+ * - Other Earnings: no totalField (grab-bag grouping), fields are misc currencies
+ */
+export interface FieldCategory {
+  /** Unique identifier (e.g., 'damageDealt', 'enemiesDestroyed') */
+  id: string;
+
+  /** Display name for the category (e.g., 'Damage Dealt') */
+  name: string;
+
+  /** Optional help text describing the category */
+  description?: string;
+
+  /** Field containing the aggregate total (optional - not all categories have one) */
+  totalField?: string;
+
+  /** Optional rate field (e.g., 'coinsPerHour' for Coins Earned) */
+  perHourField?: string;
+
+  /** The fields in this category */
+  fields: FieldConfig[];
+}


### PR DESCRIPTION
## Summary
Run Details and Source Analysis views now share a single source of truth for damage and coin field configurations. This eliminates discrepancies where certain fields (Guardian Damage, guardianCoinsStolen, coinsStolen) appeared in one view but not the other, and ensures display names and colors are consistent everywhere.

## Technical Details
- Created shared configuration at `src/shared/domain/fields/breakdown-sources/`
- New types: `FieldConfig` (atomic field definition), `FieldCategory` (grouping with optional total)
- 16 damage source fields and 11 coin source fields with alias support for data variations
- Updated `section-config.ts` (Run Details) to derive from shared config
- Updated `category-config.ts` (Source Analysis) to derive from shared config
- Added 29 unit tests covering field configurations and alias utilities

## Context
The previous implementation had separate field definitions in each view, leading to drift: Source Analysis was missing 3 fields present in Run Details, and display names/colors varied inconsistently.