### PR TITLE
BUG: Fix module effect priority handling in Monte Carlo simulation

### DIFF
--- a/src/features/tools/module-calculator/results/results-formatters.test.ts
+++ b/src/features/tools/module-calculator/results/results-formatters.test.ts
@@ -27,21 +27,23 @@ describe('results-formatters', () => {
       expect(formatCost(999999)).toBe('1000.0K');
     });
 
-    it('formats millions with M suffix', () => {
-      expect(formatCost(1000000)).toBe('1.0M');
-      expect(formatCost(2500000)).toBe('2.5M');
+    it('formats millions with M suffix and 2 decimals', () => {
+      expect(formatCost(1000000)).toBe('1.00M');
+      expect(formatCost(2500000)).toBe('2.50M');
+      expect(formatCost(1580000)).toBe('1.58M');
+      expect(formatCost(1660000)).toBe('1.66M');
     });
 
-    it('formats billions with B suffix', () => {
-      expect(formatCost(1000000000)).toBe('1.0B');
-      expect(formatCost(3700000000)).toBe('3.7B');
+    it('formats billions with B suffix and 2 decimals', () => {
+      expect(formatCost(1000000000)).toBe('1.00B');
+      expect(formatCost(3700000000)).toBe('3.70B');
     });
   });
 
   describe('formatCostRange', () => {
     it('formats range with appropriate suffixes', () => {
       expect(formatCostRange(1000, 5000)).toBe('1.0K - 5.0K');
-      expect(formatCostRange(500000, 2000000)).toBe('500.0K - 2.0M');
+      expect(formatCostRange(500000, 2000000)).toBe('500.0K - 2.00M');
     });
   });
 
@@ -128,14 +130,14 @@ describe('results-formatters', () => {
   describe('formatRunCount', () => {
     it('formats with appropriate suffix', () => {
       expect(formatRunCount(10000)).toBe('Based on 10.0K simulations');
-      expect(formatRunCount(1000000)).toBe('Based on 1.0M simulations');
+      expect(formatRunCount(1000000)).toBe('Based on 1.00M simulations');
     });
   });
 
   describe('formatConfidenceMessage', () => {
     it('formats confidence message', () => {
       expect(formatConfidenceMessage(5000000)).toBe(
-        '95% of runs cost less than 5.0M shards'
+        '95% of runs cost less than 5.00M shards'
       );
     });
   });

--- a/src/features/tools/module-calculator/results/results-formatters.ts
+++ b/src/features/tools/module-calculator/results/results-formatters.ts
@@ -6,13 +6,15 @@
 
 /**
  * Format a large number with appropriate suffix (K, M, B)
+ *
+ * Uses 2 decimal places for better precision when comparing similar values.
  */
 export function formatCost(value: number): string {
   if (value >= 1_000_000_000) {
-    return `${(value / 1_000_000_000).toFixed(1)}B`;
+    return `${(value / 1_000_000_000).toFixed(2)}B`;
   }
   if (value >= 1_000_000) {
-    return `${(value / 1_000_000).toFixed(1)}M`;
+    return `${(value / 1_000_000).toFixed(2)}M`;
   }
   if (value >= 1_000) {
     return `${(value / 1_000).toFixed(1)}K`;


### PR DESCRIPTION
## Summary
Fixed two bugs in the Module Reroll Calculator where same-priority effects were incorrectly treated as mutually exclusive ("pick one") instead of "acquire all in any order", and the simulation would accept any target effect regardless of whether higher-priority effects were still pending. Also increased cost display precision from 1 to 2 decimal places for values in millions/billions.

## Technical Details
- Modified `selectionsToSlotTargets()` to expand each same-priority effect into its own slot target, with all targets in the group sharing the full acceptable effects pool
- Added `getCurrentPriorityTargets()` to identify targets in the current priority group based on shared acceptable effects
- Added `removeLockedEffectFromTargets()` to remove locked effects from remaining targets' pools, preventing double-counting
- Updated `simulateSingleRun()` to only roll for current priority group targets, ensuring sequential priority respect
- Changed `formatCost()` to use 2 decimal places for M/B suffixes for better precision when comparing similar costs
- Added comprehensive tests for multi-effect priority groups and sequential priority behavior