### PR TITLE
MINOR: Add Manual Practice Mode to Module Reroll Calculator

### DIFF
--- a/src/features/tools/module-calculator/manual-mode/effect-slot-row.tsx
+++ b/src/features/tools/module-calculator/manual-mode/effect-slot-row.tsx
@@ -1,0 +1,232 @@
+/**
+ * Effect Slot Row
+ *
+ * Single slot row with effect display and lock toggle for manual mode.
+ */
+
+import type { ManualSlot } from './types';
+import { getRarityColor } from '@/shared/domain/module-data';
+
+interface EffectSlotRowProps {
+  slot: ManualSlot;
+  onLock: (slotNumber: number) => void;
+  onUnlock: (slotNumber: number) => void;
+  canLock: boolean;
+}
+
+export function EffectSlotRow({
+  slot,
+  onLock,
+  onUnlock,
+  canLock,
+}: EffectSlotRowProps) {
+  const hasEffect = slot.effect !== null && slot.rarity !== null;
+
+  const handleLockClick = () => {
+    if (slot.isLocked) {
+      onUnlock(slot.slotNumber);
+    } else if (hasEffect && canLock) {
+      onLock(slot.slotNumber);
+    }
+  };
+
+  const rowClassName = buildRowClassName(slot.isLocked, slot.isTargetMatch && hasEffect);
+
+  return (
+    <div className={rowClassName}>
+      {/* Slot Number */}
+      <SlotNumber number={slot.slotNumber} />
+
+      {/* Rarity Badge */}
+      <RarityBadge rarity={slot.rarity} />
+
+      {/* Effect Text */}
+      <EffectText slot={slot} />
+
+      {/* Target Match Indicator */}
+      {slot.isTargetMatch && hasEffect && (
+        <TargetMatchIndicator />
+      )}
+
+      {/* Lock Button */}
+      <LockButton
+        isLocked={slot.isLocked}
+        canLock={canLock && hasEffect}
+        onClick={handleLockClick}
+      />
+    </div>
+  );
+}
+
+function buildRowClassName(isLocked: boolean, isTargetMatch: boolean): string {
+  const base = 'flex items-center gap-3 px-3 py-2 rounded-lg transition-all duration-200';
+
+  if (isLocked && isTargetMatch) {
+    return `${base} bg-green-500/8 border border-cyan-500/40`;
+  }
+  if (isLocked) {
+    return `${base} bg-cyan-500/5 border border-cyan-500/30`;
+  }
+  if (isTargetMatch) {
+    return `${base} bg-green-500/8 border border-green-500/30`;
+  }
+  return `${base} bg-slate-800/20 border border-slate-700/30 hover:bg-slate-800/40 hover:border-slate-700/50`;
+}
+
+interface SlotNumberProps {
+  number: number;
+}
+
+function SlotNumber({ number }: SlotNumberProps) {
+  return (
+    <span className="text-xs text-slate-500 w-5 text-center tabular-nums font-medium">
+      {number}
+    </span>
+  );
+}
+
+interface RarityBadgeProps {
+  rarity: ManualSlot['rarity'];
+}
+
+function RarityBadge({ rarity }: RarityBadgeProps) {
+  // Fixed width to accommodate "Legendary" (longest word), all badges same size
+  const badgeWidth = 'w-[5rem]';
+
+  if (!rarity) {
+    return (
+      <span className={`inline-flex items-center justify-center text-[10px] font-medium text-slate-600 uppercase tracking-wide ${badgeWidth} py-0.5`}>
+        ---
+      </span>
+    );
+  }
+
+  const color = getRarityColor(rarity);
+  const label = formatRarityLabel(rarity);
+
+  return (
+    <span
+      className={`inline-flex items-center justify-center text-[10px] font-bold uppercase tracking-wide ${badgeWidth} py-0.5 px-1 rounded border`}
+      style={{
+        backgroundColor: `${color}12`,
+        color: color,
+        borderColor: `${color}25`,
+      }}
+    >
+      {label}
+    </span>
+  );
+}
+
+function formatRarityLabel(rarity: string): string {
+  // Full rarity names with proper capitalization (matching the game's display)
+  const labels: Record<string, string> = {
+    common: 'Common',
+    rare: 'Rare',
+    epic: 'Epic',
+    legendary: 'Legendary',
+    mythic: 'Mythic',
+    ancestral: 'Ancestral',
+  };
+  return labels[rarity] ?? rarity;
+}
+
+interface EffectTextProps {
+  slot: ManualSlot;
+}
+
+function EffectText({ slot }: EffectTextProps) {
+  if (!slot.effect || !slot.rarity) {
+    return (
+      <span className="flex-1 text-sm text-slate-600 italic">
+        Waiting for roll...
+      </span>
+    );
+  }
+
+  const rawValue = slot.effect.values[slot.rarity];
+  const value = typeof rawValue === 'number' ? rawValue : (rawValue ? parseFloat(rawValue) : 0);
+  const displayName = slot.effect.displayName;
+  const valuePrefix = formatValuePrefix(value, slot.effect.id);
+
+  return (
+    <span className="flex-1 text-sm text-slate-300 truncate">
+      <span className="text-orange-400 font-semibold tabular-nums">{valuePrefix}</span>
+      <span className="mx-1.5 text-slate-600">|</span>
+      <span className="text-slate-200">{displayName}</span>
+    </span>
+  );
+}
+
+function formatValuePrefix(value: number, effectId: string): string {
+  // Percentage-based effects (most effects use percentages)
+  const isPercentage = !effectId.includes('Flat');
+
+  if (isPercentage) {
+    // Values are already in percentage form in the data
+    return `+${value}%`;
+  }
+
+  // Flat values
+  return `+${value}`;
+}
+
+function TargetMatchIndicator() {
+  return (
+    <span
+      className="flex items-center justify-center w-5 h-5 text-green-400"
+      title="Target match!"
+    >
+      <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+        <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z" />
+      </svg>
+    </span>
+  );
+}
+
+interface LockButtonProps {
+  isLocked: boolean;
+  canLock: boolean;
+  onClick: () => void;
+}
+
+function LockButton({ isLocked, canLock, onClick }: LockButtonProps) {
+  const disabled = !isLocked && !canLock;
+  const className = buildLockButtonClassName(isLocked, disabled);
+
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      className={className}
+      title={isLocked ? 'Unlock slot' : 'Lock slot'}
+      aria-pressed={isLocked}
+    >
+      <LockIcon isLocked={isLocked} />
+    </button>
+  );
+}
+
+function buildLockButtonClassName(isLocked: boolean, disabled: boolean): string {
+  const base = 'flex items-center justify-center w-8 h-8 rounded-md transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900';
+
+  if (isLocked) {
+    return `${base} text-cyan-400 bg-cyan-500/15 border border-cyan-500/30 hover:bg-cyan-500/25 hover:border-cyan-500/40 focus-visible:ring-cyan-500/50`;
+  }
+  if (disabled) {
+    return `${base} text-slate-700 cursor-not-allowed`;
+  }
+  return `${base} text-slate-500 hover:text-slate-300 hover:bg-slate-700/50 border border-transparent hover:border-slate-600/50 focus-visible:ring-slate-500/50`;
+}
+
+function LockIcon({ isLocked }: { isLocked: boolean }) {
+  return (
+    <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+      {isLocked ? (
+        <path d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2z" />
+      ) : (
+        <path d="M12 17c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm6-9h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6h1.9c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm0 12H6V10h12v10z" />
+      )}
+    </svg>
+  );
+}

