### PR TITLE
IMPROVE: Add Roll Log Table to manual practice mode

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -34,7 +34,9 @@
       "Edit(/C:\\Source\\TowerOfTracking/**)",
       "NotebookEdit(/C:\\Source\\TowerOfTracking/**)",
       "Bash(timeout 15 npm run dev)",
-      "Bash(grep:*)"
+      "Bash(grep:*)",
+      "Skill(commit)",
+      "Skill(commit:*)"
     ],
     "defaultMode": "acceptEdits"
   },

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,9 +1,13 @@
 import * as React from "react"
 import { cn } from "../../shared/lib/utils"
 
-interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {
+interface SelectProps extends Omit<React.SelectHTMLAttributes<HTMLSelectElement>, 'size'> {
   /** Width constraint for the select */
   width?: 'auto' | 'full' | 'sm' | 'md' | 'lg'
+  /** Size variant matching Button component sizes */
+  size?: 'default' | 'sm' | 'compact'
+  /** Native HTML size attribute for multi-select */
+  htmlSize?: number
 }
 
 const widthClasses = {
@@ -14,6 +18,12 @@ const widthClasses = {
   lg: 'w-40'
 } as const
 
+const sizeClasses = {
+  default: 'h-9 min-h-[44px] px-3 py-1.5 text-sm',
+  sm: 'h-9 min-h-[44px] px-3 py-1.5 text-sm',
+  compact: 'h-8 min-h-0 px-2.5 py-1 text-sm [@media(pointer:coarse)]:h-10 [@media(pointer:coarse)]:min-h-[44px]',
+} as const
+
 /**
  * Styled select component with consistent dark theme styling.
  *
@@ -21,15 +31,18 @@ const widthClasses = {
  * HTML select elements with proper focus states and dark theme support.
  */
 export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
-  ({ className, width = 'auto', children, ...props }, ref) => {
+  ({ className, width = 'auto', size = 'default', htmlSize, children, ...props }, ref) => {
     return (
       <select
         ref={ref}
+        size={htmlSize}
         className={cn(
-          // Base styles - min-h-[44px] matches Button component for consistent vertical alignment
-          "flex h-9 min-h-[44px] rounded-md border border-input bg-background px-3 py-1.5",
+          // Base styles
+          "flex rounded-md border border-input bg-background",
+          // Size variant
+          sizeClasses[size],
           // Typography
-          "text-sm text-foreground",
+          "text-foreground",
           // Focus and interaction states
           "transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
           // Hover state

--- a/src/features/tools/module-calculator/manual-mode/effect-slots/effect-slot-row.tsx
+++ b/src/features/tools/module-calculator/manual-mode/effect-slots/effect-slot-row.tsx
@@ -4,7 +4,7 @@
  * Single slot row with effect display and lock toggle for manual mode.
  */
 
-import type { ManualSlot } from './types';
+import type { ManualSlot } from '../types';
 import { getRarityColor } from '@/shared/domain/module-data';
 
 interface EffectSlotRowProps {

--- a/src/features/tools/module-calculator/manual-mode/effect-slots/effect-slots-table.tsx
+++ b/src/features/tools/module-calculator/manual-mode/effect-slots/effect-slots-table.tsx
@@ -4,7 +4,7 @@
  * Container for all 8 effect slot rows in manual mode.
  */
 
-import type { ManualSlot } from './types';
+import type { ManualSlot } from '../types';
 import { EffectSlotRow } from './effect-slot-row';
 
 interface EffectSlotsTableProps {

--- a/src/features/tools/module-calculator/manual-mode/effect-slots/index.ts
+++ b/src/features/tools/module-calculator/manual-mode/effect-slots/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Effect Slots Sub-Feature
+ *
+ * Public exports for the effect slots display functionality.
+ */
+
+export { EffectSlotsTable } from './effect-slots-table';
+;

--- a/src/features/tools/module-calculator/manual-mode/index.ts
+++ b/src/features/tools/module-calculator/manual-mode/index.ts
@@ -5,4 +5,5 @@
  */
 
 export { ManualModePanel } from './manual-mode-panel';
-export { useManualMode } from './use-manual-mode';;;
+export { useManualMode } from './use-manual-mode';
+

--- a/src/features/tools/module-calculator/manual-mode/manual-mode-logic.ts
+++ b/src/features/tools/module-calculator/manual-mode/manual-mode-logic.ts
@@ -118,6 +118,7 @@ export function initializeManualMode(
     totalSpent: 0,
     isComplete: false,
     isAutoRolling: false,
+    logEntries: [],
   };
 }
 

--- a/src/features/tools/module-calculator/manual-mode/manual-mode-panel.tsx
+++ b/src/features/tools/module-calculator/manual-mode/manual-mode-panel.tsx
@@ -9,8 +9,9 @@ import { getSubEffectById } from '@/shared/domain/module-data';
 import type { UseManualModeResult } from './use-manual-mode';
 import type { ShardMode } from './types';
 import { ModuleHeader } from './module-header';
-import { EffectSlotsTable } from './effect-slots-table';
+import { EffectSlotsTable } from './effect-slots';
 import { ShardCounter } from './shard-counter';
+import { RollLog } from './roll-log';
 import { Button } from '@/components/ui';
 
 interface ManualModePanelProps {
@@ -44,32 +45,7 @@ export function ManualModePanel({
 
   return (
     <div className="space-y-4">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <h3 className="text-lg font-semibold text-slate-200">
-          Manual Practice Mode
-        </h3>
-        <div className="flex items-center gap-1.5">
-          <Button
-            variant="ghost"
-            size="compact"
-            onClick={manualMode.reset}
-            className="text-slate-400 hover:text-slate-200"
-          >
-            <ResetIcon />
-            Reset
-          </Button>
-          <Button
-            variant="ghost"
-            size="compact"
-            onClick={manualMode.deactivate}
-            className="text-slate-400 hover:text-red-400"
-          >
-            <ExitIcon />
-            Exit
-          </Button>
-        </div>
-      </div>
+      <PanelHeader onReset={manualMode.reset} onExit={manualMode.deactivate} />
 
       {/* Module Info */}
       <ModuleHeader
@@ -120,12 +96,47 @@ export function ManualModePanel({
         onStartAutoRoll={manualMode.startAutoRoll}
         onStopAutoRoll={manualMode.stopAutoRoll}
       />
+
+      {/* Roll Log */}
+      <RollLog
+        logEnabled={manualMode.logEnabled}
+        minimumLogRarity={manualMode.minimumLogRarity}
+        logEntries={manualMode.logEntries}
+        onLogEnabledChange={manualMode.setLogEnabled}
+        onMinimumRarityChange={manualMode.setMinimumLogRarity}
+        onClearLog={manualMode.clearLog}
+      />
     </div>
   );
 }
 
 interface InactiveStateProps {
   onActivate: (shardMode: ShardMode, startingBalance?: number) => void;
+}
+
+interface PanelHeaderProps {
+  onReset: () => void;
+  onExit: () => void;
+}
+
+function PanelHeader({ onReset, onExit }: PanelHeaderProps) {
+  return (
+    <div className="flex items-center justify-between">
+      <h3 className="text-lg font-semibold text-slate-200">
+        Manual Practice Mode
+      </h3>
+      <div className="flex items-center gap-1.5">
+        <Button variant="ghost" size="compact" onClick={onReset} className="text-slate-400 hover:text-slate-200">
+          <ResetIcon />
+          Reset
+        </Button>
+        <Button variant="ghost" size="compact" onClick={onExit} className="text-slate-400 hover:text-red-400">
+          <ExitIcon />
+          Exit
+        </Button>
+      </div>
+    </div>
+  );
 }
 
 function InactiveState({ onActivate }: InactiveStateProps) {

--- a/src/features/tools/module-calculator/manual-mode/roll-log/index.ts
+++ b/src/features/tools/module-calculator/manual-mode/roll-log/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Roll Log Sub-Feature
+ *
+ * Public exports for the roll log functionality.
+ */
+
+export { RollLog } from './roll-log';
+export {
+  processRollForLogging,
+  
+  
+  
+  
+  
+  
+} from './roll-log-logic';

--- a/src/features/tools/module-calculator/manual-mode/roll-log/roll-log-logic.test.ts
+++ b/src/features/tools/module-calculator/manual-mode/roll-log/roll-log-logic.test.ts
@@ -1,0 +1,412 @@
+/* eslint-disable max-lines */
+import { describe, it, expect } from 'vitest';
+import type { ManualSlot, RollLogEntry, RollLogEffect } from '../types';
+import {
+  MAX_LOG_ENTRIES,
+  filterQualifyingEffects,
+  shouldLogRoll,
+  createLogEntry,
+  addLogEntry,
+  processRollForLogging,
+} from './roll-log-logic';
+
+describe('roll-log-logic', () => {
+  const createMockSlot = (
+    slotNumber: number,
+    effectId: string | null,
+    rarity: 'common' | 'rare' | 'epic' | 'legendary' | 'mythic' | 'ancestral' | null,
+    isLocked = false
+  ): ManualSlot => ({
+    slotNumber,
+    effect: effectId ? { id: effectId, displayName: `Effect ${effectId}`, moduleType: 'cannon', values: {} } as never : null,
+    rarity,
+    isLocked,
+    isTargetMatch: false,
+  });
+
+  describe('MAX_LOG_ENTRIES', () => {
+    it('is set to 500', () => {
+      expect(MAX_LOG_ENTRIES).toBe(500);
+    });
+  });
+
+  describe('filterQualifyingEffects', () => {
+    it('returns empty array when no slots have effects', () => {
+      const slots = [createMockSlot(1, null, null)];
+      const result = filterQualifyingEffects(slots, [0], 'mythic');
+      expect(result).toEqual([]);
+    });
+
+    it('filters effects below minimum rarity', () => {
+      const slots = [
+        createMockSlot(1, 'effect1', 'common'),
+        createMockSlot(2, 'effect2', 'rare'),
+        createMockSlot(3, 'effect3', 'mythic'),
+      ];
+
+      const result = filterQualifyingEffects(slots, [0, 1, 2], 'mythic');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].effectId).toBe('effect3');
+    });
+
+    it('includes effects at exactly minimum rarity', () => {
+      const slots = [createMockSlot(1, 'effect1', 'legendary')];
+
+      const result = filterQualifyingEffects(slots, [0], 'legendary');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].rarity).toBe('legendary');
+    });
+
+    it('includes effects above minimum rarity', () => {
+      const slots = [
+        createMockSlot(1, 'effect1', 'mythic'),
+        createMockSlot(2, 'effect2', 'ancestral'),
+      ];
+
+      const result = filterQualifyingEffects(slots, [0, 1], 'legendary');
+
+      expect(result).toHaveLength(2);
+    });
+
+    it('only checks filled slot indexes', () => {
+      const slots = [
+        createMockSlot(1, 'effect1', 'mythic'),
+        createMockSlot(2, 'effect2', 'ancestral'),
+        createMockSlot(3, 'effect3', 'mythic'),
+      ];
+
+      // Only check slot at index 1
+      const result = filterQualifyingEffects(slots, [1], 'mythic');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].effectId).toBe('effect2');
+    });
+
+    it('includes correct effect properties', () => {
+      const slots = [createMockSlot(1, 'testEffect', 'ancestral')];
+
+      const result = filterQualifyingEffects(slots, [0], 'mythic');
+
+      expect(result[0]).toEqual({
+        effectId: 'testEffect',
+        name: 'Effect testEffect',
+        rarity: 'ancestral',
+        shortName: 'A',
+      });
+    });
+
+    it('handles all rarity short names correctly', () => {
+      const rarities: Array<'common' | 'rare' | 'epic' | 'legendary' | 'mythic' | 'ancestral'> = [
+        'common', 'rare', 'epic', 'legendary', 'mythic', 'ancestral',
+      ];
+      const expectedShortNames = ['C', 'R', 'E', 'L', 'M', 'A'];
+
+      for (let i = 0; i < rarities.length; i++) {
+        const slots = [createMockSlot(1, `effect${i}`, rarities[i])];
+        const result = filterQualifyingEffects(slots, [0], 'common');
+        expect(result[0].shortName).toBe(expectedShortNames[i]);
+      }
+    });
+  });
+
+  describe('shouldLogRoll', () => {
+    it('returns false when logging is disabled', () => {
+      const slots = [createMockSlot(1, 'effect1', 'ancestral')];
+      const result = shouldLogRoll(slots, [0], 'common', false);
+      expect(result).toBe(false);
+    });
+
+    it('returns false when no slots were filled', () => {
+      const slots = [createMockSlot(1, 'effect1', 'mythic')];
+      const result = shouldLogRoll(slots, [], 'mythic', true);
+      expect(result).toBe(false);
+    });
+
+    it('returns false when no effect meets minimum rarity', () => {
+      const slots = [
+        createMockSlot(1, 'effect1', 'common'),
+        createMockSlot(2, 'effect2', 'rare'),
+      ];
+      const result = shouldLogRoll(slots, [0, 1], 'mythic', true);
+      expect(result).toBe(false);
+    });
+
+    it('returns true when at least one effect meets minimum rarity', () => {
+      const slots = [
+        createMockSlot(1, 'effect1', 'common'),
+        createMockSlot(2, 'effect2', 'mythic'),
+      ];
+      const result = shouldLogRoll(slots, [0, 1], 'mythic', true);
+      expect(result).toBe(true);
+    });
+
+    it('returns true for ancestral when filtering on mythic', () => {
+      const slots = [createMockSlot(1, 'effect1', 'ancestral')];
+      const result = shouldLogRoll(slots, [0], 'mythic', true);
+      expect(result).toBe(true);
+    });
+
+    it('handles empty slot (null rarity) gracefully', () => {
+      const slots = [createMockSlot(1, null, null)];
+      const result = shouldLogRoll(slots, [0], 'mythic', true);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('createLogEntry', () => {
+    it('creates entry with correct properties', () => {
+      const effects: RollLogEffect[] = [
+        { effectId: 'effect1', name: 'Effect 1', rarity: 'mythic', shortName: 'M' },
+      ];
+
+      const entry = createLogEntry(42, 4200, 100, effects);
+
+      expect(entry).toEqual({
+        rollNumber: 42,
+        totalShards: 4200,
+        rollCost: 100,
+        effects,
+      });
+    });
+
+    it('handles empty effects array', () => {
+      const entry = createLogEntry(1, 10, 10, []);
+
+      expect(entry.effects).toEqual([]);
+    });
+
+    it('handles multiple effects', () => {
+      const effects: RollLogEffect[] = [
+        { effectId: 'effect1', name: 'Effect 1', rarity: 'mythic', shortName: 'M' },
+        { effectId: 'effect2', name: 'Effect 2', rarity: 'ancestral', shortName: 'A' },
+      ];
+
+      const entry = createLogEntry(1, 100, 100, effects);
+
+      expect(entry.effects).toHaveLength(2);
+    });
+  });
+
+  describe('addLogEntry', () => {
+    it('prepends new entry to beginning of array', () => {
+      const existingEntries: RollLogEntry[] = [
+        { rollNumber: 1, totalShards: 10, rollCost: 10, effects: [] },
+      ];
+      const newEntry: RollLogEntry = {
+        rollNumber: 2,
+        totalShards: 20,
+        rollCost: 10,
+        effects: [],
+      };
+
+      const result = addLogEntry(existingEntries, newEntry);
+
+      expect(result[0]).toBe(newEntry);
+      expect(result[1]).toBe(existingEntries[0]);
+    });
+
+    it('does not mutate original array', () => {
+      const existingEntries: RollLogEntry[] = [
+        { rollNumber: 1, totalShards: 10, rollCost: 10, effects: [] },
+      ];
+      const newEntry: RollLogEntry = {
+        rollNumber: 2,
+        totalShards: 20,
+        rollCost: 10,
+        effects: [],
+      };
+
+      addLogEntry(existingEntries, newEntry);
+
+      expect(existingEntries).toHaveLength(1);
+    });
+
+    it('enforces max entries limit', () => {
+      const existingEntries: RollLogEntry[] = Array.from({ length: MAX_LOG_ENTRIES }, (_, i) => ({
+        rollNumber: i + 1,
+        totalShards: (i + 1) * 10,
+        rollCost: 10,
+        effects: [],
+      }));
+
+      const newEntry: RollLogEntry = {
+        rollNumber: MAX_LOG_ENTRIES + 1,
+        totalShards: (MAX_LOG_ENTRIES + 1) * 10,
+        rollCost: 10,
+        effects: [],
+      };
+
+      const result = addLogEntry(existingEntries, newEntry);
+
+      expect(result).toHaveLength(MAX_LOG_ENTRIES);
+      expect(result[0].rollNumber).toBe(MAX_LOG_ENTRIES + 1);
+      expect(result[MAX_LOG_ENTRIES - 1].rollNumber).toBe(MAX_LOG_ENTRIES - 1);
+    });
+
+    it('accepts custom max entries limit', () => {
+      const existingEntries: RollLogEntry[] = [
+        { rollNumber: 1, totalShards: 10, rollCost: 10, effects: [] },
+        { rollNumber: 2, totalShards: 20, rollCost: 10, effects: [] },
+      ];
+      const newEntry: RollLogEntry = {
+        rollNumber: 3,
+        totalShards: 30,
+        rollCost: 10,
+        effects: [],
+      };
+
+      const result = addLogEntry(existingEntries, newEntry, 2);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].rollNumber).toBe(3);
+      expect(result[1].rollNumber).toBe(1);
+    });
+
+    it('handles empty existing entries', () => {
+      const newEntry: RollLogEntry = {
+        rollNumber: 1,
+        totalShards: 10,
+        rollCost: 10,
+        effects: [],
+      };
+
+      const result = addLogEntry([], newEntry);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBe(newEntry);
+    });
+  });
+
+  describe('processRollForLogging', () => {
+    it('returns unchanged entries when logging is disabled', () => {
+      const slots = [createMockSlot(1, 'effect1', 'ancestral')];
+      const existingEntries: RollLogEntry[] = [
+        { rollNumber: 1, totalShards: 100, rollCost: 100, effects: [] },
+      ];
+
+      const result = processRollForLogging({
+        slots,
+        filledSlotIndexes: [0],
+        rollNumber: 2,
+        totalSpent: 200,
+        rollCost: 100,
+        logEntries: existingEntries,
+        minimumLogRarity: 'mythic',
+        logEnabled: false,
+      });
+
+      expect(result).toBe(existingEntries);
+    });
+
+    it('returns unchanged entries when no slots were filled', () => {
+      const slots = [createMockSlot(1, 'effect1', 'mythic')];
+      const existingEntries: RollLogEntry[] = [];
+
+      const result = processRollForLogging({
+        slots,
+        filledSlotIndexes: [],
+        rollNumber: 1,
+        totalSpent: 100,
+        rollCost: 100,
+        logEntries: existingEntries,
+        minimumLogRarity: 'mythic',
+        logEnabled: true,
+      });
+
+      expect(result).toBe(existingEntries);
+    });
+
+    it('returns unchanged entries when no effect meets minimum rarity', () => {
+      const slots = [
+        createMockSlot(1, 'effect1', 'common'),
+        createMockSlot(2, 'effect2', 'rare'),
+      ];
+      const existingEntries: RollLogEntry[] = [];
+
+      const result = processRollForLogging({
+        slots,
+        filledSlotIndexes: [0, 1],
+        rollNumber: 1,
+        totalSpent: 100,
+        rollCost: 100,
+        logEntries: existingEntries,
+        minimumLogRarity: 'mythic',
+        logEnabled: true,
+      });
+
+      expect(result).toBe(existingEntries);
+    });
+
+    it('adds entry when effect meets minimum rarity', () => {
+      const slots = [createMockSlot(1, 'effect1', 'mythic')];
+      const existingEntries: RollLogEntry[] = [];
+
+      const result = processRollForLogging({
+        slots,
+        filledSlotIndexes: [0],
+        rollNumber: 5,
+        totalSpent: 500,
+        rollCost: 100,
+        logEntries: existingEntries,
+        minimumLogRarity: 'mythic',
+        logEnabled: true,
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].rollNumber).toBe(5);
+      expect(result[0].totalShards).toBe(500);
+      expect(result[0].rollCost).toBe(100);
+      expect(result[0].effects).toHaveLength(1);
+      expect(result[0].effects[0].effectId).toBe('effect1');
+    });
+
+    it('prepends new entry to existing entries', () => {
+      const slots = [createMockSlot(1, 'effect1', 'ancestral')];
+      const existingEntries: RollLogEntry[] = [
+        { rollNumber: 1, totalShards: 100, rollCost: 100, effects: [] },
+      ];
+
+      const result = processRollForLogging({
+        slots,
+        filledSlotIndexes: [0],
+        rollNumber: 2,
+        totalSpent: 200,
+        rollCost: 100,
+        logEntries: existingEntries,
+        minimumLogRarity: 'mythic',
+        logEnabled: true,
+      });
+
+      expect(result).toHaveLength(2);
+      expect(result[0].rollNumber).toBe(2);
+      expect(result[1].rollNumber).toBe(1);
+    });
+
+    it('only includes qualifying effects in entry', () => {
+      const slots = [
+        createMockSlot(1, 'effect1', 'common'),
+        createMockSlot(2, 'effect2', 'mythic'),
+        createMockSlot(3, 'effect3', 'ancestral'),
+      ];
+      const existingEntries: RollLogEntry[] = [];
+
+      const result = processRollForLogging({
+        slots,
+        filledSlotIndexes: [0, 1, 2],
+        rollNumber: 1,
+        totalSpent: 100,
+        rollCost: 100,
+        logEntries: existingEntries,
+        minimumLogRarity: 'mythic',
+        logEnabled: true,
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].effects).toHaveLength(2);
+      expect(result[0].effects[0].effectId).toBe('effect2');
+      expect(result[0].effects[1].effectId).toBe('effect3');
+    });
+  });
+});

--- a/src/features/tools/module-calculator/manual-mode/roll-log/roll-log-logic.ts
+++ b/src/features/tools/module-calculator/manual-mode/roll-log/roll-log-logic.ts
@@ -1,0 +1,142 @@
+/**
+ * Roll Log Logic
+ *
+ * Pure functions for managing the roll log in manual mode.
+ * Handles filtering qualifying effects, creating log entries, and enforcing limits.
+ */
+
+import type { Rarity } from '@/shared/domain/module-data';
+import { RARITY_CONFIG_MAP } from '@/shared/domain/module-data';
+import { isAtLeastAsRare } from '@/shared/domain/module-data/rarities/rarity-utils';
+import type { ManualSlot, RollLogEntry, RollLogEffect } from '../types';
+
+/**
+ * Maximum number of log entries to retain
+ */
+export const MAX_LOG_ENTRIES = 500;
+
+/**
+ * Filter slots to extract effects that meet the minimum rarity threshold.
+ * Only includes filled slots (non-null effect and rarity).
+ */
+export function filterQualifyingEffects(
+  slots: ManualSlot[],
+  filledSlotIndexes: number[],
+  minRarity: Rarity
+): RollLogEffect[] {
+  const qualifying: RollLogEffect[] = [];
+
+  for (const index of filledSlotIndexes) {
+    const slot = slots[index];
+    if (!slot?.effect || !slot.rarity) continue;
+
+    if (isAtLeastAsRare(slot.rarity, minRarity)) {
+      qualifying.push({
+        effectId: slot.effect.id,
+        name: slot.effect.displayName,
+        rarity: slot.rarity,
+        shortName: RARITY_CONFIG_MAP[slot.rarity].shortName,
+      });
+    }
+  }
+
+  return qualifying;
+}
+
+/**
+ * Check if a roll should be logged based on whether any effect meets the threshold.
+ */
+export function shouldLogRoll(
+  slots: ManualSlot[],
+  filledSlotIndexes: number[],
+  minRarity: Rarity,
+  logEnabled: boolean
+): boolean {
+  if (!logEnabled) return false;
+  if (filledSlotIndexes.length === 0) return false;
+
+  for (const index of filledSlotIndexes) {
+    const slot = slots[index];
+    if (!slot?.rarity) continue;
+
+    if (isAtLeastAsRare(slot.rarity, minRarity)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Create a log entry from roll data.
+ */
+export function createLogEntry(
+  rollNumber: number,
+  totalShards: number,
+  rollCost: number,
+  effects: RollLogEffect[]
+): RollLogEntry {
+  return {
+    rollNumber,
+    totalShards,
+    rollCost,
+    effects,
+  };
+}
+
+/**
+ * Add a log entry to the beginning of the entries array.
+ * Enforces the maximum entry limit by removing oldest entries.
+ */
+export function addLogEntry(
+  entries: RollLogEntry[],
+  entry: RollLogEntry,
+  maxEntries: number = MAX_LOG_ENTRIES
+): RollLogEntry[] {
+  const updated = [entry, ...entries];
+
+  if (updated.length > maxEntries) {
+    return updated.slice(0, maxEntries);
+  }
+
+  return updated;
+}
+
+/**
+ * Parameters for processing a roll for logging
+ */
+interface ProcessRollForLoggingParams {
+  slots: ManualSlot[];
+  filledSlotIndexes: number[];
+  rollNumber: number;
+  totalSpent: number;
+  rollCost: number;
+  logEntries: RollLogEntry[];
+  minimumLogRarity: Rarity;
+  logEnabled: boolean;
+}
+
+/**
+ * Process a roll result and add a log entry if it qualifies.
+ * Returns updated log entries array (unchanged if roll doesn't qualify).
+ */
+export function processRollForLogging(params: ProcessRollForLoggingParams): RollLogEntry[] {
+  const {
+    slots,
+    filledSlotIndexes,
+    rollNumber,
+    totalSpent,
+    rollCost,
+    logEntries,
+    minimumLogRarity,
+    logEnabled,
+  } = params;
+
+  if (!shouldLogRoll(slots, filledSlotIndexes, minimumLogRarity, logEnabled)) {
+    return logEntries;
+  }
+
+  const qualifyingEffects = filterQualifyingEffects(slots, filledSlotIndexes, minimumLogRarity);
+  const entry = createLogEntry(rollNumber, totalSpent, rollCost, qualifyingEffects);
+  return addLogEntry(logEntries, entry);
+}

--- a/src/features/tools/module-calculator/manual-mode/roll-log/roll-log.tsx
+++ b/src/features/tools/module-calculator/manual-mode/roll-log/roll-log.tsx
@@ -1,0 +1,223 @@
+/**
+ * Roll Log Component
+ *
+ * Displays a log of notable rolls in manual practice mode.
+ * Users can filter by minimum rarity and enable/disable logging.
+ */
+
+import type { Rarity } from '@/shared/domain/module-data';
+import { RARITY_ORDER, RARITY_CONFIG_MAP, getRarityColor } from '@/shared/domain/module-data';
+import { formatLargeNumber } from '@/shared/formatting/number-scale';
+import { ToggleSwitch } from '@/components/ui/toggle-switch';
+import { Select, Button } from '@/components/ui';
+import type { RollLogEntry } from '../types';
+
+interface RollLogProps {
+  logEnabled: boolean;
+  minimumLogRarity: Rarity;
+  logEntries: RollLogEntry[];
+  onLogEnabledChange: (enabled: boolean) => void;
+  onMinimumRarityChange: (rarity: Rarity) => void;
+  onClearLog: () => void;
+}
+
+export function RollLog({
+  logEnabled,
+  minimumLogRarity,
+  logEntries,
+  onLogEnabledChange,
+  onMinimumRarityChange,
+  onClearLog,
+}: RollLogProps) {
+  return (
+    <div className="p-4 bg-slate-800/30 rounded-lg border border-slate-700/50 space-y-3">
+      <RollLogHeader />
+      <RollLogControls
+        logEnabled={logEnabled}
+        minimumLogRarity={minimumLogRarity}
+        hasEntries={logEntries.length > 0}
+        onLogEnabledChange={onLogEnabledChange}
+        onMinimumRarityChange={onMinimumRarityChange}
+        onClearLog={onClearLog}
+      />
+      {logEnabled && <RollLogTable entries={logEntries} />}
+    </div>
+  );
+}
+
+function RollLogHeader() {
+  return (
+    <div className="flex items-center gap-2">
+      <LogIcon />
+      <h4 className="text-sm font-medium text-slate-300">Roll Log</h4>
+    </div>
+  );
+}
+
+function LogIcon() {
+  return (
+    <svg className="w-4 h-4 text-slate-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+      <polyline points="14 2 14 8 20 8" />
+      <line x1="16" y1="13" x2="8" y2="13" />
+      <line x1="16" y1="17" x2="8" y2="17" />
+      <polyline points="10 9 9 9 8 9" />
+    </svg>
+  );
+}
+
+interface RollLogControlsProps {
+  logEnabled: boolean;
+  minimumLogRarity: Rarity;
+  hasEntries: boolean;
+  onLogEnabledChange: (enabled: boolean) => void;
+  onMinimumRarityChange: (rarity: Rarity) => void;
+  onClearLog: () => void;
+}
+
+function RollLogControls({
+  logEnabled,
+  minimumLogRarity,
+  hasEntries,
+  onLogEnabledChange,
+  onMinimumRarityChange,
+  onClearLog,
+}: RollLogControlsProps) {
+  return (
+    <div className="flex items-center gap-4 flex-wrap">
+      <div className="flex items-center gap-2 text-sm text-slate-300">
+        <ToggleSwitch
+          checked={logEnabled}
+          onCheckedChange={onLogEnabledChange}
+          aria-label="Enable roll logging"
+        />
+        <span>Enable Log</span>
+      </div>
+
+      {logEnabled && (
+        <>
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-slate-400">Min Rarity:</span>
+            <Select
+              value={minimumLogRarity}
+              onChange={(e) => onMinimumRarityChange(e.target.value as Rarity)}
+              size="compact"
+              className="w-28"
+              style={{ color: getRarityColor(minimumLogRarity) }}
+            >
+              {RARITY_ORDER.map((rarity) => (
+                <option
+                  key={rarity}
+                  value={rarity}
+                  style={{ color: getRarityColor(rarity) }}
+                >
+                  {RARITY_CONFIG_MAP[rarity].displayName}
+                </option>
+              ))}
+            </Select>
+          </div>
+
+          {hasEntries && (
+            <Button
+              variant="ghost"
+              size="compact"
+              onClick={onClearLog}
+              className="text-slate-500 hover:text-slate-300"
+            >
+              <ClearIcon />
+              Clear
+            </Button>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+function ClearIcon() {
+  return (
+    <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <path d="M3 6h18M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+    </svg>
+  );
+}
+
+interface RollLogTableProps {
+  entries: RollLogEntry[];
+}
+
+function RollLogTable({ entries }: RollLogTableProps) {
+  return (
+    <div className="rounded-lg border border-slate-700/30 bg-slate-900/30 overflow-hidden">
+      <div className="overflow-y-auto max-h-[200px]">
+        <table className="w-full text-sm">
+          <thead className="bg-slate-800/60 sticky top-0">
+            <tr className="text-left text-slate-400 text-xs">
+              <th className="px-3 py-2 font-medium w-16">Roll #</th>
+              <th className="px-3 py-2 font-medium w-24 text-right">Total</th>
+              <th className="px-3 py-2 font-medium w-20 text-right">Cost</th>
+              <th className="px-3 py-2 font-medium">Effects</th>
+            </tr>
+          </thead>
+          <tbody>
+            {entries.length === 0 ? (
+              <tr>
+                <td colSpan={4} className="px-3 py-6 text-center text-slate-500 text-xs">
+                  No rolls matching filter yet
+                </td>
+              </tr>
+            ) : (
+              entries.map((entry, index) => (
+                <RollLogRow key={`${entry.rollNumber}-${index}`} entry={entry} />
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+interface RollLogRowProps {
+  entry: RollLogEntry;
+}
+
+function RollLogRow({ entry }: RollLogRowProps) {
+  return (
+    <tr className="border-t border-slate-700/30 hover:bg-slate-700/20 transition-colors">
+      <td className="px-3 py-2 tabular-nums text-slate-400 text-xs">{entry.rollNumber}</td>
+      <td className="px-3 py-2 tabular-nums text-right text-slate-200 font-medium">
+        {formatLargeNumber(entry.totalShards)}
+      </td>
+      <td className="px-3 py-2 tabular-nums text-right text-orange-400/80 text-xs">
+        +{formatLargeNumber(entry.rollCost)}
+      </td>
+      <td className="px-3 py-2">
+        <EffectsList effects={entry.effects} />
+      </td>
+    </tr>
+  );
+}
+
+interface EffectsListProps {
+  effects: RollLogEntry['effects'];
+}
+
+function EffectsList({ effects }: EffectsListProps) {
+  return (
+    <span className="text-slate-300 text-xs">
+      {effects.map((effect, index) => (
+        <span key={effect.effectId}>
+          {index > 0 && <span className="text-slate-600">, </span>}
+          <span className="text-slate-400">{effect.name}</span>
+          <span
+            className="ml-1 font-medium"
+            style={{ color: getRarityColor(effect.rarity) }}
+          >
+            ({effect.shortName})
+          </span>
+        </span>
+      ))}
+    </span>
+  );
+}

--- a/src/features/tools/module-calculator/manual-mode/types.ts
+++ b/src/features/tools/module-calculator/manual-mode/types.ts
@@ -62,6 +62,9 @@ export interface ManualModeState {
 
   /** Whether auto-rolling is currently active */
   isAutoRolling: boolean;
+
+  /** Log of notable rolls (filtered by minimum rarity) */
+  logEntries: RollLogEntry[];
 }
 
 /**
@@ -101,4 +104,31 @@ export interface ManualModeConfig {
 
   /** Minimum rarity required for each effect (effectId -> Rarity) */
   minRarityMap: Map<string, Rarity>;
+}
+
+/**
+ * An effect in a roll log entry
+ */
+export interface RollLogEffect {
+  effectId: string;
+  name: string;
+  rarity: Rarity;
+  shortName: string;
+}
+
+/**
+ * A single entry in the roll log
+ */
+export interface RollLogEntry {
+  /** Roll number when this entry was logged */
+  rollNumber: number;
+
+  /** Total shards spent at time of roll */
+  totalShards: number;
+
+  /** Cost of this specific roll */
+  rollCost: number;
+
+  /** Effects that qualified for logging (met minimum rarity) */
+  effects: RollLogEffect[];
 }


### PR DESCRIPTION
## Summary
Users practicing module rolling can now track notable rolls in a scrollable log table. The log captures rolls that contain effects meeting a minimum rarity threshold (default: Mythic), showing roll number, cumulative shards spent, per-roll cost, and the qualifying effects with rarity indicators. This helps users identify high-value effects they may have passed over and validates simulator accuracy against actual roll distributions.

## Technical Details
- Added `roll-log/` subdirectory with pure logic (`roll-log-logic.ts`), comprehensive tests, and UI component
- New types: `RollLogEntry` and `RollLogEffect` for log data structure
- Integrated log state into `useManualMode` hook with `logEnabled`, `minimumLogRarity`, and entry management
- Added compact size variant to `Select` component for dense UI contexts
- Reorganized `effect-slot-row.tsx` and `effect-slots-table.tsx` into `effect-slots/` subdirectory
- Log enforces 500-entry limit (oldest entries removed) to prevent memory issues
- Full test coverage for all pure log logic functions

## Context
This feature addresses user feedback that rolling history was lost between rolls, making it impossible to evaluate target strategy effectiveness or compare actual roll distributions against Monte Carlo predictions.