### PR TITLE
IMPROVE: Add data discrepancy detection to breakdown displays

### DIFF
--- a/e2e/features/analytics/source-analysis.spec.ts
+++ b/e2e/features/analytics/source-analysis.spec.ts
@@ -44,6 +44,6 @@ test.describe('Source Analysis', () => {
     // Chain Lightning is the top damage source in the seed data
     expect(sourceRankingContent).toContain('Chain Lightning');
     expect(sourceRankingContent).toContain('2.92S'); // ~2.92 sextillion damage
-    expect(sourceRankingContent).toContain('56%'); // Top source percentage
+    expect(sourceRankingContent).toContain('57.7%'); // Top source percentage (against totalField)
   });
 });

--- a/src/features/analysis/source-analysis/types.ts
+++ b/src/features/analysis/source-analysis/types.ts
@@ -86,6 +86,10 @@ export interface SourceValue {
   color: string;
   value: number; // Absolute value
   percentage: number; // Percentage of total (0-100)
+  /** True if this is a discrepancy entry (Unknown/Overage) */
+  isDiscrepancy?: boolean;
+  /** Type of discrepancy if isDiscrepancy is true */
+  discrepancyType?: 'unknown' | 'overage';
 }
 
 /**
@@ -116,6 +120,10 @@ export interface SourceSummaryValue {
   color: string;
   totalValue: number; // Sum across all periods
   percentage: number; // Percentage of grand total (0-100)
+  /** True if this is a discrepancy entry (Unknown/Overage) */
+  isDiscrepancy?: boolean;
+  /** Type of discrepancy if isDiscrepancy is true */
+  discrepancyType?: 'unknown' | 'overage';
 }
 
 /**

--- a/src/features/game-runs/card-view/run-details/breakdown/breakdown-bar.tsx
+++ b/src/features/game-runs/card-view/run-details/breakdown/breakdown-bar.tsx
@@ -3,11 +3,15 @@
  *
  * Horizontal bar chart for displaying a single breakdown metric.
  * Shows label, value, percentage, and visual bar.
+ *
+ * Supports discrepancy items (Unknown/Overage) with distinct styling
+ * and explanatory tooltips.
  */
 
 import type { BreakdownItem } from '../types'
 import { formatPercentage } from '@/shared/formatting/number-scale'
 import { formatFieldDisplayName } from '@/shared/domain/fields/field-formatters'
