### PR TITLE
BUG: Fix production build failure from Web Worker path alias resolution

### DIFF
--- a/src/features/tools/module-calculator/simulation/monte-carlo-simulation.ts
+++ b/src/features/tools/module-calculator/simulation/monte-carlo-simulation.ts
@@ -5,7 +5,8 @@
  * Runs multiple iterations to generate cost distributions.
  */
 
-import { getLockCost, RARITY_ORDER } from '@/shared/domain/module-data';
+// Note: Using relative import for Web Worker compatibility (path aliases don't resolve in worker bundles)
+import { getLockCost, RARITY_ORDER } from '../../../../shared/domain/module-data';
 import type {
   CalculatorConfig,
   SimulationConfig,
@@ -121,7 +122,7 @@ function rollUntilTargetHitFast(
     const target = checkTargetMatch(
       entry,
       targets,
-      minRarityForEffect as Map<string, import('@/shared/domain/module-data').Rarity>
+      minRarityForEffect as Map<string, import('../../../../shared/domain/module-data').Rarity>
     );
 
     if (target) {
@@ -146,7 +147,7 @@ function buildMinRarityMap(targets: SlotTarget[]): Map<string, string> {
       } else {
         // Keep the lower minimum (more permissive)
         const existingIndex = RARITY_ORDER.indexOf(
-          existing as import('@/shared/domain/module-data').Rarity
+          existing as import('../../../../shared/domain/module-data').Rarity
         );
         const newIndex = RARITY_ORDER.indexOf(target.minRarity);
         if (newIndex < existingIndex) {
@@ -175,7 +176,7 @@ function updateMinRarityMap(
         map.set(effectId, target.minRarity);
       } else {
         const existingIndex = RARITY_ORDER.indexOf(
-          existing as import('@/shared/domain/module-data').Rarity
+          existing as import('../../../../shared/domain/module-data').Rarity
         );
         const newIndex = RARITY_ORDER.indexOf(target.minRarity);
         if (newIndex < existingIndex) {

--- a/src/features/tools/module-calculator/simulation/pool-dynamics.ts
+++ b/src/features/tools/module-calculator/simulation/pool-dynamics.ts
@@ -5,13 +5,14 @@
  * probability recalculation as the pool changes.
  */
 
-import type { ModuleType, Rarity } from '@/shared/domain/module-data';
+// Note: Using relative import for Web Worker compatibility (path aliases don't resolve in worker bundles)
+import type { ModuleType, Rarity } from '../../../../shared/domain/module-data';
 import {
   getSubEffectsForModule,
   getRarityProbability,
   getAvailableRarities,
   RARITY_ORDER,
-} from '@/shared/domain/module-data';
+} from '../../../../shared/domain/module-data';
 import type { PoolEntry, SlotTarget } from '../types';
 
 /**


### PR DESCRIPTION
## Summary
Fixed a production build failure caused by Web Worker bundling issues. The `@/` path aliases in files imported by the web worker were not resolving correctly during Vite's production build because web workers are bundled separately from the main application.

## Technical Details
- Converted `@/shared/domain/module-data` imports to relative paths in `monte-carlo-simulation.ts`
- Converted `@/shared/domain/module-data` imports to relative paths in `pool-dynamics.ts`
- Added explanatory comments documenting why relative imports are required for worker compatibility
- Fixed both static imports and inline dynamic type imports

## Context
This issue emerged after adding Web Worker parallelization in #156. The development build worked because Vite's dev server handles path resolution differently than the production bundler.