### PR TITLE
IMPROVE: Add daily average calculations to weekly/monthly chart tooltips

### DIFF
--- a/src/features/analysis/time-series/chart-types.ts
+++ b/src/features/analysis/time-series/chart-types.ts
@@ -4,12 +4,21 @@
 export type { RunInfo } from '@/features/analysis/shared/tooltips/run-info-header'
 import type { RunInfo } from '@/features/analysis/shared/tooltips/run-info-header'
 
+export interface PeriodInfo {
+  /** Daily average for this period */
+  dailyAverage: number
+  /** Number of days used in calculation */
+  daysInPeriod: number
+}
+
 export interface ChartDataPoint {
   date: string
   value: number
   timestamp: Date
   /** Optional run info for per-run data points */
   runInfo?: RunInfo
+  /** Optional period info for weekly/monthly daily averages */
+  periodInfo?: PeriodInfo
 }
 
 

--- a/src/features/analysis/time-series/daily-average.test.ts
+++ b/src/features/analysis/time-series/daily-average.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect } from 'vitest'
+import {
+  isCurrentWeek,
+  isCurrentMonth,
+  calculateWeeklyDailyAverage,
+  calculateMonthlyDailyAverage,
+} from './daily-average'
+
+describe('isCurrentWeek', () => {
+  it('returns true when reference date is within the week', () => {
+    // Sunday Dec 1, 2024
+    const weekStart = new Date(2024, 11, 1)
+    // Wednesday Dec 4, 2024
+    const referenceDate = new Date(2024, 11, 4)
+    expect(isCurrentWeek(weekStart, referenceDate)).toBe(true)
+  })
+
+  it('returns true when reference date is the start of the week', () => {
+    const weekStart = new Date(2024, 11, 1)
+    const referenceDate = new Date(2024, 11, 1)
+    expect(isCurrentWeek(weekStart, referenceDate)).toBe(true)
+  })
+
+  it('returns true when reference date is the end of the week', () => {
+    // Sunday Dec 1, 2024
+    const weekStart = new Date(2024, 11, 1)
+    // Saturday Dec 7, 2024
+    const referenceDate = new Date(2024, 11, 7)
+    expect(isCurrentWeek(weekStart, referenceDate)).toBe(true)
+  })
+
+  it('returns false when reference date is before the week', () => {
+    const weekStart = new Date(2024, 11, 8)
+    const referenceDate = new Date(2024, 11, 4)
+    expect(isCurrentWeek(weekStart, referenceDate)).toBe(false)
+  })
+
+  it('returns false when reference date is after the week', () => {
+    const weekStart = new Date(2024, 11, 1)
+    const referenceDate = new Date(2024, 11, 10)
+    expect(isCurrentWeek(weekStart, referenceDate)).toBe(false)
+  })
+})
+
+describe('isCurrentMonth', () => {
+  it('returns true when reference date is within the same month', () => {
+    const monthDate = new Date(2024, 11, 1)
+    const referenceDate = new Date(2024, 11, 21)
+    expect(isCurrentMonth(monthDate, referenceDate)).toBe(true)
+  })
+
+  it('returns false when reference date is in a different month', () => {
+    const monthDate = new Date(2024, 10, 1) // November
+    const referenceDate = new Date(2024, 11, 21) // December
+    expect(isCurrentMonth(monthDate, referenceDate)).toBe(false)
+  })
+
+  it('returns false when reference date is in a different year', () => {
+    const monthDate = new Date(2023, 11, 1) // December 2023
+    const referenceDate = new Date(2024, 11, 21) // December 2024
+    expect(isCurrentMonth(monthDate, referenceDate)).toBe(false)
+  })
+})
+
+describe('calculateWeeklyDailyAverage', () => {
+  describe('past weeks', () => {
+    it('uses 7 days for a past week', () => {
+      // Week starting Nov 24, 2024 (past week)
+      const weekStart = new Date(2024, 10, 24)
+      // Reference date is Dec 7, 2024 (different week)
+      const referenceDate = new Date(2024, 11, 7)
+      const total = 700
+
+      const result = calculateWeeklyDailyAverage(total, weekStart, referenceDate)
+
+      expect(result.daysInPeriod).toBe(7)
+      expect(result.dailyAverage).toBe(100)
+    })
+  })
+
+  describe('current week', () => {
+    it('uses days elapsed for current week (Wednesday = 4 days)', () => {
+      // Week starting Sunday Dec 1, 2024
+      const weekStart = new Date(2024, 11, 1)
+      // Reference date is Wednesday Dec 4, 2024 (Sun, Mon, Tue, Wed = 4 days)
+      const referenceDate = new Date(2024, 11, 4)
+      const total = 400
+
+      const result = calculateWeeklyDailyAverage(total, weekStart, referenceDate)
+
+      expect(result.daysInPeriod).toBe(4)
+      expect(result.dailyAverage).toBe(100)
+    })
+
+    it('uses 1 day for first day of week (Sunday)', () => {
+      // Week starting Sunday Dec 1, 2024
+      const weekStart = new Date(2024, 11, 1)
+      // Reference date is Sunday Dec 1, 2024
+      const referenceDate = new Date(2024, 11, 1)
+      const total = 100
+
+      const result = calculateWeeklyDailyAverage(total, weekStart, referenceDate)
+
+      expect(result.daysInPeriod).toBe(1)
+      expect(result.dailyAverage).toBe(100)
+    })
+
+    it('uses 7 days for Saturday (last day of week)', () => {
+      // Week starting Sunday Dec 1, 2024
+      const weekStart = new Date(2024, 11, 1)
+      // Reference date is Saturday Dec 7, 2024
+      const referenceDate = new Date(2024, 11, 7)
+      const total = 700
+
+      const result = calculateWeeklyDailyAverage(total, weekStart, referenceDate)
+
+      expect(result.daysInPeriod).toBe(7)
+      expect(result.dailyAverage).toBe(100)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('handles zero total', () => {
+      const weekStart = new Date(2024, 11, 1)
+      const referenceDate = new Date(2024, 11, 10)
+
+      const result = calculateWeeklyDailyAverage(0, weekStart, referenceDate)
+
+      expect(result.daysInPeriod).toBe(7)
+      expect(result.dailyAverage).toBe(0)
+    })
+  })
+})
+
+describe('calculateMonthlyDailyAverage', () => {
+  describe('past months', () => {
+    it('uses 30 days for November', () => {
+      const monthDate = new Date(2024, 10, 1) // November
+      const referenceDate = new Date(2024, 11, 7) // December
+      const total = 3000
+
+      const result = calculateMonthlyDailyAverage(total, monthDate, referenceDate)
+
+      expect(result.daysInPeriod).toBe(30)
+      expect(result.dailyAverage).toBe(100)
+    })
+
+    it('uses 31 days for October', () => {
+      const monthDate = new Date(2024, 9, 1) // October
+      const referenceDate = new Date(2024, 11, 7) // December
+      const total = 3100
+
+      const result = calculateMonthlyDailyAverage(total, monthDate, referenceDate)
+
+      expect(result.daysInPeriod).toBe(31)
+      expect(result.dailyAverage).toBe(100)
+    })
+
+    it('uses 28 days for February in a non-leap year', () => {
+      const monthDate = new Date(2023, 1, 1) // February 2023
+      const referenceDate = new Date(2023, 11, 7) // December 2023
+      const total = 2800
+
+      const result = calculateMonthlyDailyAverage(total, monthDate, referenceDate)
+
+      expect(result.daysInPeriod).toBe(28)
+      expect(result.dailyAverage).toBe(100)
+    })
+
+    it('uses 29 days for February in a leap year', () => {
+      const monthDate = new Date(2024, 1, 1) // February 2024
+      const referenceDate = new Date(2024, 11, 7) // December 2024
+      const total = 2900
+
+      const result = calculateMonthlyDailyAverage(total, monthDate, referenceDate)
+
+      expect(result.daysInPeriod).toBe(29)
+      expect(result.dailyAverage).toBe(100)
+    })
+  })
+
+  describe('current month', () => {
+    it('uses day of month for current month (Dec 21 = 21 days)', () => {
+      const monthDate = new Date(2024, 11, 1) // December
+      const referenceDate = new Date(2024, 11, 21) // December 21
+      const total = 2100
+
+      const result = calculateMonthlyDailyAverage(total, monthDate, referenceDate)
+
+      expect(result.daysInPeriod).toBe(21)
+      expect(result.dailyAverage).toBe(100)
+    })
+
+    it('uses 1 day for first day of month', () => {
+      const monthDate = new Date(2024, 11, 1) // December
+      const referenceDate = new Date(2024, 11, 1) // December 1
+      const total = 100
+
+      const result = calculateMonthlyDailyAverage(total, monthDate, referenceDate)
+
+      expect(result.daysInPeriod).toBe(1)
+      expect(result.dailyAverage).toBe(100)
+    })
+
+    it('uses full days for last day of month', () => {
+      const monthDate = new Date(2024, 10, 1) // November
+      const referenceDate = new Date(2024, 10, 30) // November 30
+      const total = 3000
+
+      const result = calculateMonthlyDailyAverage(total, monthDate, referenceDate)
+
+      expect(result.daysInPeriod).toBe(30)
+      expect(result.dailyAverage).toBe(100)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('handles zero total', () => {
+      const monthDate = new Date(2024, 10, 1) // November
+      const referenceDate = new Date(2024, 11, 7) // December
+
+      const result = calculateMonthlyDailyAverage(0, monthDate, referenceDate)
+
+      expect(result.daysInPeriod).toBe(30)
+      expect(result.dailyAverage).toBe(0)
+    })
+  })
+})

--- a/src/features/analysis/time-series/daily-average.ts
+++ b/src/features/analysis/time-series/daily-average.ts
@@ -1,0 +1,77 @@
+import {
+  getDaysInMonth,
+  differenceInDays,
+  isSameMonth,
+  isSameYear,
+  endOfWeek,
+  isWithinInterval,
+  getDate,
+} from 'date-fns'
+import type { PeriodInfo } from './chart-types'
+
+/**
+ * Check if a week contains the reference date (i.e., is the "current" week)
+ */
+export function isCurrentWeek(weekStart: Date, referenceDate: Date): boolean {
+  const weekEnd = endOfWeek(weekStart, { weekStartsOn: 0 })
+  return isWithinInterval(referenceDate, { start: weekStart, end: weekEnd })
+}
+
+/**
+ * Check if a month contains the reference date (i.e., is the "current" month)
+ */
+export function isCurrentMonth(monthDate: Date, referenceDate: Date): boolean {
+  return isSameMonth(monthDate, referenceDate) && isSameYear(monthDate, referenceDate)
+}
+
+/**
+ * Calculate daily average for a weekly period
+ * - Current week: days from Sunday through reference date
+ * - Past weeks: 7 days
+ */
+export function calculateWeeklyDailyAverage(
+  total: number,
+  weekStart: Date,
+  referenceDate: Date = new Date()
+): PeriodInfo {
+  let daysInPeriod: number
+
+  if (isCurrentWeek(weekStart, referenceDate)) {
+    // Current week: count days from Sunday through today (inclusive)
+    daysInPeriod = differenceInDays(referenceDate, weekStart) + 1
+  } else {
+    // Past week: always 7 days
+    daysInPeriod = 7
+  }
+
+  return {
+    dailyAverage: daysInPeriod > 0 ? total / daysInPeriod : 0,
+    daysInPeriod,
+  }
+}
+
+/**
+ * Calculate daily average for a monthly period
+ * - Current month: days from 1st through reference date
+ * - Past months: actual days in that month
+ */
+export function calculateMonthlyDailyAverage(
+  total: number,
+  monthDate: Date,
+  referenceDate: Date = new Date()
+): PeriodInfo {
+  let daysInPeriod: number
+
+  if (isCurrentMonth(monthDate, referenceDate)) {
+    // Current month: count days from 1st through today
+    daysInPeriod = getDate(referenceDate)
+  } else {
+    // Past month: use actual days in that month
+    daysInPeriod = getDaysInMonth(monthDate)
+  }
+
+  return {
+    dailyAverage: daysInPeriod > 0 ? total / daysInPeriod : 0,
+    daysInPeriod,
+  }
+}

--- a/src/features/analysis/time-series/field-aggregation.ts
+++ b/src/features/analysis/time-series/field-aggregation.ts
@@ -7,6 +7,10 @@ import {
   formatDisplayMonthDay,
   formatDisplayMonth,
 } from '@/shared/formatting/date-formatters'
+import {
+  calculateWeeklyDailyAverage,
+  calculateMonthlyDailyAverage,
+} from './daily-average'
 
 /**
  * Field aggregation functions
@@ -93,6 +97,7 @@ export function prepareFieldPerDayData(
 
 /**
  * Function to prepare weekly aggregated data for any field
+ * Includes daily average calculation for tooltip display
  */
 export function prepareFieldPerWeekData(
   runs: ParsedGameRun[],
@@ -111,11 +116,13 @@ export function prepareFieldPerWeekData(
       return sum + (value ?? 0)
     }, 0)
     const timestamp = startOfWeek(weekRuns[0].timestamp, { weekStartsOn: 0 })
+    const periodInfo = calculateWeeklyDailyAverage(total, timestamp)
 
     weeklyData.push({
       date: formatDisplayMonthDay(timestamp),
       value: total,
       timestamp,
+      periodInfo,
     })
   })
 
@@ -124,6 +131,7 @@ export function prepareFieldPerWeekData(
 
 /**
  * Function to prepare monthly aggregated data for any field
+ * Includes daily average calculation for tooltip display
  */
 export function prepareFieldPerMonthData(
   runs: ParsedGameRun[],
@@ -142,11 +150,13 @@ export function prepareFieldPerMonthData(
       return sum + (value ?? 0)
     }, 0)
     const timestamp = startOfMonth(monthRuns[0].timestamp)
+    const periodInfo = calculateMonthlyDailyAverage(total, timestamp)
 
     monthlyData.push({
       date: `${formatDisplayMonth(timestamp)} ${timestamp.getFullYear()}`,
       value: total,
       timestamp,
+      periodInfo,
     })
   })
 

--- a/src/features/analysis/time-series/time-series-tooltip.tsx
+++ b/src/features/analysis/time-series/time-series-tooltip.tsx
@@ -7,7 +7,7 @@
  * Also exports a Recharts-compatible wrapper for easy integration with chart components.
  */
 
-import type { RunInfo, ChartDataPoint } from './chart-types'
+import type { RunInfo, ChartDataPoint, PeriodInfo } from './chart-types'
 import { RunInfoHeader } from '@/features/analysis/shared/tooltips/run-info-header'
 
 interface TimeSeriesTooltipProps {
@@ -21,6 +21,10 @@ interface TimeSeriesTooltipProps {
   metricLabel: string
   /** Optional run info for per-run data points */
   runInfo?: RunInfo
+  /** Optional period info for weekly/monthly daily averages */
+  periodInfo?: PeriodInfo
+  /** Formatter function for daily average */
+  formatter?: (value: number) => string
   /** Accent color for styling */
   accentColor?: string
 }
@@ -31,6 +35,8 @@ function TimeSeriesTooltip({
   formattedValue,
   metricLabel,
   runInfo,
+  periodInfo,
+  formatter,
   accentColor,
 }: TimeSeriesTooltipProps) {
   return (
@@ -63,6 +69,17 @@ function TimeSeriesTooltip({
           {formattedValue}
         </span>
       </div>
+
+      {/* Daily Average row - only for weekly/monthly */}
+      {periodInfo && formatter && (
+        <div className="flex items-baseline justify-between gap-4 mt-2 pt-2 border-t border-slate-700/30">
+          <span className="text-slate-500 text-xs">Daily Avg</span>
+          <span className="text-slate-400 text-xs tabular-nums">
+            {formatter(periodInfo.dailyAverage)}
+            <span className="text-slate-500 ml-0.5">/day</span>
+          </span>
+        </div>
+      )}
     </div>
   )
 }
@@ -111,6 +128,8 @@ export function TimeSeriesChartTooltip({
       formattedValue={formattedValue}
       metricLabel={metricLabel}
       runInfo={dataPoint.runInfo}
+      periodInfo={dataPoint.periodInfo}
+      formatter={formatter}
       accentColor={accentColor}
     />
   )


### PR DESCRIPTION
## Summary
Weekly and monthly time series chart tooltips now display a daily average row, showing users their earning rate per day. This eliminates the need for manual calculation when comparing performance across different time periods. The feature intelligently handles partial periods by using actual days elapsed for the current week/month.

## Technical Details
- Added `PeriodInfo` interface to `chart-types.ts` with `dailyAverage` and `daysInPeriod` properties
- Created `daily-average.ts` with pure calculation functions for weekly/monthly averages
- Current periods calculate using days elapsed (e.g., Wednesday = 4 days into week)
- Past periods use standard divisors (7 for weeks, `getDaysInMonth` for months)
- Updated `prepareFieldPerWeekData` and `prepareFieldPerMonthData` to include period info
- Extended tooltip component with subordinate daily average display row
- Added 21 unit tests covering all calculation edge cases including leap years