--- a/src/features/tools/module-calculator/manual-mode/effect-slots-table.tsx
+++ b/src/features/tools/module-calculator/manual-mode/effect-slots-table.tsx
@@ -1,0 +1,40 @@
+/**
+ * Effect Slots Table
+ *
+ * Container for all 8 effect slot rows in manual mode.
+ */
+
+import type { ManualSlot } from './types';
+import { EffectSlotRow } from './effect-slot-row';
+
+interface EffectSlotsTableProps {
+  slots: ManualSlot[];
+  onLockSlot: (slotNumber: number) => void;
+  onUnlockSlot: (slotNumber: number) => void;
+  maxLocks: number;
+  lockedCount: number;
+}
+
+export function EffectSlotsTable({
+  slots,
+  onLockSlot,
+  onUnlockSlot,
+  maxLocks,
+  lockedCount,
+}: EffectSlotsTableProps) {
+  const canLockMore = lockedCount < maxLocks;
+
+  return (
+    <div className="space-y-1.5">
+      {slots.map((slot) => (
+        <EffectSlotRow
+          key={slot.slotNumber}
+          slot={slot}
+          onLock={onLockSlot}
+          onUnlock={onUnlockSlot}
+          canLock={canLockMore}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/features/tools/module-calculator/manual-mode/index.ts
+++ b/src/features/tools/module-calculator/manual-mode/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Manual Mode
+ *
+ * Public exports for the manual practice mode feature.
+ */
+
+export { ManualModePanel } from './manual-mode-panel';
+export { useManualMode } from './use-manual-mode';;;

--- a/src/features/tools/module-calculator/manual-mode/manual-mode-logic.test.ts
+++ b/src/features/tools/module-calculator/manual-mode/manual-mode-logic.test.ts
@@ -1,0 +1,824 @@
+/* eslint-disable max-lines */
+import { describe, it, expect } from 'vitest';
+import type { CalculatorConfig, SlotTarget } from '../types';
+import type { ManualModeConfig } from './types';
+import {
+  initializeManualMode,
+  executeRoll,
+  lockSlot,
+  unlockSlot,
+  canRoll,
+  canAutoRoll,
+  getCurrentRollCost,
+  getCurrentBalance,
+  checkCompletion,
+  countUnfulfilledTargetEffects,
+  markComplete,
+  setAutoRolling,
+  getBalanceStatus,
+  countOpenSlots,
+  countLockedSlots,
+  getPoolSize,
+  buildMinRarityMap,
+} from './manual-mode-logic';
+
+describe('manual-mode-logic', () => {
+  const createTestConfig = (overrides?: Partial<CalculatorConfig>): CalculatorConfig => ({
+    moduleType: 'cannon',
+    moduleLevel: 100,
+    moduleRarity: 'ancestral',
+    slotCount: 8,
+    bannedEffects: [],
+    slotTargets: [],
+    preLockedEffects: [],
+    ...overrides,
+  });
+
+  const createModeConfig = (targets: SlotTarget[] = []): ManualModeConfig => ({
+    targets,
+    minRarityMap: buildMinRarityMap(targets),
+  });
+
+  describe('buildMinRarityMap', () => {
+    it('builds map from slot targets', () => {
+      const targets: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['attackSpeed'], minRarity: 'legendary' },
+        { slotNumber: 2, acceptableEffects: ['critChance'], minRarity: 'epic' },
+      ];
+
+      const map = buildMinRarityMap(targets);
+
+      expect(map.get('attackSpeed')).toBe('legendary');
+      expect(map.get('critChance')).toBe('epic');
+    });
+
+    it('returns empty map for no targets', () => {
+      const map = buildMinRarityMap([]);
+      expect(map.size).toBe(0);
+    });
+  });
+
+  describe('initializeManualMode', () => {
+    it('creates initial state with correct slot count', () => {
+      const config = createTestConfig({ slotCount: 8 });
+      const state = initializeManualMode(config, 'accumulator', 0);
+
+      expect(state.slots).toHaveLength(8);
+      expect(state.slots.every((s) => !s.isLocked)).toBe(true);
+      expect(state.slots.every((s) => s.effect === null)).toBe(true);
+    });
+
+    it('initializes with budget mode settings', () => {
+      const config = createTestConfig();
+      const state = initializeManualMode(config, 'budget', 10000);
+
+      expect(state.shardMode).toBe('budget');
+      expect(state.startingBalance).toBe(10000);
+      expect(state.totalSpent).toBe(0);
+    });
+
+    it('initializes with accumulator mode settings', () => {
+      const config = createTestConfig();
+      const state = initializeManualMode(config, 'accumulator', 0);
+
+      expect(state.shardMode).toBe('accumulator');
+      expect(state.startingBalance).toBe(0);
+      expect(state.totalSpent).toBe(0);
+    });
+
+    it('excludes banned effects from pool', () => {
+      const config = createTestConfig({ bannedEffects: ['attackSpeed'] });
+      const state = initializeManualMode(config, 'accumulator', 0);
+
+      const hasAttackSpeed = state.pool.entries.some(
+        (e) => e.effect.id === 'attackSpeed'
+      );
+      expect(hasAttackSpeed).toBe(false);
+    });
+
+    it('excludes pre-locked effects from pool', () => {
+      const config = createTestConfig({
+        preLockedEffects: [{ effectId: 'attackSpeed', rarity: 'legendary' }],
+      });
+      const state = initializeManualMode(config, 'accumulator', 0);
+
+      const hasAttackSpeed = state.pool.entries.some(
+        (e) => e.effect.id === 'attackSpeed'
+      );
+      expect(hasAttackSpeed).toBe(false);
+    });
+
+    it('initializes with correct default values', () => {
+      const config = createTestConfig();
+      const state = initializeManualMode(config, 'accumulator', 0);
+
+      expect(state.rollCount).toBe(0);
+      expect(state.isComplete).toBe(false);
+      expect(state.isAutoRolling).toBe(false);
+    });
+
+    it('has non-empty pool for valid configuration', () => {
+      const config = createTestConfig();
+      const state = initializeManualMode(config, 'accumulator', 0);
+
+      expect(state.pool.entries.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('executeRoll', () => {
+    it('fills all open slots', () => {
+      const config = createTestConfig({ slotCount: 4 });
+      const state = initializeManualMode(config, 'accumulator', 0);
+      const modeConfig = createModeConfig();
+
+      const { newState, result } = executeRoll(state, modeConfig);
+
+      // All slots should now have effects
+      expect(newState.slots.filter((s) => s.effect !== null)).toHaveLength(4);
+      expect(result.filledSlotIndexes).toHaveLength(4);
+    });
+
+    it('increments roll count', () => {
+      const config = createTestConfig();
+      const state = initializeManualMode(config, 'accumulator', 0);
+      const modeConfig = createModeConfig();
+
+      const { newState } = executeRoll(state, modeConfig);
+
+      expect(newState.rollCount).toBe(1);
+    });
+
+    it('adds shard cost to totalSpent', () => {
+      const config = createTestConfig();
+      const state = initializeManualMode(config, 'accumulator', 0);
+      const modeConfig = createModeConfig();
+
+      const { newState, result } = executeRoll(state, modeConfig);
+
+      expect(newState.totalSpent).toBe(result.shardCost);
+      expect(result.shardCost).toBe(10); // First lock cost is 10
+    });
+
+    it('skips locked slots', () => {
+      const config = createTestConfig({ slotCount: 4 });
+      const state = initializeManualMode(config, 'accumulator', 0);
+      const modeConfig = createModeConfig();
+
+      // First roll to fill slots
+      const { newState: stateAfterRoll } = executeRoll(state, modeConfig);
+
+      // Lock slot 1
+      const stateWithLock = lockSlot(stateAfterRoll, 1);
+      expect(stateWithLock.slots[0].isLocked).toBe(true);
+
+      // Second roll should skip slot 1
+      const { result } = executeRoll(stateWithLock, modeConfig);
+
+      expect(result.filledSlotIndexes).not.toContain(0);
+      expect(result.filledSlotIndexes).toHaveLength(3);
+    });
+
+    it('returns no-op when all slots are locked', () => {
+      const config = createTestConfig({ slotCount: 2 });
+      const state = initializeManualMode(config, 'accumulator', 0);
+      const modeConfig = createModeConfig();
+
+      // Fill slots first
+      const { newState: stateAfterRoll } = executeRoll(state, modeConfig);
+
+      // Lock all slots
+      let lockedState = lockSlot(stateAfterRoll, 1);
+      lockedState = lockSlot(lockedState, 2);
+
+      const { newState, result } = executeRoll(lockedState, modeConfig);
+
+      expect(result.shardCost).toBe(0);
+      expect(result.filledSlotIndexes).toHaveLength(0);
+      expect(newState.rollCount).toBe(lockedState.rollCount);
+    });
+
+    it('detects target matches', () => {
+      const config = createTestConfig({ slotCount: 4 });
+      const targets: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['attackSpeed'], minRarity: 'common' },
+      ];
+      const state = initializeManualMode(config, 'accumulator', 0);
+      const modeConfig = createModeConfig(targets);
+
+      // Run multiple rolls to increase chance of hitting target
+      let currentState = state;
+      let hitTarget = false;
+
+      for (let i = 0; i < 50 && !hitTarget; i++) {
+        const { newState, result } = executeRoll(currentState, modeConfig);
+        hitTarget = result.hasTargetHit;
+        currentState = newState;
+      }
+
+      // With enough rolls, should eventually hit the target
+      expect(hitTarget).toBe(true);
+    });
+  });
+
+  describe('lockSlot', () => {
+    it('locks slot with effect', () => {
+      const config = createTestConfig({ slotCount: 4 });
+      const state = initializeManualMode(config, 'accumulator', 0);
+      const modeConfig = createModeConfig();
+
+      // Fill slots first
+      const { newState } = executeRoll(state, modeConfig);
+
+      const lockedState = lockSlot(newState, 1);
+
+      expect(lockedState.slots[0].isLocked).toBe(true);
+    });
+
+    it('removes effect from pool when locked', () => {
+      const config = createTestConfig({ slotCount: 4 });
+      const state = initializeManualMode(config, 'accumulator', 0);
+      const modeConfig = createModeConfig();
+
+      // Fill slots first
+      const { newState } = executeRoll(state, modeConfig);
+
+      const effectId = newState.slots[0].effect!.id;
+      const initialPoolSize = newState.pool.entries.filter(
+        (e) => e.effect.id === effectId
+      ).length;
+
+      const lockedState = lockSlot(newState, 1);
+
+      const finalPoolSize = lockedState.pool.entries.filter(
+        (e) => e.effect.id === effectId
+      ).length;
+
+      expect(finalPoolSize).toBe(0);
+      expect(initialPoolSize).toBeGreaterThan(0);
+    });
+
+    it('does nothing for empty slot', () => {
+      const config = createTestConfig({ slotCount: 4 });
+      const state = initializeManualMode(config, 'accumulator', 0);
+
+      const result = lockSlot(state, 1);
+
+      expect(result).toBe(state);
+    });
+
+    it('does nothing for already locked slot', () => {
+      const config = createTestConfig({ slotCount: 4 });
+      const state = initializeManualMode(config, 'accumulator', 0);
+      const modeConfig = createModeConfig();
+
+      const { newState } = executeRoll(state, modeConfig);
+      const lockedOnce = lockSlot(newState, 1);
+      const lockedTwice = lockSlot(lockedOnce, 1);
+
+      expect(lockedTwice).toBe(lockedOnce);
+    });
+  });
+
+  describe('unlockSlot', () => {
+    it('unlocks a locked slot', () => {
+      const config = createTestConfig({ slotCount: 4 });
+      const state = initializeManualMode(config, 'accumulator', 0);
+      const modeConfig = createModeConfig();
+
+      const { newState } = executeRoll(state, modeConfig);
+      const lockedState = lockSlot(newState, 1);
+      const unlockedState = unlockSlot(lockedState, 1, config);
+
+      expect(unlockedState.slots[0].isLocked).toBe(false);
+    });
+
+    it('restores effect to pool when unlocked', () => {
+      const config = createTestConfig({ slotCount: 4 });
+      const state = initializeManualMode(config, 'accumulator', 0);
+      const modeConfig = createModeConfig();
+
+      const { newState } = executeRoll(state, modeConfig);
+      const effectId = newState.slots[0].effect!.id;
+
+      const lockedState = lockSlot(newState, 1);
+      const lockedPoolSize = lockedState.pool.entries.filter(
+        (e) => e.effect.id === effectId
+      ).length;
+      expect(lockedPoolSize).toBe(0);
+
+      const unlockedState = unlockSlot(lockedState, 1, config);
+      const unlockedPoolSize = unlockedState.pool.entries.filter(
+        (e) => e.effect.id === effectId
+      ).length;
+      expect(unlockedPoolSize).toBeGreaterThan(0);
+    });
+
+    it('does nothing for unlocked slot', () => {
+      const config = createTestConfig({ slotCount: 4 });
+      const state = initializeManualMode(config, 'accumulator', 0);
+      const modeConfig = createModeConfig();
+
+      const { newState } = executeRoll(state, modeConfig);
+      const result = unlockSlot(newState, 1, config);
+
+      expect(result).toBe(newState);
+    });
+  });
+
+  describe('canRoll', () => {
+    it('allows roll with open slots and pool', () => {
+      const config = createTestConfig();
+      const state = initializeManualMode(config, 'accumulator', 0);
+
+      const result = canRoll(state);
+
+      expect(result.allowed).toBe(true);
+      expect(result.reason).toBeNull();
+    });
+
+    it('disallows roll when all slots locked', () => {
+      const config = createTestConfig({ slotCount: 2 });
+      const state = initializeManualMode(config, 'accumulator', 0);
+      const modeConfig = createModeConfig();
+
+      const { newState } = executeRoll(state, modeConfig);
+      let lockedState = lockSlot(newState, 1);
+      lockedState = lockSlot(lockedState, 2);
+
+      const result = canRoll(lockedState);
+
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe('All slots are locked');
+    });
+
+    it('disallows roll when budget depleted', () => {
+      const config = createTestConfig();
+      const state = initializeManualMode(config, 'budget', 5); // Only 5 shards, cost is 10
+
+      const result = canRoll(state);
+
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe('Insufficient shard balance');
+    });
+
+    it('allows manual roll when session complete (users can continue rolling)', () => {
+      const config = createTestConfig();
+      let state = initializeManualMode(config, 'accumulator', 0);
+      state = markComplete(state);
+
+      // canRoll now allows rolling after session complete
+      // (the completion is informational only)
+      const result = canRoll(state);
+
+      expect(result.allowed).toBe(true);
+      expect(result.reason).toBe(null);
+    });
+  });
+
+  describe('getCurrentRollCost', () => {
+    it('returns 10 for no locked slots', () => {
+      const config = createTestConfig();
+      const state = initializeManualMode(config, 'accumulator', 0);
+
+      expect(getCurrentRollCost(state)).toBe(10);
+    });
+
+    it('returns 40 for 1 locked slot', () => {
+      const config = createTestConfig({ slotCount: 4 });
+      const state = initializeManualMode(config, 'accumulator', 0);
+      const modeConfig = createModeConfig();
+
+      const { newState } = executeRoll(state, modeConfig);
+      const lockedState = lockSlot(newState, 1);
+
+      expect(getCurrentRollCost(lockedState)).toBe(40);
+    });
+
+    it('returns 160 for 2 locked slots', () => {
+      const config = createTestConfig({ slotCount: 4 });
+      const state = initializeManualMode(config, 'accumulator', 0);
+      const modeConfig = createModeConfig();
+
+      const { newState } = executeRoll(state, modeConfig);
+      let lockedState = lockSlot(newState, 1);
+      lockedState = lockSlot(lockedState, 2);
+
+      expect(getCurrentRollCost(lockedState)).toBe(160);
+    });
+  });
+
+  describe('getCurrentBalance', () => {
+    it('returns remaining balance in budget mode', () => {
+      const config = createTestConfig();
+      const state = initializeManualMode(config, 'budget', 1000);
+      const modeConfig = createModeConfig();
+
+      const { newState } = executeRoll(state, modeConfig);
+
+      expect(getCurrentBalance(newState)).toBe(990); // 1000 - 10
+    });
+
+    it('returns total spent in accumulator mode', () => {
+      const config = createTestConfig();
+      const state = initializeManualMode(config, 'accumulator', 0);
+      const modeConfig = createModeConfig();
+
+      const { newState } = executeRoll(state, modeConfig);
+
+      expect(getCurrentBalance(newState)).toBe(10);
+    });
+  });
+
+  describe('countUnfulfilledTargetEffects', () => {
+    it('returns total effect count when nothing locked', () => {
+      const config = createTestConfig();
+      const state = initializeManualMode(config, 'accumulator', 0);
+
+      const targets: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['effectA', 'effectB'], minRarity: 'common' },
+        { slotNumber: 2, acceptableEffects: ['effectC'], minRarity: 'common' },
+      ];
+
+      // 3 unique effects: effectA, effectB, effectC
+      expect(countUnfulfilledTargetEffects(state, targets)).toBe(3);
+    });
+
+    it('returns 0 when all target effects are locked', () => {
+      const config = createTestConfig();
+      let state = initializeManualMode(config, 'accumulator', 0);
+
+      // Simulate locked slots with target effects
+      state = {
+        ...state,
+        slots: state.slots.map((slot, i) => {
+          if (i === 0) {
+            return { ...slot, isLocked: true, effect: { id: 'effectA', displayName: 'Effect A', moduleType: 'cannon', values: {} } as never };
+          }
+          if (i === 1) {
+            return { ...slot, isLocked: true, effect: { id: 'effectB', displayName: 'Effect B', moduleType: 'cannon', values: {} } as never };
+          }
+          return slot;
+        }),
+      };
+
+      const targets: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['effectA', 'effectB'], minRarity: 'common' },
+      ];
+
+      // Both effectA and effectB are locked
+      expect(countUnfulfilledTargetEffects(state, targets)).toBe(0);
+    });
+
+    it('counts only missing effects when some are locked', () => {
+      const config = createTestConfig();
+      let state = initializeManualMode(config, 'accumulator', 0);
+
+      // Lock one effect
+      state = {
+        ...state,
+        slots: state.slots.map((slot, i) => {
+          if (i === 0) {
+            return { ...slot, isLocked: true, effect: { id: 'effectA', displayName: 'Effect A', moduleType: 'cannon', values: {} } as never };
+          }
+          return slot;
+        }),
+      };
+
+      const targets: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['effectA', 'effectB', 'effectC'], minRarity: 'common' },
+      ];
+
+      // effectA is locked, effectB and effectC are not
+      expect(countUnfulfilledTargetEffects(state, targets)).toBe(2);
+    });
+  });
+
+  describe('checkCompletion', () => {
+    it('returns false with no targets', () => {
+      const config = createTestConfig();
+      const state = initializeManualMode(config, 'accumulator', 0);
+
+      expect(checkCompletion(state, [])).toBe(false);
+    });
+
+    it('returns true when pool is exhausted', () => {
+      const config = createTestConfig();
+      let state = initializeManualMode(config, 'accumulator', 0);
+
+      // Simulate exhausted pool
+      state = {
+        ...state,
+        pool: { entries: [], cumulativeProbs: [] },
+      };
+
+      const targets: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['attackSpeed'], minRarity: 'legendary' },
+      ];
+
+      expect(checkCompletion(state, targets)).toBe(true);
+    });
+
+    it('returns false when some target effects are not yet locked', () => {
+      const config = createTestConfig();
+      let state = initializeManualMode(config, 'accumulator', 0);
+
+      // Lock one effect but target has 2 effects
+      state = {
+        ...state,
+        slots: state.slots.map((slot, i) => {
+          if (i === 0) {
+            return { ...slot, isLocked: true, effect: { id: 'effectA', displayName: 'Effect A', moduleType: 'cannon', values: {} } as never };
+          }
+          return slot;
+        }),
+      };
+
+      const targets: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['effectA', 'effectB'], minRarity: 'common' },
+      ];
+
+      // Only effectA is locked, effectB is still needed
+      expect(checkCompletion(state, targets)).toBe(false);
+    });
+
+    it('returns true when all target effects are locked', () => {
+      const config = createTestConfig();
+      let state = initializeManualMode(config, 'accumulator', 0);
+
+      // Lock both effects
+      state = {
+        ...state,
+        slots: state.slots.map((slot, i) => {
+          if (i === 0) {
+            return { ...slot, isLocked: true, effect: { id: 'effectA', displayName: 'Effect A', moduleType: 'cannon', values: {} } as never };
+          }
+          if (i === 1) {
+            return { ...slot, isLocked: true, effect: { id: 'effectB', displayName: 'Effect B', moduleType: 'cannon', values: {} } as never };
+          }
+          return slot;
+        }),
+      };
+
+      const targets: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['effectA', 'effectB'], minRarity: 'common' },
+      ];
+
+      expect(checkCompletion(state, targets)).toBe(true);
+    });
+  });
+
+  describe('markComplete', () => {
+    it('sets isComplete to true', () => {
+      const config = createTestConfig();
+      const state = initializeManualMode(config, 'accumulator', 0);
+
+      const result = markComplete(state);
+
+      expect(result.isComplete).toBe(true);
+    });
+
+    it('stops auto-rolling', () => {
+      const config = createTestConfig();
+      let state = initializeManualMode(config, 'accumulator', 0);
+      state = setAutoRolling(state, true);
+
+      const result = markComplete(state);
+
+      expect(result.isAutoRolling).toBe(false);
+    });
+  });
+
+  describe('setAutoRolling', () => {
+    it('sets auto-rolling state', () => {
+      const config = createTestConfig();
+      const state = initializeManualMode(config, 'accumulator', 0);
+
+      const enabled = setAutoRolling(state, true);
+      expect(enabled.isAutoRolling).toBe(true);
+
+      const disabled = setAutoRolling(enabled, false);
+      expect(disabled.isAutoRolling).toBe(false);
+    });
+  });
+
+  describe('getBalanceStatus', () => {
+    it('returns normal for accumulator mode', () => {
+      const config = createTestConfig();
+      const state = initializeManualMode(config, 'accumulator', 0);
+
+      expect(getBalanceStatus(state)).toBe('normal');
+    });
+
+    it('returns normal for healthy budget', () => {
+      const config = createTestConfig();
+      const state = initializeManualMode(config, 'budget', 10000);
+
+      expect(getBalanceStatus(state)).toBe('normal');
+    });
+
+    it('returns warning for low budget', () => {
+      const config = createTestConfig();
+      let state = initializeManualMode(config, 'budget', 100);
+      // Simulate spending to get below 20%
+      state = { ...state, totalSpent: 85 }; // 15 remaining, < 20 (20% of 100)
+
+      expect(getBalanceStatus(state)).toBe('warning');
+    });
+
+    it('returns critical when cannot afford roll', () => {
+      const config = createTestConfig();
+      let state = initializeManualMode(config, 'budget', 100);
+      // Simulate spending to below roll cost
+      state = { ...state, totalSpent: 95 }; // 5 remaining, < 10 (roll cost)
+
+      expect(getBalanceStatus(state)).toBe('critical');
+    });
+  });
+
+  describe('countOpenSlots', () => {
+    it('returns all slots when none locked', () => {
+      const config = createTestConfig({ slotCount: 8 });
+      const state = initializeManualMode(config, 'accumulator', 0);
+
+      expect(countOpenSlots(state)).toBe(8);
+    });
+
+    it('decreases when slots are locked', () => {
+      const config = createTestConfig({ slotCount: 4 });
+      const state = initializeManualMode(config, 'accumulator', 0);
+      const modeConfig = createModeConfig();
+
+      const { newState } = executeRoll(state, modeConfig);
+      const lockedState = lockSlot(newState, 1);
+
+      expect(countOpenSlots(lockedState)).toBe(3);
+    });
+  });
+
+  describe('countLockedSlots', () => {
+    it('returns 0 when none locked', () => {
+      const config = createTestConfig({ slotCount: 8 });
+      const state = initializeManualMode(config, 'accumulator', 0);
+
+      expect(countLockedSlots(state)).toBe(0);
+    });
+
+    it('increases when slots are locked', () => {
+      const config = createTestConfig({ slotCount: 4 });
+      const state = initializeManualMode(config, 'accumulator', 0);
+      const modeConfig = createModeConfig();
+
+      const { newState } = executeRoll(state, modeConfig);
+      let lockedState = lockSlot(newState, 1);
+      lockedState = lockSlot(lockedState, 2);
+
+      expect(countLockedSlots(lockedState)).toBe(2);
+    });
+  });
+
+  describe('getPoolSize', () => {
+    it('returns initial pool size', () => {
+      const config = createTestConfig();
+      const state = initializeManualMode(config, 'accumulator', 0);
+
+      expect(getPoolSize(state)).toBeGreaterThan(0);
+    });
+
+    it('decreases when effects are locked', () => {
+      const config = createTestConfig({ slotCount: 4 });
+      const state = initializeManualMode(config, 'accumulator', 0);
+      const modeConfig = createModeConfig();
+
+      const { newState } = executeRoll(state, modeConfig);
+      const initialPoolSize = getPoolSize(newState);
+
+      const lockedState = lockSlot(newState, 1);
+      const finalPoolSize = getPoolSize(lockedState);
+
+      expect(finalPoolSize).toBeLessThan(initialPoolSize);
+    });
+  });
+
+  describe('canAutoRoll', () => {
+    it('allows auto-roll when targets exist and not all acquired', () => {
+      const target: SlotTarget = {
+        slotNumber: 1,
+        acceptableEffects: ['cannonCritChance'],
+        minRarity: 'common',
+      };
+      const config = createTestConfig({ slotTargets: [target] });
+      const state = initializeManualMode(config, 'accumulator', 0);
+
+      const result = canAutoRoll(state, [target]);
+
+      expect(result.allowed).toBe(true);
+      expect(result.reason).toBe(null);
+    });
+
+    it('disallows auto-roll when no targets configured', () => {
+      const config = createTestConfig();
+      const state = initializeManualMode(config, 'accumulator', 0);
+
+      const result = canAutoRoll(state, []);
+
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe('No targets configured');
+    });
+
+    it('allows auto-roll when some target effects remain unfulfilled', () => {
+      const config = createTestConfig();
+      let state = initializeManualMode(config, 'accumulator', 0);
+
+      // Lock one effect but there are 2 target effects
+      state = {
+        ...state,
+        slots: state.slots.map((slot, i) => {
+          if (i === 0) {
+            return { ...slot, isLocked: true, effect: { id: 'effectA', displayName: 'Effect A', moduleType: 'cannon', values: {} } as never };
+          }
+          return slot;
+        }),
+      };
+
+      const target: SlotTarget = {
+        slotNumber: 1,
+        acceptableEffects: ['effectA', 'effectB'],
+        minRarity: 'common',
+      };
+
+      // effectA is locked but effectB is still needed
+      const result = canAutoRoll(state, [target]);
+
+      expect(result.allowed).toBe(true);
+      expect(result.reason).toBe(null);
+    });
+
+    it('disallows auto-roll when all target effects are acquired', () => {
+      const config = createTestConfig();
+      let state = initializeManualMode(config, 'accumulator', 0);
+
+      // Lock both target effects
+      state = {
+        ...state,
+        slots: state.slots.map((slot, i) => {
+          if (i === 0) {
+            return { ...slot, isLocked: true, effect: { id: 'effectA', displayName: 'Effect A', moduleType: 'cannon', values: {} } as never };
+          }
+          if (i === 1) {
+            return { ...slot, isLocked: true, effect: { id: 'effectB', displayName: 'Effect B', moduleType: 'cannon', values: {} } as never };
+          }
+          return slot;
+        }),
+      };
+
+      const target: SlotTarget = {
+        slotNumber: 1,
+        acceptableEffects: ['effectA', 'effectB'],
+        minRarity: 'common',
+      };
+
+      const result = canAutoRoll(state, [target]);
+
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe('All targets acquired');
+    });
+
+    it('disallows auto-roll when all slots locked', () => {
+      const target: SlotTarget = {
+        slotNumber: 1,
+        acceptableEffects: ['cannonCritChance'],
+        minRarity: 'common',
+      };
+      const config = createTestConfig({ slotCount: 1 });
+      const state = initializeManualMode(config, 'accumulator', 0);
+      const modeConfig = createModeConfig([target]);
+
+      // Roll and lock the only slot
+      const { newState } = executeRoll(state, modeConfig);
+      const lockedState = lockSlot(newState, 1);
+
+      const result = canAutoRoll(lockedState, [target]);
+
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe('All slots are locked');
+    });
+
+    it('disallows auto-roll when pool exhausted', () => {
+      const target: SlotTarget = {
+        slotNumber: 1,
+        acceptableEffects: ['cannonCritChance'],
+        minRarity: 'common',
+      };
+      const config = createTestConfig();
+      let state = initializeManualMode(config, 'accumulator', 0);
+
+      // Exhaust the pool manually
+      state = { ...state, pool: { ...state.pool, entries: [] } };
+
+      const result = canAutoRoll(state, [target]);
+
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe('Effect pool is exhausted');
+    });
+  });
+});

