### PR TITLE
IMPROVE: Add E2E test coverage for Coverage Report page

### DIFF
--- a/e2e/features/analytics/coverage-report.spec.ts
+++ b/e2e/features/analytics/coverage-report.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '../../fixtures/seeded-page';
+import { AppPage } from '../../page-objects/app-page';
+import { CoverageReportPage } from '../../page-objects/coverage-report-page';
+
+/**
+ * Coverage Report E2E Test
+ *
+ * Single happy-path test that verifies:
+ * - Page loads and renders charts
+ * - Duration filter switching works
+ * - Timeline chart tooltip shows real data on hover
+ * - Death Wave metric appears with correct percentage value
+ */
+
+test.describe('Coverage Report', () => {
+  test('loads page, switches to monthly, and shows tooltip with coverage data', async ({ seededPage }) => {
+    const appPage = new AppPage(seededPage);
+    const coverageReportPage = new CoverageReportPage(seededPage);
+
+    // Step 1: Navigate to Coverage Report page via sidebar
+    await appPage.goto();
+    await appPage.coverageReportLink.click();
+    await coverageReportPage.waitForChartLoad();
+
+    // Step 2: Verify chart container is visible
+    await expect(coverageReportPage.chartContainer).toBeVisible();
+
+    // Step 3: Switch to Monthly duration
+    await coverageReportPage.switchToMonthly();
+
+    // Step 4: Hover over a month label on the timeline chart (monthly view shows "Oct '25" format)
+    await coverageReportPage.hoverOverChartLabel("Oct '25");
+
+    // Step 5: Verify tooltip appears with Death Wave and specific percentage value
+    const tooltipContent = await coverageReportPage.getTooltipContent();
+    expect(tooltipContent).toBeTruthy();
+    expect(tooltipContent).toContain('Death Wave');
+    expect(tooltipContent).toContain('13.2%'); // Death Wave coverage percentage for Oct '25
+  });
+});

--- a/e2e/page-objects/app-page.ts
+++ b/e2e/page-objects/app-page.ts
@@ -30,6 +30,7 @@ export class AppPage {
   readonly tierStatsLink: Locator;
   readonly tierTrendsLink: Locator;
   readonly sourceAnalysisLink: Locator;
+  readonly coverageReportLink: Locator;
 
   // Sidebar navigation - Settings section (deep links to settings page)
   readonly regionalFormatLink: Locator;
@@ -60,6 +61,7 @@ export class AppPage {
     this.tierStatsLink = page.locator('a:has-text("Tier Stats")');
     this.tierTrendsLink = page.locator('a:has-text("Tier Trends")');
     this.sourceAnalysisLink = page.locator('a:has-text("Source Analysis")');
+    this.coverageReportLink = page.locator('a:has-text("Coverage Report")');
 
     // Settings section (deep links to settings page)
     this.regionalFormatLink = page.locator('a:has-text("Regional Format")');

--- a/e2e/page-objects/coverage-report-page.ts
+++ b/e2e/page-objects/coverage-report-page.ts
@@ -1,0 +1,44 @@
+import { Page } from '@playwright/test';
+import { BaseAnalyticsPage } from './base-analytics-page';
+
+/**
+ * Coverage Report Page Object Model
+ *
+ * Extends BaseAnalyticsPage to provide Coverage Report specific functionality:
+ * - Multi-chart page with timeline and summary charts
+ * - Targets "Coverage Percentages Over Time" chart for hover interactions
+ *
+ * Inherits from BaseAnalyticsPage:
+ * - Time period switching
+ * - Chart hover with optional chartTitle parameter for multi-chart targeting
+ * - Tooltip content retrieval with multi-strategy detection
+ */
+export class CoverageReportPage extends BaseAnalyticsPage {
+  // Timeline chart title for targeting hover interactions
+  static readonly TIMELINE_CHART_TITLE = 'Coverage Percentages Over Time';
+
+  constructor(page: Page) {
+    super(page);
+  }
+
+  /**
+   * Navigate to the Coverage Report page
+   */
+  async goto(): Promise<void> {
+    await this.page.goto('/charts/coverage');
+    await this.waitForChartLoad();
+  }
+
+  /**
+   * Hover over a specific X-axis label on the TIMELINE chart to trigger tooltip
+   *
+   * Overrides base implementation to automatically target the timeline chart
+   * since Coverage Report has multiple charts.
+   *
+   * @param labelText - The X-axis label text to hover over (e.g., "Oct 25")
+   */
+  async hoverOverChartLabel(labelText: string): Promise<void> {
+    // Call base implementation with the timeline chart title
+    await super.hoverOverChartLabel(labelText, CoverageReportPage.TIMELINE_CHART_TITLE);
+  }
+}


### PR DESCRIPTION
## Summary
Adds end-to-end test coverage for the Coverage Report analytics page. The test verifies the page loads correctly, duration filters work, and chart tooltips display accurate coverage percentages when hovering over timeline data points.

## Technical Details
- Created `CoverageReportPage` POM extending `BaseAnalyticsPage` with multi-chart targeting
- Overrides `hoverOverChartLabel()` to automatically target the "Coverage Percentages Over Time" chart
- Added `coverageReportLink` locator to `AppPage` for sidebar navigation
- Single happy-path test covers: navigation, chart rendering, Monthly filter, and tooltip verification
- Validates specific data point: Death Wave at 13.2% for Oct '25