+import { buildDiscrepancyTooltip } from './breakdown-tooltip'
 
 interface BreakdownBarProps {
   item: BreakdownItem
@@ -17,10 +21,20 @@ interface BreakdownBarProps {
 const MIN_BAR_WIDTH_PERCENT = 2
 
 export function BreakdownBar({ item }: BreakdownBarProps) {
-  const { fieldName, displayName, color, percentage, displayValue } = item
+  const {
+    fieldName,
+    displayName,
+    color,
+    percentage,
+    displayValue,
+    isDiscrepancy,
+    discrepancyType,
+  } = item
 
-  // Show original field name (title case) as tooltip for reference to battle export
-  const tooltipText = formatFieldDisplayName(fieldName)
+  // Build tooltip: explanatory text for discrepancies, field name for regular items
+  const tooltipText = isDiscrepancy && discrepancyType
+    ? buildDiscrepancyTooltip(discrepancyType, percentage, displayValue)
+    : formatFieldDisplayName(fieldName)
 
   // Cap visual width at 100%, but show actual percentage in text
   const visualPercentage = Math.min(percentage, 100)
@@ -30,11 +44,34 @@ export function BreakdownBar({ item }: BreakdownBarProps) {
     ? Math.max(visualPercentage, MIN_BAR_WIDTH_PERCENT)
     : 0
 
+  // Base label classes shared by all items
+  const labelBaseClassName = 'text-sm w-32 sm:w-40 truncate flex-shrink-0 transition-colors duration-200'
+
+  // Discrepancy items: italic label with inline color (no hover override to preserve color connection)
+  // Regular items: muted color with hover brightening
+  const labelClassName = isDiscrepancy
+    ? `${labelBaseClassName} italic`
+    : `${labelBaseClassName} text-muted-foreground group-hover:text-foreground/80`
+
+  // Discrepancy bar: dashed border around all edges with subtle fill to convey "estimated/tentative"
+  // Regular bar: solid gradient fill with strong visual presence
+  const barStyle = isDiscrepancy
+    ? {
+        width: `${barWidth}%`,
+        background: `linear-gradient(90deg, ${color}30 0%, ${color}15 100%)`,
+        border: `1px dashed ${color}80`,
+      }
+    : {
+        width: `${barWidth}%`,
+        background: `linear-gradient(90deg, ${color} 0%, ${color}99 50%, ${color}55 100%)`,
+      }
+
   return (
     <div className="flex items-center gap-2 sm:gap-3 group">
       {/* Label - wider for readability, truncates gracefully */}
       <span
-        className="text-sm text-muted-foreground w-32 sm:w-40 truncate flex-shrink-0 transition-colors duration-200 group-hover:text-foreground/80"
+        className={labelClassName}
+        style={isDiscrepancy ? { color } : undefined}
         title={tooltipText}
       >
         {displayName}
@@ -52,13 +89,10 @@ export function BreakdownBar({ item }: BreakdownBarProps) {
 
       {/* Bar container - flex to fill remaining space */}
       <div className="flex-1 min-w-8 sm:min-w-12 relative h-5 sm:h-6 rounded-sm overflow-hidden bg-muted/20">
-        {/* Filled bar with gradient */}
+        {/* Filled bar with gradient (or dashed for discrepancy) */}
         <div
           className="absolute inset-y-0 left-0 rounded-sm transition-all duration-300 ease-out"
-          style={{
-            width: `${barWidth}%`,
-            background: `linear-gradient(90deg, ${color} 0%, ${color}99 50%, ${color}55 100%)`,
-          }}
+          style={barStyle}
         />
       </div>
     </div>

--- a/src/features/game-runs/card-view/run-details/breakdown/breakdown-calculations.test.ts
+++ b/src/features/game-runs/card-view/run-details/breakdown/breakdown-calculations.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 /**
  * Breakdown Calculations Tests
  *
@@ -54,18 +55,23 @@ describe('calculateBreakdownGroup', () => {
     expect(result).toBeNull()
   })
 
-  it('only includes fields that exist in run', () => {
+  it('only includes fields that exist in run (plus discrepancy if applicable)', () => {
     const run = createMockRun({
       damageDealt: 1000,
       deathWaveDamage: 700,
       // thornDamage and orbDamage don't exist
+      // Sum = 700, total = 1000 → 30% unknown discrepancy
     })
 
     const result = calculateBreakdownGroup(run, damageConfig)
 
     expect(result).not.toBeNull()
-    expect(result!.items).toHaveLength(1)
+    // 1 existing source field + 1 unknown discrepancy
+    expect(result!.items).toHaveLength(2)
     expect(result!.items[0].fieldName).toBe('deathWaveDamage')
+    // Second item is the discrepancy
+    expect(result!.items[1].isDiscrepancy).toBe(true)
+    expect(result!.items[1].discrepancyType).toBe('unknown')
   })
 
   it('includes zero-value fields if they exist', () => {
@@ -141,6 +147,228 @@ describe('calculateBreakdownGroup', () => {
 
     expect(result).not.toBeNull()
     expect(result!.perHourDisplayValue).toBeDefined()
+  })
+
+  // ===========================================================================
+  // Discrepancy Detection Tests
+  // ===========================================================================
+
+  describe('discrepancy detection', () => {
+    const damageConfigWithTotal: BreakdownConfig = {
+      totalField: 'damageDealt',
+      label: 'DAMAGE DEALT',
+      sources: [
+        { fieldName: 'deathWaveDamage', displayName: 'Death Wave', color: '#ef4444' },
+        { fieldName: 'thornDamage', displayName: 'Thorn', color: '#22d3ee' },
+        { fieldName: 'orbDamage', displayName: 'Orb', color: '#f87171' },
+      ],
+    }
+
+    it('adds Unknown item when sources sum to less than total by more than 1%', () => {
+      const run = createMockRun({
+        damageDealt: 1000,
+        deathWaveDamage: 500,
+        thornDamage: 300,
+        // orbDamage missing - but total is 1000, sources sum to 800 = 20% unknown
+      })
+
+      const result = calculateBreakdownGroup(run, damageConfigWithTotal)
+
+      expect(result).not.toBeNull()
+      // 2 source items + 1 unknown item
+      expect(result!.items).toHaveLength(3)
+
+      const unknownItem = result!.items.find(i => i.isDiscrepancy)
+      expect(unknownItem).toBeDefined()
+      expect(unknownItem!.discrepancyType).toBe('unknown')
+      expect(unknownItem!.displayName).toBe('Unknown')
+      expect(unknownItem!.value).toBe(200)
+      expect(unknownItem!.percentage).toBe(20)
+    })
+
+    it('adds Overage item when sources sum to more than total by more than 1%', () => {
+      const run = createMockRun({
+        damageDealt: 1000,
+        deathWaveDamage: 600,
+        thornDamage: 400,
+        orbDamage: 150, // Sum = 1150, total = 1000 → 15% overage
+      })
+
+      const result = calculateBreakdownGroup(run, damageConfigWithTotal)
+
+      expect(result).not.toBeNull()
+      // 3 source items + 1 overage item
+      expect(result!.items).toHaveLength(4)
+
+      const overageItem = result!.items.find(i => i.isDiscrepancy)
+      expect(overageItem).toBeDefined()
+      expect(overageItem!.discrepancyType).toBe('overage')
+      expect(overageItem!.displayName).toBe('Overage')
+      expect(overageItem!.value).toBe(150)
+      expect(overageItem!.percentage).toBe(15)
+    })
+
+    it('does not add discrepancy when within threshold (1%)', () => {
+      const run = createMockRun({
+        damageDealt: 1000,
+        deathWaveDamage: 500,
+        thornDamage: 300,
+        orbDamage: 195, // Sum = 995, total = 1000 → 0.5% unknown (below 1%)
+      })
+
+      const result = calculateBreakdownGroup(run, damageConfigWithTotal)
+
+      expect(result).not.toBeNull()
+      expect(result!.items).toHaveLength(3) // No discrepancy item
+      expect(result!.items.every(i => !i.isDiscrepancy)).toBe(true)
+    })
+
+    it('does not add discrepancy when sources exactly match total', () => {
+      const run = createMockRun({
+        damageDealt: 1000,
+        deathWaveDamage: 500,
+        thornDamage: 300,
+        orbDamage: 200, // Sum = 1000, total = 1000 → no discrepancy
+      })
+
+      const result = calculateBreakdownGroup(run, damageConfigWithTotal)
+
+      expect(result).not.toBeNull()
+      expect(result!.items).toHaveLength(3)
+      expect(result!.items.every(i => !i.isDiscrepancy)).toBe(true)
+    })
+
+    it('places discrepancy item at the end after sorted items', () => {
+      const run = createMockRun({
+        damageDealt: 1000,
+        deathWaveDamage: 200,
+        thornDamage: 500,
+        // Sum = 700, total = 1000 → 30% unknown
+      })
+
+      const result = calculateBreakdownGroup(run, damageConfigWithTotal)
+
+      expect(result).not.toBeNull()
+      expect(result!.items).toHaveLength(3)
+
+      // First two items should be sorted by percentage
+      expect(result!.items[0].displayName).toBe('Thorn') // 50%
+      expect(result!.items[1].displayName).toBe('Death Wave') // 20%
+
+      // Last item should be the discrepancy
+      expect(result!.items[2].isDiscrepancy).toBe(true)
+      expect(result!.items[2].displayName).toBe('Unknown')
+    })
+
+    it('does not add discrepancy for computed sum totals (totalField: null)', () => {
+      const shardsConfig: BreakdownConfig = {
+        totalField: null,
+        label: 'SHARDS',
+        sources: [
+          { fieldName: 'rerollShards', displayName: 'Re-roll', color: '#94a3b8' },
+          { fieldName: 'armorShards', displayName: 'Armor', color: '#64748b' },
+        ],
+      }
+
+      const run = createMockRun({
+        rerollShards: 100,
+        armorShards: 50,
+      })
+
+      const result = calculateBreakdownGroup(run, shardsConfig)
+
+      expect(result).not.toBeNull()
+      expect(result!.items).toHaveLength(2) // No discrepancy item
+      expect(result!.items.every(i => !i.isDiscrepancy)).toBe(true)
+    })
+
+    it('handles 100% unknown (total exists but no sources)', () => {
+      const run = createMockRun({
+        damageDealt: 1000,
+        deathWaveDamage: 0, // Exists with zero value
+      })
+
+      const result = calculateBreakdownGroup(run, damageConfigWithTotal)
+
+      expect(result).not.toBeNull()
+      // Should have zero-value item + unknown item
+      expect(result!.items).toHaveLength(2)
+
+      const unknownItem = result!.items.find(i => i.isDiscrepancy)
+      expect(unknownItem).toBeDefined()
+      expect(unknownItem!.percentage).toBe(100)
+    })
+
+    it('provides correct color for unknown discrepancy', () => {
+      const run = createMockRun({
+        damageDealt: 1000,
+        deathWaveDamage: 800,
+      })
+
+      const result = calculateBreakdownGroup(run, damageConfigWithTotal)
+      const unknownItem = result!.items.find(i => i.isDiscrepancy)
+
+      expect(unknownItem!.color).toBe('#6b7280') // gray-600
+    })
+
+    it('provides correct color for overage discrepancy', () => {
+      const run = createMockRun({
+        damageDealt: 1000,
+        deathWaveDamage: 1200,
+      })
+
+      const result = calculateBreakdownGroup(run, damageConfigWithTotal)
+      const overageItem = result!.items.find(i => i.isDiscrepancy)
+
+      expect(overageItem!.color).toBe('#fbbf24') // amber-400
+    })
+
+    it('skips discrepancy detection when skipDiscrepancy is true', () => {
+      const configWithSkip: BreakdownConfig = {
+        totalField: 'totalEnemies',
+        label: 'ENEMIES AFFECTED BY',
+        skipDiscrepancy: true, // Supplementary data, not a breakdown of total
+        sources: [
+          { fieldName: 'destroyedInSpotlight', displayName: 'Spotlight', color: '#e2e8f0' },
+          { fieldName: 'taggedByDeathwave', displayName: 'Deathwave', color: '#ef4444' },
+        ],
+      }
+
+      const run = createMockRun({
+        totalEnemies: 1000,
+        destroyedInSpotlight: 100, // Only 10% of total
+        taggedByDeathwave: 200,    // Only 20% of total
+        // Sum = 300, total = 1000 → would normally be 70% unknown
+      })
+
+      const result = calculateBreakdownGroup(run, configWithSkip)
+
+      expect(result).not.toBeNull()
+      expect(result!.items).toHaveLength(2) // No discrepancy item
+      expect(result!.items.every(i => !i.isDiscrepancy)).toBe(true)
+    })
+
+    it('still detects discrepancy when skipDiscrepancy is false', () => {
+      const configWithoutSkip: BreakdownConfig = {
+        totalField: 'damageDealt',
+        label: 'DAMAGE',
+        skipDiscrepancy: false,
+        sources: [
+          { fieldName: 'deathWaveDamage', displayName: 'Death Wave', color: '#ef4444' },
+        ],
+      }
+
+      const run = createMockRun({
+        damageDealt: 1000,
+        deathWaveDamage: 500, // 50% of total
+      })
+
+      const result = calculateBreakdownGroup(run, configWithoutSkip)
+
+      expect(result).not.toBeNull()
+      expect(result!.items).toHaveLength(2) // 1 source + 1 unknown
+      expect(result!.items.some(i => i.isDiscrepancy)).toBe(true)
+    })
   })
 })
 

--- a/src/features/game-runs/card-view/run-details/breakdown/breakdown-tooltip.ts
+++ b/src/features/game-runs/card-view/run-details/breakdown/breakdown-tooltip.ts
@@ -1,0 +1,30 @@
+/**
+ * Breakdown Tooltip Utilities
+ *
+ * Pure functions for building tooltip text for breakdown items.
+ */
+
+import type { DiscrepancyType } from '@/shared/domain/fields/breakdown-sources'
+
+/**
+ * Build explanatory tooltip text for discrepancy entries.
+ *
+ * @param type - 'unknown' (missing data) or 'overage' (excess data)
+ * @param percentage - The discrepancy percentage (0-100)
+ * @param displayValue - Formatted discrepancy value (e.g., "9K")
+ * @returns Human-readable tooltip explaining the discrepancy
+ */
+export function buildDiscrepancyTooltip(
+  type: DiscrepancyType,
+  percentage: number,
+  displayValue: string
+): string {
+  const accountedPercentage = (100 - percentage).toFixed(1)
+  const excessPercentage = (100 + percentage).toFixed(1)
+
+  if (type === 'unknown') {
+    return `Missing sources: Listed sources account for ${accountedPercentage}% of total. ${displayValue} (${percentage}%) is unaccounted for.`
+  }
+
+  return `Data inconsistency: Listed sources sum to ${excessPercentage}% of the reported total. This may indicate a game export bug.`
+}

--- a/src/features/game-runs/card-view/run-details/section-config.ts
+++ b/src/features/game-runs/card-view/run-details/section-config.ts
@@ -97,6 +97,7 @@ export const ENEMIES_DESTROYED_CONFIG: BreakdownConfig = {
 export const DESTROYED_BY_CONFIG: BreakdownConfig = {
   totalField: 'totalEnemies',
   label: 'ENEMIES KILLED (OR HIT) BY',
+  skipDiscrepancy: true, // Sources are supplementary hit counts, not a breakdown of totalEnemies
   sources: [
     { fieldName: 'enemiesHitByOrbs', displayName: 'Orb Hits', color: '#f87171' },
     { fieldName: 'destroyedByOrbs', displayName: 'Orbs', color: '#f87171' },
@@ -109,6 +110,7 @@ export const DESTROYED_BY_CONFIG: BreakdownConfig = {
 export const ENEMIES_AFFECTED_BY_CONFIG: BreakdownConfig = {
   totalField: 'totalEnemies',
   label: 'ENEMIES AFFECTED BY',
+  skipDiscrepancy: true, // Sources are supplementary effects, not a breakdown of totalEnemies
   sources: [
     { fieldName: 'destroyedInSpotlight', displayName: 'Spotlight', color: '#e2e8f0' },
     { fieldName: 'taggedByDeathwave', displayName: 'Deathwave', color: '#ef4444' },

--- a/src/features/game-runs/card-view/run-details/types.ts
+++ b/src/features/game-runs/card-view/run-details/types.ts
@@ -30,6 +30,12 @@ export interface BreakdownConfig {
   perHourField?: string
   /** Source fields that break down the total */
   sources: BreakdownSourceConfig[]
+  /**
+   * Skip discrepancy detection for this group.
+   * Use when sources are supplementary data that don't sum to the total.
+   * Example: "Enemies Affected By" - the sources aren't meant to add up to totalEnemies.
+   */
+  skipDiscrepancy?: boolean
 }
 
 /**
@@ -68,6 +74,10 @@ export interface BreakdownItem {
   percentage: number
   /** Formatted display value (e.g., "1.5B") */
   displayValue: string
+  /** True if this is a discrepancy entry (Unknown/Overage) */
+  isDiscrepancy?: boolean
+  /** Type of discrepancy if isDiscrepancy is true */
+  discrepancyType?: 'unknown' | 'overage'
 }
 
 /**

--- a/src/shared/domain/fields/breakdown-sources/discrepancy-calculation.test.ts
+++ b/src/shared/domain/fields/breakdown-sources/discrepancy-calculation.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import { calculateDiscrepancy } from './discrepancy-calculation';
+import { DISCREPANCY_THRESHOLD } from './discrepancy-config';
+
+describe('calculateDiscrepancy', () => {
+  describe('unknown discrepancy (total > sourceSum)', () => {
+    it('returns unknown when sources sum to less than total by more than threshold', () => {
+      const result = calculateDiscrepancy(1000, 850);
+      expect(result).toEqual({
+        type: 'unknown',
+        value: 150,
+        percentage: 15,
+      });
+    });
+
+    it('calculates percentage correctly for large values', () => {
+      // 312K total, 303K sources = 9K unknown (2.88%)
+      const result = calculateDiscrepancy(312000, 303000);
+      expect(result).toEqual({
+        type: 'unknown',
+        value: 9000,
+        percentage: 2.88,
+      });
+    });
+
+    it('returns 100% unknown when all sources are zero but total exists', () => {
+      const result = calculateDiscrepancy(1000, 0);
+      expect(result).toEqual({
+        type: 'unknown',
+        value: 1000,
+        percentage: 100,
+      });
+    });
+  });
+
+  describe('overage discrepancy (sourceSum > total)', () => {
+    it('returns overage when sources sum to more than total by more than threshold', () => {
+      const result = calculateDiscrepancy(1000, 1150);
+      expect(result).toEqual({
+        type: 'overage',
+        value: 150,
+        percentage: 15,
+      });
+    });
+
+    it('calculates percentage correctly for overage', () => {
+      // 8.5T total, 9.1T sources = 600B overage (~7.1%)
+      const result = calculateDiscrepancy(8500, 9100);
+      expect(result).toEqual({
+        type: 'overage',
+        value: 600,
+        percentage: 7.06,
+      });
+    });
+  });
+
+  describe('threshold handling', () => {
+    it('returns null when discrepancy is below default threshold (1%)', () => {
+      // 0.5% difference - below 1% threshold
+      const result = calculateDiscrepancy(1000, 995);
+      expect(result).toBeNull();
+    });
+
+    it('returns null when discrepancy is exactly at threshold', () => {
+      // Exactly 1% difference - not strictly greater
+      const result = calculateDiscrepancy(1000, 990);
+      expect(result).toBeNull();
+    });
+
+    it('returns discrepancy when just above threshold', () => {
+      // 1.1% difference - strictly greater than 1%
+      const result = calculateDiscrepancy(1000, 989);
+      expect(result).not.toBeNull();
+      expect(result?.type).toBe('unknown');
+    });
+
+    it('respects custom threshold', () => {
+      // 5% difference with 10% threshold - should return null
+      const result = calculateDiscrepancy(1000, 950, 0.1);
+      expect(result).toBeNull();
+
+      // Same values with 1% threshold - should return discrepancy
+      const result2 = calculateDiscrepancy(1000, 950, 0.01);
+      expect(result2).not.toBeNull();
+    });
+
+    it('uses default threshold constant', () => {
+      expect(DISCREPANCY_THRESHOLD).toBe(0.01);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns null when both total and sourceSum are zero', () => {
+      const result = calculateDiscrepancy(0, 0);
+      expect(result).toBeNull();
+    });
+
+    it('returns overage when total is zero but sources exist', () => {
+      const result = calculateDiscrepancy(0, 100);
+      expect(result).toEqual({
+        type: 'overage',
+        value: 100,
+        percentage: 100,
+      });
+    });
+
+    it('returns null when total exactly equals sourceSum', () => {
+      const result = calculateDiscrepancy(1000, 1000);
+      expect(result).toBeNull();
+    });
+
+    it('handles very small percentages', () => {
+      // 1.5% difference
+      const result = calculateDiscrepancy(10000, 9850);
+      expect(result?.percentage).toBe(1.5);
+    });
+
+    it('rounds percentage to 2 decimal places', () => {
+      // Creates a percentage with many decimal places
+      const result = calculateDiscrepancy(333, 300);
+      expect(result?.percentage).toBe(9.91); // 33/333 = 9.909909...
+    });
+  });
+});

--- a/src/shared/domain/fields/breakdown-sources/discrepancy-calculation.ts
+++ b/src/shared/domain/fields/breakdown-sources/discrepancy-calculation.ts
@@ -1,0 +1,95 @@
+/**
+ * Discrepancy Calculation Utilities
+ *
+ * Pure functions for detecting and calculating discrepancies
+ * between source breakdowns and their totals.
+ */
+
+import {
+  DISCREPANCY_THRESHOLD,
+  type DiscrepancyType,
+} from './discrepancy-config';
+
+/**
+ * Result of discrepancy calculation.
+ */
+interface DiscrepancyResult {
+  /** Type of discrepancy: 'unknown' for missing data, 'overage' for excess */
+  type: DiscrepancyType;
+  /** Absolute value of the discrepancy */
+  value: number;
+  /** Percentage of total that the discrepancy represents (0-100) */
+  percentage: number;
+}
+
+/**
+ * Calculates discrepancy between a total and the sum of its sources.
+ *
+ * @param total - The stated total value
+ * @param sourceSum - The sum of all source values
+ * @param threshold - Minimum percentage to report (default: 1%)
+ * @returns Discrepancy result if significant, null otherwise
+ *
+ * @example
+ * // Unknown: sources don't fully explain total
+ * calculateDiscrepancy(1000, 900) // { type: 'unknown', value: 100, percentage: 10 }
+ *
+ * // Overage: sources exceed total
+ * calculateDiscrepancy(1000, 1100) // { type: 'overage', value: 100, percentage: 10 }
+ *
+ * // Below threshold: no discrepancy shown
+ * calculateDiscrepancy(1000, 995) // null (0.5% < 1% threshold)
+ */
+export function calculateDiscrepancy(
+  total: number,
+  sourceSum: number,
+  threshold: number = DISCREPANCY_THRESHOLD
+): DiscrepancyResult | null {
+  // Handle zero total edge case
+  if (total === 0) {
+    if (sourceSum > 0) {
+      // Sources exist but total is zero - 100% overage
+      return {
+        type: 'overage',
+        value: sourceSum,
+        percentage: 100,
+      };
+    }
+    // Both zero - no discrepancy
+    return null;
+  }
+
+  const difference = total - sourceSum;
+
+  // No difference at all
+  if (difference === 0) {
+    return null;
+  }
+
+  // Calculate percentage relative to total
+  const percentageDecimal = Math.abs(difference) / total;
+
+  // Only report if strictly greater than threshold
+  if (percentageDecimal <= threshold) {
+    return null;
+  }
+
+  // Convert to display percentage (0-100) with 2 decimal precision
+  const percentage = Math.round(percentageDecimal * 10000) / 100;
+
+  if (difference > 0) {
+    // Total > sourceSum: missing/unknown sources
+    return {
+      type: 'unknown',
+      value: difference,
+      percentage,
+    };
+  } else {
+    // sourceSum > total: overage/excess
+    return {
+      type: 'overage',
+      value: Math.abs(difference),
+      percentage,
+    };
+  }
+}

--- a/src/shared/domain/fields/breakdown-sources/discrepancy-config.ts
+++ b/src/shared/domain/fields/breakdown-sources/discrepancy-config.ts
@@ -1,0 +1,51 @@
+/**
+ * Discrepancy Detection Configuration
+ *
+ * Constants and types for detecting and displaying discrepancies
+ * between source breakdowns and their totals in Run Details and
+ * Source Analysis views.
+ */
+
+/**
+ * Minimum percentage difference to show a discrepancy entry.
+ * Discrepancies at or below this threshold are ignored to filter
+ * out floating-point noise.
+ *
+ * Value: 1% (0.01)
+ */
+export const DISCREPANCY_THRESHOLD = 0.01;
+
+/**
+ * Colors for discrepancy visualization.
+ * - unknown: Gray for missing/unaccounted data (informational)
+ * - overage: Amber for excess data (warning, may indicate bug)
+ */
+export const DISCREPANCY_COLORS = {
+  unknown: '#6b7280', // gray-600
+  overage: '#fbbf24', // amber-400
+} as const;
+
+/**
+ * Type of discrepancy detected between source sum and total.
+ * - 'unknown': Total > source sum (missing data)
+ * - 'overage': Source sum > total (excess data)
+ * - null: No significant discrepancy
+ */
+export type DiscrepancyType = 'unknown' | 'overage';
+
+/**
+ * Field names used for discrepancy entries.
+ * Prefixed with underscore to distinguish from real fields.
+ */
+export const DISCREPANCY_FIELD_NAMES = {
+  unknown: '_unknown',
+  overage: '_overage',
+} as const;
+
+/**
+ * Display names shown to users for discrepancy entries.
+ */
+export const DISCREPANCY_DISPLAY_NAMES = {
+  unknown: 'Unknown',
+  overage: 'Overage',
+} as const;

--- a/src/shared/domain/fields/breakdown-sources/index.ts
+++ b/src/shared/domain/fields/breakdown-sources/index.ts
@@ -62,6 +62,19 @@ export const COINS_EARNED_CATEGORY: FieldCategory = {
   fields: COIN_FIELDS,
 };
 
+// Discrepancy detection
+export {
+  
+  DISCREPANCY_COLORS,
+  DISCREPANCY_FIELD_NAMES,
+  DISCREPANCY_DISPLAY_NAMES,
+  type DiscrepancyType,
+} from './discrepancy-config';
+export {
+  calculateDiscrepancy,
+  
+} from './discrepancy-calculation';
+
 // Future categories will follow the same pattern:
 // export const ENEMIES_DESTROYED_CATEGORY: FieldCategory = { ... };
 // export const ENEMIES_AFFECTED_BY_CATEGORY: FieldCategory = { ... };


### PR DESCRIPTION
## Summary
Breakdown displays now show "Unknown" or "Overage" entries when the listed sources don't add up to the reported total. Unknown (gray) appears when data is missing; Overage (amber) appears when sources exceed the total. This helps users identify data quality issues and understand when to trust or question their analytics.

The feature applies to Run Details breakdowns (individual runs) and Source Analysis charts (aggregated trends), using a 1% threshold to filter out insignificant floating-point differences.

## Technical Details
- Added shared discrepancy calculation module (`discrepancy-calculation.ts`, `discrepancy-config.ts`) with pure functions and constants
- Extended `BreakdownItem` and `SourceValue` types with `isDiscrepancy` and `discrepancyType` fields
- Modified `calculateBreakdownGroup()` to detect and append discrepancy items for Run Details
- Modified `calculatePeriodBreakdown()` and `calculateSummary()` to aggregate discrepancies across runs/periods for Source Analysis
- Added distinct visual styling: dashed borders, muted fill for discrepancy bars in Run Details
- Implemented explanatory tooltips for discrepancy items in Run Details (`breakdown-tooltip.ts`)
- Added `skipDiscrepancy` config option for breakdowns where sources aren't expected to sum to total
- Updated E2E test expectations to reflect percentage calculation against totalField