--- a/src/features/tools/module-calculator/manual-mode/manual-mode-logic.ts
+++ b/src/features/tools/module-calculator/manual-mode/manual-mode-logic.ts
@@ -1,0 +1,413 @@
+/**
+ * Manual Mode Logic
+ *
+ * Pure functions for managing manual mode state, rolling, and locking.
+ * State query utilities are in state-utils.ts.
+ */
+
+import type { Rarity, SubEffectConfig } from '@/shared/domain/module-data';
+import { getLockCost } from '@/shared/domain/module-data/modules/lock-costs';
+import type { CalculatorConfig, SlotTarget, PreLockedEffect } from '../types';
+import {
+  buildInitialPool,
+  preparePool,
+  simulateRollFast,
+  removeEffectFromPreparedPool,
+  checkTargetMatch,
+} from '../simulation/pool-dynamics';
+import type {
+  ManualSlot,
+  ManualModeState,
+  ShardMode,
+  RollResult,
+  CanRollResult,
+  ManualModeConfig,
+} from './types';
+
+/**
+ * Create a stub effect for pre-locked effects display.
+ * The actual effect config would be resolved from the module data.
+ */
+function createStubEffect(effectId: string): SubEffectConfig {
+  return {
+    id: effectId,
+    displayName: effectId,
+    moduleType: 'cannon',
+    values: {},
+  } as SubEffectConfig;
+}
+
+/**
+ * Create an empty slot
+ */
+function createEmptySlot(slotNumber: number): ManualSlot {
+  return {
+    slotNumber,
+    effect: null,
+    rarity: null,
+    isLocked: false,
+    isTargetMatch: false,
+  };
+}
+
+/**
+ * Build the minimum rarity map from slot targets
+ */
+export function buildMinRarityMap(targets: SlotTarget[]): Map<string, Rarity> {
+  const map = new Map<string, Rarity>();
+
+  for (const target of targets) {
+    for (const effectId of target.acceptableEffects) {
+      // Use the lowest min rarity if effect appears in multiple slots
+      const existing = map.get(effectId);
+      if (!existing || target.minRarity < existing) {
+        map.set(effectId, target.minRarity);
+      }
+    }
+  }
+
+  return map;
+}
+
+/**
+ * Initialize manual mode state from calculator configuration
+ */
+export function initializeManualMode(
+  config: CalculatorConfig,
+  shardMode: ShardMode,
+  startingBalance: number
+): ManualModeState {
+  // Build initial pool excluding banned and pre-locked effects
+  const preLockedEffectIds = config.preLockedEffects.map((e) => e.effectId);
+  const excludedEffects = [...config.bannedEffects, ...preLockedEffectIds];
+
+  const initialPool = buildInitialPool(
+    config.moduleType,
+    config.moduleRarity,
+    excludedEffects
+  );
+  const pool = preparePool(initialPool);
+
+  // Build min rarity map for target matching
+  const minRarityMap = buildMinRarityMap(config.slotTargets);
+
+  // Initialize slots - pre-locked effects start as locked
+  const slots: ManualSlot[] = [];
+  for (let i = 1; i <= config.slotCount; i++) {
+    const preLocked = config.preLockedEffects.find(
+      (_, idx) => idx + 1 === i && config.preLockedEffects.length > 0
+    );
+
+    if (preLocked) {
+      // This is a simplification - pre-locked effects should fill first slots
+      slots.push(createEmptySlot(i));
+    } else {
+      slots.push(createEmptySlot(i));
+    }
+  }
+
+  // Apply pre-locked effects to first slots
+  const preLockedSlots = applyPreLockedEffects(slots, config.preLockedEffects, minRarityMap);
+
+  return {
+    slots: preLockedSlots,
+    pool,
+    rollCount: 0,
+    shardMode,
+    startingBalance,
+    totalSpent: 0,
+    isComplete: false,
+    isAutoRolling: false,
+  };
+}
+
+/**
+ * Apply pre-locked effects to the first available slots
+ */
+function applyPreLockedEffects(
+  slots: ManualSlot[],
+  preLockedEffects: PreLockedEffect[],
+  minRarityMap: Map<string, Rarity>
+): ManualSlot[] {
+  if (preLockedEffects.length === 0) {
+    return slots;
+  }
+
+  const result = [...slots];
+  let slotIndex = 0;
+
+  for (const preLocked of preLockedEffects) {
+    if (slotIndex >= result.length) break;
+
+    // Check if this pre-locked effect matches any target
+    const isTargetMatch = minRarityMap.has(preLocked.effectId);
+
+    result[slotIndex] = {
+      ...result[slotIndex],
+      effect: createStubEffect(preLocked.effectId),
+      rarity: preLocked.rarity,
+      isLocked: true,
+      isTargetMatch,
+    };
+    slotIndex++;
+  }
+
+  return result;
+}
+
+/**
+ * Execute a roll, filling all open (unlocked) slots
+ */
+// eslint-disable-next-line max-statements
+export function executeRoll(
+  state: ManualModeState,
+  modeConfig: ManualModeConfig
+): { newState: ManualModeState; result: RollResult } {
+  const { targets, minRarityMap } = modeConfig;
+
+  // Find open (unlocked) slots
+  const openSlotIndexes = state.slots
+    .map((slot, index) => ({ slot, index }))
+    .filter(({ slot }) => !slot.isLocked)
+    .map(({ index }) => index);
+
+  if (openSlotIndexes.length === 0) {
+    // All slots locked - no roll needed
+    return {
+      newState: state,
+      result: {
+        slots: state.slots,
+        shardCost: 0,
+        hasTargetHit: false,
+        filledSlotIndexes: [],
+      },
+    };
+  }
+
+  // Calculate roll cost based on locked count
+  const lockedCount = state.slots.filter((s) => s.isLocked).length;
+  const shardCost = getLockCost(lockedCount);
+
+  // Roll for each open slot
+  const newSlots = [...state.slots];
+  let hasTargetHit = false;
+  const currentPool = state.pool;
+
+  for (const slotIndex of openSlotIndexes) {
+    if (currentPool.entries.length === 0) {
+      // Pool exhausted - leave slot empty
+      newSlots[slotIndex] = {
+        ...newSlots[slotIndex],
+        effect: null,
+        rarity: null,
+        isTargetMatch: false,
+      };
+      continue;
+    }
+
+    const random = Math.random();
+    const entry = simulateRollFast(currentPool, random);
+
+    // Check if this roll matches a target
+    const matchedTarget = checkTargetMatch(entry, targets, minRarityMap);
+    const isTargetMatch = matchedTarget !== null;
+
+    if (isTargetMatch) {
+      hasTargetHit = true;
+    }
+
+    newSlots[slotIndex] = {
+      slotNumber: slotIndex + 1,
+      effect: entry.effect,
+      rarity: entry.rarity,
+      isLocked: false,
+      isTargetMatch,
+    };
+  }
+
+  const newState: ManualModeState = {
+    ...state,
+    slots: newSlots,
+    rollCount: state.rollCount + 1,
+    totalSpent: state.totalSpent + shardCost,
+  };
+
+  return {
+    newState,
+    result: {
+      slots: newSlots,
+      shardCost,
+      hasTargetHit,
+      filledSlotIndexes: openSlotIndexes,
+    },
+  };
+}
+
+/**
+ * Lock a slot, removing the effect from the pool
+ */
+export function lockSlot(
+  state: ManualModeState,
+  slotNumber: number
+): ManualModeState {
+  const slotIndex = slotNumber - 1;
+  const slot = state.slots[slotIndex];
+
+  if (!slot?.effect || slot.isLocked) {
+    return state;
+  }
+
+  // Remove ALL rarities of this effect from pool
+  const newPool = removeEffectFromPreparedPool(state.pool, slot.effect.id);
+
+  const newSlots = state.slots.map((s, i) =>
+    i === slotIndex ? { ...s, isLocked: true } : s
+  );
+
+  return {
+    ...state,
+    slots: newSlots,
+    pool: newPool,
+  };
+}
+
+/**
+ * Unlock a slot, restoring the effect to the pool
+ */
+export function unlockSlot(
+  state: ManualModeState,
+  slotNumber: number,
+  config: CalculatorConfig
+): ManualModeState {
+  const slotIndex = slotNumber - 1;
+  const slot = state.slots[slotIndex];
+
+  if (!slot?.isLocked || !slot.effect) {
+    return state;
+  }
+
+  // Rebuild pool to include the unlocked effect
+  const preLockedEffectIds = config.preLockedEffects.map((e) => e.effectId);
+  const currentlyLockedEffectIds = state.slots
+    .filter((s, i) => s.isLocked && i !== slotIndex && s.effect)
+    .map((s) => s.effect!.id);
+
+  const excludedEffects = [
+    ...config.bannedEffects,
+    ...preLockedEffectIds,
+    ...currentlyLockedEffectIds,
+  ];
+
+  const newPoolEntries = buildInitialPool(
+    config.moduleType,
+    config.moduleRarity,
+    excludedEffects
+  );
+  const newPool = preparePool(newPoolEntries);
+
+  const newSlots = state.slots.map((s, i) =>
+    i === slotIndex ? { ...s, isLocked: false } : s
+  );
+
+  return {
+    ...state,
+    slots: newSlots,
+    pool: newPool,
+  };
+}
+
+/**
+ * Check if a manual roll is allowed.
+ * Note: Manual rolls are allowed even after session is "complete" (all targets acquired).
+ * The completion state is informational only - users can continue rolling.
+ */
+export function canRoll(state: ManualModeState): CanRollResult {
+  // Check if all slots are locked
+  const openSlots = state.slots.filter((s) => !s.isLocked);
+  if (openSlots.length === 0) {
+    return { allowed: false, reason: 'All slots are locked' };
+  }
+
+  // Check if pool is exhausted
+  if (state.pool.entries.length === 0) {
+    return { allowed: false, reason: 'Effect pool is exhausted' };
+  }
+
+  // Check budget mode balance
+  if (state.shardMode === 'budget') {
+    const lockedCount = state.slots.filter((s) => s.isLocked).length;
+    const rollCost = getLockCost(lockedCount);
+    const currentBalance = state.startingBalance - state.totalSpent;
+
+    if (currentBalance < rollCost) {
+      return { allowed: false, reason: 'Insufficient shard balance' };
+    }
+  }
+
+  // Removed isComplete check - allow manual rolls even after targets acquired
+  return { allowed: true, reason: null };
+}
+
+/**
+ * Check if auto-roll should be allowed.
+ * Auto-roll requires active targets that haven't been acquired yet.
+ */
+export function canAutoRoll(
+  state: ManualModeState,
+  targets: SlotTarget[]
+): CanRollResult {
+  // First check if basic rolling is allowed
+  const basicCheck = canRoll(state);
+  if (!basicCheck.allowed) {
+    return basicCheck;
+  }
+
+  // Auto-roll requires unfulfilled targets
+  if (targets.length === 0) {
+    return { allowed: false, reason: 'No targets configured' };
+  }
+
+  // Check if all unique target effects have been acquired
+  const unfulfilledCount = countUnfulfilledTargetEffects(state, targets);
+  if (unfulfilledCount === 0) {
+    return { allowed: false, reason: 'All targets acquired' };
+  }
+
+  return { allowed: true, reason: null };
+}
+
+// Re-export state queries for convenient access
+export {
+  getCurrentRollCost,
+  getCurrentBalance,
+  getBalanceStatus,
+  countOpenSlots,
+  countLockedSlots,
+  getPoolSize,
+  markComplete,
+  setAutoRolling,
+  countUnfulfilledTargetEffects,
+} from './state-queries';
+
+// Import for local use
+import { countUnfulfilledTargetEffects } from './state-queries';
+
+/**
+ * Check if all targets have been acquired
+ */
+export function checkCompletion(
+  state: ManualModeState,
+  targets: SlotTarget[]
+): boolean {
+  if (targets.length === 0) {
+    return false;
+  }
+
+  // Check if pool is exhausted
+  if (state.pool.entries.length === 0) {
+    return true;
+  }
+
+  // Complete when all unique target effects have been locked
+  return countUnfulfilledTargetEffects(state, targets) === 0;
+}

--- a/src/features/tools/module-calculator/manual-mode/manual-mode-panel.tsx
+++ b/src/features/tools/module-calculator/manual-mode/manual-mode-panel.tsx
@@ -1,0 +1,272 @@
+/**
+ * Manual Mode Panel
+ *
+ * Main container for the manual practice mode.
+ */
+
+import type { Rarity } from '@/shared/domain/module-data';
+import { getSubEffectById } from '@/shared/domain/module-data';
+import type { UseManualModeResult } from './use-manual-mode';
+import type { ShardMode } from './types';
+import { ModuleHeader } from './module-header';
+import { EffectSlotsTable } from './effect-slots-table';
+import { ShardCounter } from './shard-counter';
+import { Button } from '@/components/ui';
+
+interface ManualModePanelProps {
+  moduleRarity: Rarity;
+  moduleLevel: number;
+  slotCount: number;
+  bannedEffects: string[];
+  manualMode: UseManualModeResult;
+}
+
+export function ManualModePanel({
+  moduleRarity,
+  moduleLevel,
+  slotCount,
+  bannedEffects,
+  manualMode,
+}: ManualModePanelProps) {
+  const maxLocks = Math.max(0, slotCount - 1);
+
+  if (!manualMode.isActive) {
+    return (
+      <InactiveState onActivate={manualMode.activate} />
+    );
+  }
+
+  if (!manualMode.state) {
+    return null;
+  }
+
+  const lockedCount = manualMode.state.slots.filter((s) => s.isLocked).length;
+
+  return (
+    <div className="space-y-4">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-semibold text-slate-200">
+          Manual Practice Mode
+        </h3>
+        <div className="flex items-center gap-1.5">
+          <Button
+            variant="ghost"
+            size="compact"
+            onClick={manualMode.reset}
+            className="text-slate-400 hover:text-slate-200"
+          >
+            <ResetIcon />
+            Reset
+          </Button>
+          <Button
+            variant="ghost"
+            size="compact"
+            onClick={manualMode.deactivate}
+            className="text-slate-400 hover:text-red-400"
+          >
+            <ExitIcon />
+            Exit
+          </Button>
+        </div>
+      </div>
+
+      {/* Module Info */}
+      <ModuleHeader
+        moduleRarity={moduleRarity}
+        moduleLevel={moduleLevel}
+      />
+
+      {/* Completion State */}
+      {manualMode.state.isComplete && (
+        <CompletionBanner
+          totalSpent={manualMode.state.totalSpent}
+          rollCount={manualMode.state.rollCount}
+        />
+      )}
+
+      {/* Effect Slots */}
+      <EffectSlotsTable
+        slots={manualMode.state.slots}
+        onLockSlot={manualMode.lockSlot}
+        onUnlockSlot={manualMode.unlockSlot}
+        maxLocks={maxLocks}
+        lockedCount={lockedCount}
+      />
+
+      {/* Banned Effects */}
+      {bannedEffects.length > 0 && (
+        <BannedEffectsInfo
+          effectNames={bannedEffects.map((id) => {
+            const effect = getSubEffectById(id);
+            return effect?.displayName ?? id;
+          })}
+        />
+      )}
+
+      {/* Shard Counter and Controls */}
+      <ShardCounter
+        shardMode={manualMode.state.shardMode}
+        balance={manualMode.currentBalance}
+        rollCost={manualMode.currentRollCost}
+        rollCount={manualMode.state.rollCount}
+        balanceStatus={manualMode.balanceStatus}
+        canRoll={manualMode.canRoll}
+        rollDisabledReason={manualMode.rollDisabledReason}
+        canAutoRoll={manualMode.canAutoRollNow}
+        autoRollDisabledReason={manualMode.autoRollDisabledReason}
+        isAutoRolling={manualMode.state.isAutoRolling}
+        onRoll={manualMode.roll}
+        onStartAutoRoll={manualMode.startAutoRoll}
+        onStopAutoRoll={manualMode.stopAutoRoll}
+      />
+    </div>
+  );
+}
+
+interface InactiveStateProps {
+  onActivate: (shardMode: ShardMode, startingBalance?: number) => void;
+}
+
+function InactiveState({ onActivate }: InactiveStateProps) {
+  return (
+    <div className="space-y-4">
+      <h3 className="text-lg font-semibold text-slate-200">
+        Manual Practice Mode
+      </h3>
+
+      <div className="p-4 bg-slate-800/30 rounded-lg border border-slate-700/50">
+        <div className="text-center space-y-4">
+          <div className="space-y-2">
+            <div className="flex items-center justify-center w-12 h-12 mx-auto rounded-full bg-orange-500/10 border border-orange-500/20">
+              <DiceIcon />
+            </div>
+            <p className="text-sm text-slate-400">
+              Practice rolling manually to build intuition for module costs
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-2.5 pt-2">
+            <Button
+              variant="default"
+              size="sm"
+              onClick={() => onActivate('accumulator', 0)}
+              className="w-full gap-2"
+            >
+              <CountUpIcon />
+              Start Practicing (Count Up)
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => onActivate('budget', 10000)}
+              className="w-full gap-2"
+            >
+              <BudgetIcon />
+              Start with Budget (10,000)
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DiceIcon() {
+  return (
+    <svg className="w-6 h-6 text-orange-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <rect x="3" y="3" width="18" height="18" rx="2" />
+      <circle cx="8.5" cy="8.5" r="1.5" fill="currentColor" />
+      <circle cx="15.5" cy="8.5" r="1.5" fill="currentColor" />
+      <circle cx="8.5" cy="15.5" r="1.5" fill="currentColor" />
+      <circle cx="15.5" cy="15.5" r="1.5" fill="currentColor" />
+      <circle cx="12" cy="12" r="1.5" fill="currentColor" />
+    </svg>
+  );
+}
+
+function CountUpIcon() {
+  return (
+    <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <path d="M12 19V5M5 12l7-7 7 7" />
+    </svg>
+  );
+}
+
+function BudgetIcon() {
+  return (
+    <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <path d="M12 2v20M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6" />
+    </svg>
+  );
+}
+
+function ResetIcon() {
+  return (
+    <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <path d="M1 4v6h6M23 20v-6h-6" />
+      <path d="M20.49 9A9 9 0 0 0 5.64 5.64L1 10m22 4l-4.64 4.36A9 9 0 0 1 3.51 15" />
+    </svg>
+  );
+}
+
+function ExitIcon() {
+  return (
+    <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <path d="M18 6L6 18M6 6l12 12" />
+    </svg>
+  );
+}
+
+interface CompletionBannerProps {
+  totalSpent: number;
+  rollCount: number;
+}
+
+function CompletionBanner({ totalSpent, rollCount }: CompletionBannerProps) {
+  return (
+    <div className="p-4 bg-green-500/8 border border-green-500/25 rounded-lg">
+      <div className="flex items-center gap-2.5">
+        <div className="flex items-center justify-center w-8 h-8 rounded-full bg-green-500/15 border border-green-500/30">
+          <svg className="w-4 h-4 text-green-400" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z" />
+          </svg>
+        </div>
+        <div>
+          <span className="text-green-400 font-semibold">Session Complete!</span>
+          <div className="flex items-center gap-3 mt-0.5 text-sm text-slate-400">
+            <span>
+              <span className="text-slate-200 font-medium tabular-nums">{totalSpent.toLocaleString()}</span> shards
+            </span>
+            <span className="text-slate-600">|</span>
+            <span>
+              <span className="text-slate-200 font-medium tabular-nums">{rollCount}</span> rolls
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface BannedEffectsInfoProps {
+  effectNames: string[];
+}
+
+function BannedEffectsInfo({ effectNames }: BannedEffectsInfoProps) {
+  return (
+    <div className="px-3 py-2 rounded-md bg-slate-800/20 border border-slate-700/30 space-y-1">
+      <div className="flex items-center gap-2">
+        <svg className="w-4 h-4 text-red-400/70" viewBox="0 0 24 24" fill="currentColor">
+          <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8 0-1.85.63-3.55 1.69-4.9L16.9 18.31C15.55 19.37 13.85 20 12 20zm6.31-3.1L7.1 5.69C8.45 4.63 10.15 4 12 4c4.42 0 8 3.58 8 8 0 1.85-.63 3.55-1.69 4.9z" />
+        </svg>
+        <span className="text-xs text-slate-400 font-medium">
+          Effects banned from pool:
+        </span>
+      </div>
+      <div className="ml-6 text-xs text-slate-500">
+        {effectNames.join(', ')}
+      </div>
+    </div>
+  );
+}

--- a/src/features/tools/module-calculator/manual-mode/module-header.tsx
+++ b/src/features/tools/module-calculator/manual-mode/module-header.tsx
@@ -1,0 +1,60 @@
+/**
+ * Module Header
+ *
+ * Displays module rarity badge and level for manual mode.
+ */
+
+import type { Rarity } from '@/shared/domain/module-data';
+import { getRarityColor } from '@/shared/domain/module-data';
+
+interface ModuleHeaderProps {
+  moduleRarity: Rarity;
+  moduleLevel: number;
+}
+
+export function ModuleHeader({ moduleRarity, moduleLevel }: ModuleHeaderProps) {
+  const rarityColor = getRarityColor(moduleRarity);
+  const rarityLabel = moduleRarity.toUpperCase();
+
+  return (
+    <div className="flex items-center justify-between p-3 bg-slate-800/30 rounded-lg border border-slate-700/50">
+      <RarityBadge label={rarityLabel} color={rarityColor} />
+      <LevelDisplay level={moduleLevel} />
+    </div>
+  );
+}
+
+interface RarityBadgeProps {
+  label: string;
+  color: string;
+}
+
+function RarityBadge({ label, color }: RarityBadgeProps) {
+  return (
+    <span
+      className="inline-flex items-center px-3 py-1.5 text-xs font-bold tracking-wider rounded-md border transition-colors"
+      style={{
+        backgroundColor: `${color}15`,
+        color: color,
+        borderColor: `${color}30`,
+      }}
+    >
+      {label}
+    </span>
+  );
+}
+
+interface LevelDisplayProps {
+  level: number;
+}
+
+function LevelDisplay({ level }: LevelDisplayProps) {
+  return (
+    <div className="flex items-center gap-1.5 text-sm tabular-nums">
+      <span className="text-slate-500">Level</span>
+      <span className="text-slate-200 font-semibold">{level}</span>
+      <span className="text-slate-600">/</span>
+      <span className="text-slate-500">200</span>
+    </div>
+  );
+}

--- a/src/features/tools/module-calculator/manual-mode/shard-counter.tsx
+++ b/src/features/tools/module-calculator/manual-mode/shard-counter.tsx
@@ -1,0 +1,252 @@
+/**
+ * Shard Counter
+ *
+ * Displays balance/cost and reroll button for manual mode.
+ */
+
+import type { ShardMode } from './types';
+import { Button } from '@/components/ui';
+
+interface ShardCounterProps {
+  shardMode: ShardMode;
+  balance: number;
+  rollCost: number;
+  rollCount: number;
+  balanceStatus: 'normal' | 'warning' | 'critical';
+  canRoll: boolean;
+  rollDisabledReason: string | null;
+  canAutoRoll: boolean;
+  autoRollDisabledReason: string | null;
+  isAutoRolling: boolean;
+  onRoll: () => void;
+  onStartAutoRoll: () => void;
+  onStopAutoRoll: () => void;
+}
+
+export function ShardCounter({
+  shardMode,
+  balance,
+  rollCost,
+  rollCount,
+  balanceStatus,
+  canRoll,
+  rollDisabledReason,
+  canAutoRoll,
+  autoRollDisabledReason,
+  isAutoRolling,
+  onRoll,
+  onStartAutoRoll,
+  onStopAutoRoll,
+}: ShardCounterProps) {
+  return (
+    <div className="p-4 bg-slate-800/30 rounded-lg border border-slate-700/50 space-y-4">
+      {/* Shard Display */}
+      <div className="flex items-center justify-between">
+        <ShardDisplay
+          shardMode={shardMode}
+          balance={balance}
+          rollCost={rollCost}
+          balanceStatus={balanceStatus}
+        />
+        <RollCounter count={rollCount} />
+      </div>
+
+      {/* Roll Buttons */}
+      <div className="flex items-center gap-2">
+        <RollButton
+          canRoll={canRoll}
+          rollDisabledReason={rollDisabledReason}
+          isAutoRolling={isAutoRolling}
+          onRoll={onRoll}
+        />
+        <AutoRollButton
+          canAutoRoll={canAutoRoll}
+          autoRollDisabledReason={autoRollDisabledReason}
+          isAutoRolling={isAutoRolling}
+          onStartAutoRoll={onStartAutoRoll}
+          onStopAutoRoll={onStopAutoRoll}
+        />
+      </div>
+    </div>
+  );
+}
+
+interface ShardDisplayProps {
+  shardMode: ShardMode;
+  balance: number;
+  rollCost: number;
+  balanceStatus: 'normal' | 'warning' | 'critical';
+}
+
+function ShardDisplay({
+  shardMode,
+  balance,
+  rollCost,
+  balanceStatus,
+}: ShardDisplayProps) {
+  const balanceClassName = getBalanceClassName(balanceStatus);
+  const label = shardMode === 'budget' ? 'Balance' : 'Spent';
+
+  return (
+    <div className="flex items-center gap-2.5">
+      <ShardIcon />
+      <div className="flex flex-col gap-0.5">
+        <div className="flex items-baseline gap-2">
+          <span className="text-xs text-slate-500 font-medium">{label}:</span>
+          <span className={`text-xl font-bold tabular-nums ${balanceClassName}`}>
+            {balance.toLocaleString()}
+          </span>
+          {shardMode === 'budget' && (
+            <div className="flex items-baseline gap-1.5 text-sm">
+              <span className="text-slate-600">/</span>
+              <span className="text-orange-400/80 tabular-nums font-medium">
+                -{rollCost.toLocaleString()}
+              </span>
+            </div>
+          )}
+        </div>
+        <div className="flex items-baseline gap-1.5 text-xs">
+          <span className="text-slate-500">Cost per roll:</span>
+          <span className="text-orange-400 tabular-nums font-medium">
+            {rollCost.toLocaleString()}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function getBalanceClassName(status: 'normal' | 'warning' | 'critical'): string {
+  switch (status) {
+    case 'critical':
+      return 'text-red-400';
+    case 'warning':
+      return 'text-yellow-400';
+    default:
+      return 'text-slate-100';
+  }
+}
+
+function ShardIcon() {
+  return (
+    <div className="flex items-center justify-center w-8 h-8 rounded-md bg-orange-500/10 border border-orange-500/20">
+      <svg
+        className="w-4 h-4 text-orange-400"
+        viewBox="0 0 24 24"
+        fill="currentColor"
+      >
+        <path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5" />
+      </svg>
+    </div>
+  );
+}
+
+interface RollCounterProps {
+  count: number;
+}
+
+function RollCounter({ count }: RollCounterProps) {
+  return (
+    <div className="flex items-center gap-1.5 px-2.5 py-1 rounded-md bg-slate-700/30 border border-slate-700/50">
+      <span className="text-xs text-slate-500">Rolls:</span>
+      <span className="text-sm text-slate-200 font-semibold tabular-nums">{count}</span>
+    </div>
+  );
+}
+
+interface RollButtonProps {
+  canRoll: boolean;
+  rollDisabledReason: string | null;
+  isAutoRolling: boolean;
+  onRoll: () => void;
+}
+
+function RollButton({
+  canRoll,
+  rollDisabledReason,
+  isAutoRolling,
+  onRoll,
+}: RollButtonProps) {
+  return (
+    <Button
+      variant="default"
+      size="sm"
+      onClick={onRoll}
+      disabled={!canRoll || isAutoRolling}
+      title={rollDisabledReason ?? undefined}
+      className="flex-1 gap-2"
+    >
+      <RerollIcon />
+      Reroll
+    </Button>
+  );
+}
+
+function RerollIcon() {
+  return (
+    <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <path d="M1 4v6h6M23 20v-6h-6" />
+      <path d="M20.49 9A9 9 0 0 0 5.64 5.64L1 10m22 4l-4.64 4.36A9 9 0 0 1 3.51 15" />
+    </svg>
+  );
+}
+
+interface AutoRollButtonProps {
+  canAutoRoll: boolean;
+  autoRollDisabledReason: string | null;
+  isAutoRolling: boolean;
+  onStartAutoRoll: () => void;
+  onStopAutoRoll: () => void;
+}
+
+function AutoRollButton({
+  canAutoRoll,
+  autoRollDisabledReason,
+  isAutoRolling,
+  onStartAutoRoll,
+  onStopAutoRoll,
+}: AutoRollButtonProps) {
+  if (isAutoRolling) {
+    return (
+      <Button
+        variant="destructive"
+        size="sm"
+        onClick={onStopAutoRoll}
+        className="gap-2"
+      >
+        <StopIcon />
+        Stop
+      </Button>
+    );
+  }
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={onStartAutoRoll}
+      disabled={!canAutoRoll}
+      title={autoRollDisabledReason ?? undefined}
+      className="gap-2"
+    >
+      <PlayIcon />
+      Auto
+    </Button>
+  );
+}
+
+function PlayIcon() {
+  return (
+    <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="currentColor">
+      <path d="M8 5v14l11-7z" />
+    </svg>
+  );
+}
+
+function StopIcon() {
+  return (
+    <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="currentColor">
+      <path d="M6 6h12v12H6z" />
+    </svg>
+  );
+}

--- a/src/features/tools/module-calculator/manual-mode/state-queries.ts
+++ b/src/features/tools/module-calculator/manual-mode/state-queries.ts
@@ -1,0 +1,132 @@
+/**
+ * Manual Mode State Queries
+ *
+ * Pure functions for querying and deriving values from manual mode state.
+ * These are simple getters and predicates that don't mutate state.
+ */
+
+import { getLockCost } from '@/shared/domain/module-data/modules/lock-costs';
+import type { SlotTarget } from '../types';
+import type { ManualModeState } from './types';
+
+/**
+ * Get the current roll cost based on locked count
+ */
+export function getCurrentRollCost(state: ManualModeState): number {
+  const lockedCount = state.slots.filter((s) => s.isLocked).length;
+  return getLockCost(lockedCount);
+}
+
+/**
+ * Get the current balance (for display)
+ */
+export function getCurrentBalance(state: ManualModeState): number {
+  if (state.shardMode === 'budget') {
+    return state.startingBalance - state.totalSpent;
+  }
+  return state.totalSpent;
+}
+
+/**
+ * Get the balance status for UI display
+ */
+export function getBalanceStatus(
+  state: ManualModeState
+): 'normal' | 'warning' | 'critical' {
+  if (state.shardMode !== 'budget') {
+    return 'normal';
+  }
+
+  const balance = getCurrentBalance(state);
+  const rollCost = getCurrentRollCost(state);
+
+  if (balance < rollCost) {
+    return 'critical';
+  }
+
+  const warningThreshold = state.startingBalance * 0.2;
+  if (balance < warningThreshold) {
+    return 'warning';
+  }
+
+  return 'normal';
+}
+
+/**
+ * Count the number of open (unlocked) slots
+ */
+export function countOpenSlots(state: ManualModeState): number {
+  return state.slots.filter((s) => !s.isLocked).length;
+}
+
+/**
+ * Count the number of locked slots
+ */
+export function countLockedSlots(state: ManualModeState): number {
+  return state.slots.filter((s) => s.isLocked).length;
+}
+
+/**
+ * Get remaining pool size
+ */
+export function getPoolSize(state: ManualModeState): number {
+  return state.pool.entries.length;
+}
+
+/**
+ * Mark the session as complete
+ */
+export function markComplete(state: ManualModeState): ManualModeState {
+  return {
+    ...state,
+    isComplete: true,
+    isAutoRolling: false,
+  };
+}
+
+/**
+ * Toggle auto-rolling state
+ */
+export function setAutoRolling(
+  state: ManualModeState,
+  isAutoRolling: boolean
+): ManualModeState {
+  return {
+    ...state,
+    isAutoRolling,
+  };
+}
+
+/**
+ * Get count of unique target effects that haven't been acquired yet
+ */
+export function countUnfulfilledTargetEffects(
+  state: ManualModeState,
+  targets: SlotTarget[]
+): number {
+  // Collect all unique effect IDs from all targets
+  const allTargetEffects = new Set<string>();
+  for (const target of targets) {
+    for (const effectId of target.acceptableEffects) {
+      allTargetEffects.add(effectId);
+    }
+  }
+
+  // Get locked effect IDs
+  const lockedEffectIds = new Set<string>();
+  for (const slot of state.slots) {
+    if (slot.isLocked && slot.effect) {
+      lockedEffectIds.add(slot.effect.id);
+    }
+  }
+
+  // Count unfulfilled target effects
+  let unfulfilledCount = 0;
+  for (const effectId of allTargetEffects) {
+    if (!lockedEffectIds.has(effectId)) {
+      unfulfilledCount++;
+    }
+  }
+
+  return unfulfilledCount;
+}

--- a/src/features/tools/module-calculator/manual-mode/types.ts
+++ b/src/features/tools/module-calculator/manual-mode/types.ts
@@ -1,0 +1,104 @@
+/**
+ * Manual Mode Types
+ *
+ * Types specific to the manual practice mode for module rolling.
+ */
+
+import type { Rarity, SubEffectConfig } from '@/shared/domain/module-data';
+import type { PreparedPool } from '../simulation/pool-dynamics';
+import type { SlotTarget } from '../types';
+
+/**
+ * A single slot in manual mode with its current effect and state
+ */
+export interface ManualSlot {
+  /** Slot number (1-8) */
+  slotNumber: number;
+
+  /** Current effect in this slot (null = empty) */
+  effect: SubEffectConfig | null;
+
+  /** Rarity of the current effect (null = empty) */
+  rarity: Rarity | null;
+
+  /** Whether this slot is locked */
+  isLocked: boolean;
+
+  /** Whether this slot matches a target */
+  isTargetMatch: boolean;
+}
+
+/**
+ * Shard tracking mode
+ * - budget: Start with balance, spend down (tracks remaining)
+ * - accumulator: Start at 0, count up (tracks total spent)
+ */
+export type ShardMode = 'budget' | 'accumulator';
+
+/**
+ * Complete state for a manual mode session
+ */
+export interface ManualModeState {
+  /** Current state of all 8 slots */
+  slots: ManualSlot[];
+
+  /** Current roll pool (effects remaining after locks) */
+  pool: PreparedPool;
+
+  /** Number of rolls performed */
+  rollCount: number;
+
+  /** Shard tracking mode */
+  shardMode: ShardMode;
+
+  /** Starting balance (for budget mode) */
+  startingBalance: number;
+
+  /** Total shards spent so far */
+  totalSpent: number;
+
+  /** Whether all targets have been acquired or pool is exhausted */
+  isComplete: boolean;
+
+  /** Whether auto-rolling is currently active */
+  isAutoRolling: boolean;
+}
+
+/**
+ * Result of a roll operation
+ */
+export interface RollResult {
+  /** Updated slot states */
+  slots: ManualSlot[];
+
+  /** Shard cost of this roll */
+  shardCost: number;
+
+  /** Whether any slot hit a target */
+  hasTargetHit: boolean;
+
+  /** Indexes of slots that were filled */
+  filledSlotIndexes: number[];
+}
+
+/**
+ * Result of checking if a roll is allowed
+ */
+export interface CanRollResult {
+  /** Whether rolling is allowed */
+  allowed: boolean;
+
+  /** Reason for disallowing (null if allowed) */
+  reason: string | null;
+}
+
+/**
+ * Configuration passed to initialize manual mode
+ */
+export interface ManualModeConfig {
+  /** Current slot targets from calculator config */
+  targets: SlotTarget[];
+
+  /** Minimum rarity required for each effect (effectId -> Rarity) */
+  minRarityMap: Map<string, Rarity>;
+}

--- a/src/features/tools/module-calculator/manual-mode/use-manual-mode.ts
+++ b/src/features/tools/module-calculator/manual-mode/use-manual-mode.ts
@@ -1,0 +1,301 @@
+/* eslint-disable max-lines-per-function, max-statements */
+/**
+ * Manual Mode Hook
+ *
+ * Orchestrates manual mode state, providing actions for UI interaction
+ * and computed values for display.
+ */
+
+import { useState, useCallback, useMemo, useRef, useEffect } from 'react';
+import type { Rarity } from '@/shared/domain/module-data';
+import type { CalculatorConfig } from '../types';
+import type { ManualModeState, ShardMode, ManualModeConfig } from './types';
+import {
+  initializeManualMode,
+  executeRoll,
+  lockSlot,
+  unlockSlot,
+  canRoll,
+  canAutoRoll,
+  getCurrentRollCost,
+  getCurrentBalance,
+  checkCompletion,
+  markComplete,
+  setAutoRolling,
+  getBalanceStatus,
+  buildMinRarityMap,
+} from './manual-mode-logic';
+
+const AUTO_ROLL_DELAY_MS = 100;
+
+export interface UseManualModeResult {
+  /** Current manual mode state (null if inactive) */
+  state: ManualModeState | null;
+
+  /** Whether manual mode is currently active */
+  isActive: boolean;
+
+  // Actions
+  /** Activate manual mode with the specified shard mode and optional starting balance */
+  activate: (shardMode: ShardMode, startingBalance?: number) => void;
+
+  /** Execute a single roll */
+  roll: () => void;
+
+  /** Lock a specific slot */
+  lockSlot: (slotNumber: number) => void;
+
+  /** Unlock a specific slot */
+  unlockSlot: (slotNumber: number) => void;
+
+  /** Start auto-rolling until target hit or completion */
+  startAutoRoll: () => void;
+
+  /** Stop auto-rolling */
+  stopAutoRoll: () => void;
+
+  /** Reset the current session (keeps mode active) */
+  reset: () => void;
+
+  /** Deactivate manual mode completely */
+  deactivate: () => void;
+
+  // Computed values
+  /** Whether manual rolling is currently allowed */
+  canRoll: boolean;
+
+  /** Reason rolling is disabled (null if allowed) */
+  rollDisabledReason: string | null;
+
+  /** Whether auto-rolling is currently allowed (requires unfulfilled targets) */
+  canAutoRollNow: boolean;
+
+  /** Reason auto-roll is disabled (null if allowed) */
+  autoRollDisabledReason: string | null;
+
+  /** Current cost per roll */
+  currentRollCost: number;
+
+  /** Current balance (remaining in budget mode, spent in accumulator mode) */
+  currentBalance: number;
+
+  /** Balance status for UI styling */
+  balanceStatus: 'normal' | 'warning' | 'critical';
+}
+
+export function useManualMode(
+  config: CalculatorConfig,
+  onLockEffect: (effectId: string, rarity: Rarity) => void,
+  onUnlockEffect: (effectId: string) => void
+): UseManualModeResult {
+  const [state, setState] = useState<ManualModeState | null>(null);
+  const [lastShardMode, setLastShardMode] = useState<ShardMode>('accumulator');
+  const [lastStartingBalance, setLastStartingBalance] = useState<number>(0);
+  const autoRollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Build mode config from calculator config
+  const modeConfig = useMemo<ManualModeConfig>(
+    () => ({
+      targets: config.slotTargets,
+      minRarityMap: buildMinRarityMap(config.slotTargets),
+    }),
+    [config.slotTargets]
+  );
+
+  // Reset state when key config values change
+  useEffect(() => {
+    if (state) {
+      // Reset when module type, rarity, or slot count changes
+      setState(null);
+      stopAutoRollInternal();
+    }
+  }, [config.moduleType, config.moduleRarity, config.slotCount]);
+
+  const stopAutoRollInternal = useCallback(() => {
+    if (autoRollIntervalRef.current) {
+      clearInterval(autoRollIntervalRef.current);
+      autoRollIntervalRef.current = null;
+    }
+    if (state) {
+      setState((prev) => (prev ? setAutoRolling(prev, false) : null));
+    }
+  }, [state]);
+
+  // Cleanup auto-roll on unmount
+  useEffect(() => {
+    return () => {
+      if (autoRollIntervalRef.current) {
+        clearInterval(autoRollIntervalRef.current);
+      }
+    };
+  }, []);
+
+  const activate = useCallback(
+    (shardMode: ShardMode, startingBalance: number = 0) => {
+      setLastShardMode(shardMode);
+      setLastStartingBalance(startingBalance);
+      const newState = initializeManualMode(config, shardMode, startingBalance);
+      setState(newState);
+    },
+    [config]
+  );
+
+  const roll = useCallback(() => {
+    if (!state) return;
+
+    const rollCheck = canRoll(state);
+    if (!rollCheck.allowed) return;
+
+    const { newState, result } = executeRoll(state, modeConfig);
+
+    // Check for completion
+    if (checkCompletion(newState, config.slotTargets)) {
+      setState(markComplete(newState));
+      stopAutoRollInternal();
+      return;
+    }
+
+    setState(newState);
+
+    // If auto-rolling and we hit a target, stop
+    if (state.isAutoRolling && result.hasTargetHit) {
+      stopAutoRollInternal();
+    }
+  }, [state, modeConfig, config.slotTargets, stopAutoRollInternal]);
+
+  const handleLockSlot = useCallback(
+    (slotNumber: number) => {
+      if (!state) return;
+
+      const slot = state.slots[slotNumber - 1];
+      if (!slot?.effect || slot.isLocked) return;
+
+      const newState = lockSlot(state, slotNumber);
+      setState(newState);
+
+      // Notify parent for bidirectional sync
+      onLockEffect(slot.effect.id, slot.rarity!);
+
+      // Check for completion after locking
+      if (checkCompletion(newState, config.slotTargets)) {
+        setState(markComplete(newState));
+        stopAutoRollInternal();
+      }
+    },
+    [state, onLockEffect, config.slotTargets, stopAutoRollInternal]
+  );
+
+  const handleUnlockSlot = useCallback(
+    (slotNumber: number) => {
+      if (!state) return;
+
+      const slot = state.slots[slotNumber - 1];
+      if (!slot?.isLocked || !slot.effect) return;
+
+      const newState = unlockSlot(state, slotNumber, config);
+      setState(newState);
+
+      // Notify parent for bidirectional sync
+      onUnlockEffect(slot.effect.id);
+    },
+    [state, config, onUnlockEffect]
+  );
+
+  const startAutoRoll = useCallback(() => {
+    if (!state || state.isAutoRolling) return;
+
+    // Check if auto-roll is allowed (has unfulfilled targets)
+    const autoRollCheck = canAutoRoll(state, config.slotTargets);
+    if (!autoRollCheck.allowed) return;
+
+    setState((prev) => (prev ? setAutoRolling(prev, true) : null));
+
+    autoRollIntervalRef.current = setInterval(() => {
+      setState((currentState) => {
+        if (!currentState || !currentState.isAutoRolling) {
+          if (autoRollIntervalRef.current) {
+            clearInterval(autoRollIntervalRef.current);
+            autoRollIntervalRef.current = null;
+          }
+          return currentState;
+        }
+
+        // Check if auto-roll should continue (unfulfilled targets remain)
+        const autoCheck = canAutoRoll(currentState, config.slotTargets);
+        if (!autoCheck.allowed) {
+          if (autoRollIntervalRef.current) {
+            clearInterval(autoRollIntervalRef.current);
+            autoRollIntervalRef.current = null;
+          }
+          // Mark complete if all targets acquired, otherwise just stop
+          if (checkCompletion(currentState, config.slotTargets)) {
+            return markComplete(setAutoRolling(currentState, false));
+          }
+          return setAutoRolling(currentState, false);
+        }
+
+        const { newState, result } = executeRoll(currentState, modeConfig);
+
+        // Stop on target hit (let user decide to lock)
+        if (result.hasTargetHit) {
+          if (autoRollIntervalRef.current) {
+            clearInterval(autoRollIntervalRef.current);
+            autoRollIntervalRef.current = null;
+          }
+          return setAutoRolling(newState, false);
+        }
+
+        return newState;
+      });
+    }, AUTO_ROLL_DELAY_MS);
+  }, [state, modeConfig, config.slotTargets]);
+
+  const stopAutoRoll = useCallback(() => {
+    stopAutoRollInternal();
+  }, [stopAutoRollInternal]);
+
+  const reset = useCallback(() => {
+    stopAutoRollInternal();
+    const newState = initializeManualMode(config, lastShardMode, lastStartingBalance);
+    setState(newState);
+  }, [config, lastShardMode, lastStartingBalance, stopAutoRollInternal]);
+
+  const deactivate = useCallback(() => {
+    stopAutoRollInternal();
+    setState(null);
+  }, [stopAutoRollInternal]);
+
+  // Computed values
+  const canRollResult = useMemo(() => (state ? canRoll(state) : { allowed: false, reason: null }), [state]);
+
+  const canAutoRollResult = useMemo(
+    () => (state ? canAutoRoll(state, config.slotTargets) : { allowed: false, reason: null }),
+    [state, config.slotTargets]
+  );
+
+  const currentRollCost = useMemo(() => (state ? getCurrentRollCost(state) : 0), [state]);
+
+  const currentBalance = useMemo(() => (state ? getCurrentBalance(state) : 0), [state]);
+
+  const balanceStatus = useMemo(() => (state ? getBalanceStatus(state) : 'normal'), [state]);
+
+  return {
+    state,
+    isActive: state !== null,
+    activate,
+    roll,
+    lockSlot: handleLockSlot,
+    unlockSlot: handleUnlockSlot,
+    startAutoRoll,
+    stopAutoRoll,
+    reset,
+    deactivate,
+    canRoll: canRollResult.allowed,
+    rollDisabledReason: canRollResult.reason,
+    canAutoRollNow: canAutoRollResult.allowed,
+    autoRollDisabledReason: canAutoRollResult.reason,
+    currentRollCost,
+    currentBalance,
+    balanceStatus,
+  };
+}

--- a/src/features/tools/module-calculator/mode-toggle.tsx
+++ b/src/features/tools/module-calculator/mode-toggle.tsx
@@ -1,0 +1,115 @@
+/**
+ * Mode Toggle
+ *
+ * Toggle button group for switching between calculator modes.
+ */
+
+export type CalculatorMode = 'monteCarlo' | 'manual';
+
+interface ModeOption {
+  value: CalculatorMode;
+  label: string;
+  icon: React.ReactNode;
+  description: string;
+}
+
+const MODE_OPTIONS: ModeOption[] = [
+  {
+    value: 'monteCarlo',
+    label: 'Monte Carlo',
+    icon: <SimulationIcon />,
+    description: 'Run statistical simulation for cost estimates',
+  },
+  {
+    value: 'manual',
+    label: 'Practice',
+    icon: <PracticeIcon />,
+    description: 'Practice rolling manually',
+  },
+];
+
+interface ModeToggleProps {
+  mode: CalculatorMode;
+  onModeChange: (mode: CalculatorMode) => void;
+}
+
+export function ModeToggle({ mode, onModeChange }: ModeToggleProps) {
+  return (
+    <div
+      className="inline-flex items-center bg-slate-800/50 rounded-lg p-1 border border-slate-700/50 w-full"
+      role="group"
+      aria-label="Calculator mode"
+    >
+      {MODE_OPTIONS.map((modeOption, index) => (
+        <ModeButton
+          key={modeOption.value}
+          option={modeOption}
+          isSelected={mode === modeOption.value}
+          isFirst={index === 0}
+          isLast={index === MODE_OPTIONS.length - 1}
+          onSelect={onModeChange}
+        />
+      ))}
+    </div>
+  );
+}
+
+interface ModeButtonProps {
+  option: ModeOption;
+  isSelected: boolean;
+  isFirst: boolean;
+  isLast: boolean;
+  onSelect: (mode: CalculatorMode) => void;
+}
+
+function ModeButton({
+  option,
+  isSelected,
+  isFirst,
+  isLast,
+  onSelect,
+}: ModeButtonProps) {
+  const className = buildModeButtonClassName(isSelected, isFirst, isLast);
+
+  return (
+    <button
+      onClick={() => onSelect(option.value)}
+      aria-pressed={isSelected}
+      title={option.description}
+      className={className}
+    >
+      <span className="opacity-70">{option.icon}</span>
+      {option.label}
+    </button>
+  );
+}
+
+function buildModeButtonClassName(isSelected: boolean, isFirst: boolean, isLast: boolean): string {
+  const base = 'flex-1 relative flex items-center justify-center gap-1.5 px-3 py-2 text-xs font-medium transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-500/50 focus-visible:z-10';
+  const rounded = `${isFirst ? 'rounded-l-md' : ''} ${isLast ? 'rounded-r-md' : ''}`;
+
+  if (isSelected) {
+    return `${base} ${rounded} bg-orange-500/15 text-orange-400 border border-orange-500/40 shadow-sm`;
+  }
+  return `${base} ${rounded} text-slate-400 hover:text-slate-300 hover:bg-slate-700/40 border border-transparent`;
+}
+
+function SimulationIcon() {
+  return (
+    <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <path d="M3 3v18h18" />
+      <path d="M7 16l4-8 4 5 5-10" />
+    </svg>
+  );
+}
+
+function PracticeIcon() {
+  return (
+    <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <rect x="3" y="3" width="18" height="18" rx="2" />
+      <circle cx="8.5" cy="8.5" r="1" fill="currentColor" />
+      <circle cx="15.5" cy="15.5" r="1" fill="currentColor" />
+      <circle cx="12" cy="12" r="1" fill="currentColor" />
+    </svg>
+  );
+}

--- a/src/features/tools/module-calculator/module-calculator.tsx
+++ b/src/features/tools/module-calculator/module-calculator.tsx
@@ -5,17 +5,23 @@
  * Monte Carlo-based cost estimation for module sub-effect rolls.
  */
 
+import { useState } from 'react';
 import { useModuleCalculator } from './use-module-calculator';
 import { ModuleConfigPanel } from './configuration/module-config-panel';
 import { SubEffectTable } from './sub-effect-table/sub-effect-table';
 import { TargetSummaryPanel } from './target-summary/target-summary-panel';
 import { ResultsPanel } from './results/results-panel';
+import { ManualModePanel } from './manual-mode';
+import { ModeToggle, type CalculatorMode } from './mode-toggle';
 
 export function ModuleCalculator() {
+  const [mode, setMode] = useState<CalculatorMode>('monteCarlo');
+
   const {
     config,
     table,
     simulation,
+    manualMode,
     calculatorConfig,
     runSimulation,
   } = useModuleCalculator('cannon');
@@ -73,18 +79,33 @@ export function ModuleCalculator() {
             moduleRarity={config.config.moduleRarity}
           />
 
-          {/* Results Panel */}
-          <ResultsPanel
-            results={simulation.results}
-            isRunning={simulation.isRunning}
-            progress={simulation.progress}
-            error={simulation.error}
-            config={calculatorConfig}
-            confidenceLevel={simulation.confidenceLevel}
-            onConfidenceLevelChange={simulation.setConfidenceLevel}
-            onRunSimulation={runSimulation}
-            onCancel={simulation.cancelSimulation}
-          />
+          {/* Mode Toggle */}
+          <ModeToggle mode={mode} onModeChange={setMode} />
+
+          {/* Mode-specific Panel */}
+          {mode === 'monteCarlo' && (
+            <ResultsPanel
+              results={simulation.results}
+              isRunning={simulation.isRunning}
+              progress={simulation.progress}
+              error={simulation.error}
+              config={calculatorConfig}
+              confidenceLevel={simulation.confidenceLevel}
+              onConfidenceLevelChange={simulation.setConfidenceLevel}
+              onRunSimulation={runSimulation}
+              onCancel={simulation.cancelSimulation}
+            />
+          )}
+
+          {mode === 'manual' && (
+            <ManualModePanel
+              moduleRarity={config.config.moduleRarity}
+              moduleLevel={config.config.moduleLevel}
+              slotCount={config.config.slotCount}
+              bannedEffects={calculatorConfig.bannedEffects}
+              manualMode={manualMode}
+            />
+          )}
         </div>
       </div>
     </div>

--- a/src/features/tools/module-calculator/sub-effect-table/sub-effect-table.tsx
+++ b/src/features/tools/module-calculator/sub-effect-table/sub-effect-table.tsx
@@ -11,7 +11,11 @@ import { SubEffectRow } from './sub-effect-row';
 import { SlotHeader } from './slot-selector';
 import type { UseSubEffectTableResult } from './use-sub-effect-table';
 
-interface SubEffectTableProps extends UseSubEffectTableResult {
+/**
+ * Props for SubEffectTable - excludes programmatic lock/unlock functions
+ * which are for internal bidirectional sync with manual mode.
+ */
+interface SubEffectTableProps extends Omit<UseSubEffectTableResult, 'programmaticLock' | 'programmaticUnlock'> {
   moduleRarity: Rarity;
   availableSlots: number[];
 }


### PR DESCRIPTION
## Summary
Users can now practice module rolling manually instead of relying solely on Monte Carlo simulation. The new Practice Mode lets you roll slot effects one at a time, lock desired effects, and track shard costs in real-time. Two tracking modes are available: "count up" for tracking total spent, or "budget" for counting down from a starting balance.

## Technical Details
- Created `manual-mode/` feature directory with complete React three-layer architecture
- Added `ManualModeState` and supporting types for slots, roll results, and shard tracking
- Implemented pure logic functions (`manual-mode-logic.ts`) for state transitions: `executeRoll`, `lockSlot`, `unlockSlot`, `checkCompletion`
- Added `useManualMode` hook orchestrating state, auto-roll interval (100ms), and completion detection
- Created 5 presentation components: `ManualModePanel`, `EffectSlotsTable`, `EffectSlotRow`, `ShardCounter`, `ModuleHeader`
- Extracted `ModeToggle` component for switching between Monte Carlo and Practice modes
- Added `programmaticLock`/`programmaticUnlock` to `use-sub-effect-table.ts` for bidirectional sync
- Integrated manual mode into `useModuleCalculator` with lock/unlock callbacks
- Added 824 lines of unit tests covering all logic functions