### PR TITLE
IMPROVE: Add localStorage persistence for module calculator selections

### DIFF
--- a/src/features/tools/module-calculator/configuration/module-config-panel.tsx
+++ b/src/features/tools/module-calculator/configuration/module-config-panel.tsx
@@ -5,6 +5,7 @@
  * Displays available slots based on level.
  */
 
+import { RotateCcw } from 'lucide-react';
 import type { ModuleType, Rarity } from '@/shared/domain/module-data';
 import {
   MODULE_TYPE_CONFIGS,
@@ -13,7 +14,7 @@ import {
   RARITY_CONFIG_MAP,
 } from '@/shared/domain/module-data';
 import { ROLLABLE_MODULE_RARITIES } from './module-config-logic';
-import { Input, Select, FormControl } from '@/components/ui';
+import { Input, Select, FormControl, Button } from '@/components/ui';
 
 interface ModuleConfigPanelProps {
   moduleType: ModuleType;
@@ -23,6 +24,7 @@ interface ModuleConfigPanelProps {
   onModuleTypeChange: (type: ModuleType) => void;
   onModuleLevelChange: (level: number) => void;
   onModuleRarityChange: (rarity: Rarity) => void;
+  onReset: () => void;
 }
 
 export function ModuleConfigPanel({
@@ -33,6 +35,7 @@ export function ModuleConfigPanel({
   onModuleTypeChange,
   onModuleLevelChange,
   onModuleRarityChange,
+  onReset,
 }: ModuleConfigPanelProps) {
   return (
     <div className="space-y-4">
@@ -53,6 +56,18 @@ export function ModuleConfigPanel({
           onChange={onModuleRarityChange}
         />
         <SlotDisplay count={slotCount} />
+        <div className="ml-auto">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onReset}
+            className="text-slate-400 hover:text-slate-200"
+            title="Reset all selections for this module"
+          >
+            <RotateCcw className="h-4 w-4 mr-1.5" />
+            Reset
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/src/features/tools/module-calculator/configuration/use-module-config.ts
+++ b/src/features/tools/module-calculator/configuration/use-module-config.ts
@@ -17,6 +17,15 @@ import {
   ROLLABLE_MODULE_RARITIES,
 } from './module-config-logic';
 
+/**
+ * Initial configuration values for persistence
+ */
+export interface InitialModuleConfigValues {
+  moduleType: ModuleType;
+  moduleLevel: number;
+  moduleRarity: Rarity;
+}
+
 interface UseModuleConfigResult {
   /** Current configuration */
   config: CalculatorConfig;
@@ -50,11 +59,19 @@ interface UseModuleConfigResult {
 }
 
 export function useModuleConfig(
-  initialModuleType: ModuleType = 'cannon'
+  initialModuleType: ModuleType = 'cannon',
+  initialValues?: InitialModuleConfigValues
 ): UseModuleConfigResult {
-  const [config, setConfig] = useState<CalculatorConfig>(() =>
-    createDefaultConfig(initialModuleType)
-  );
+  const [config, setConfig] = useState<CalculatorConfig>(() => {
+    if (initialValues) {
+      const baseConfig = createDefaultConfig(initialValues.moduleType);
+      return updateModuleRarity(
+        updateModuleLevel(baseConfig, initialValues.moduleLevel),
+        initialValues.moduleRarity
+      );
+    }
+    return createDefaultConfig(initialModuleType);
+  });
 
   const setModuleType = useCallback((moduleType: ModuleType) => {
     setConfig((prev) => updateModuleType(prev, moduleType));

--- a/src/features/tools/module-calculator/module-calculator.tsx
+++ b/src/features/tools/module-calculator/module-calculator.tsx
@@ -24,6 +24,7 @@ export function ModuleCalculator() {
     manualMode,
     calculatorConfig,
     runSimulation,
+    reset,
   } = useModuleCalculator('cannon');
 
   return (
@@ -40,6 +41,7 @@ export function ModuleCalculator() {
         onModuleTypeChange={config.setModuleType}
         onModuleLevelChange={config.setModuleLevel}
         onModuleRarityChange={config.setModuleRarity}
+        onReset={reset}
       />
 
       {/* Main Content Grid */}

--- a/src/features/tools/module-calculator/persistence/module-calc-persistence.test.ts
+++ b/src/features/tools/module-calculator/persistence/module-calc-persistence.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  loadModuleCalcState,
+  loadModuleCalcStateRaw,
+  saveModuleCalcState,
+  clearModuleCalcState,
+  getDefaultStoredState,
+  getDefaultFlatState,
+  serializeSelections,
+  deserializeSelections,
+  type StoredModuleCalcState,
+  type FlatModuleCalcState,
+  type ModuleTypeState
+} from './module-calc-persistence'
+import type { EffectSelection } from '../types'
+
+describe('module-calc-persistence', () => {
+  const STORAGE_KEY = 'tower-tracking-module-calc-state'
+
+  const createSelection = (id: string, overrides: Partial<EffectSelection> = {}): EffectSelection => ({
+    effectId: id, minRarity: null, targetSlots: [], isBanned: false, isLocked: false, lockedRarity: null, ...overrides
+  })
+
+  const createFlatState = (overrides: Partial<FlatModuleCalcState> = {}): FlatModuleCalcState => ({
+    moduleType: 'cannon', moduleLevel: 141, moduleRarity: 'ancestral', selections: [],
+    confidenceLevel: 'medium', lastUpdated: Date.now(), ...overrides
+  })
+
+  const createModuleTypeState = (overrides: Partial<ModuleTypeState> = {}): ModuleTypeState => ({
+    moduleLevel: 141, moduleRarity: 'ancestral', selections: [], confidenceLevel: 'medium', ...overrides
+  })
+
+  const createStoredState = (overrides: Partial<StoredModuleCalcState> = {}): StoredModuleCalcState => ({
+    activeModuleType: 'cannon', modules: {}, lastUpdated: Date.now(), ...overrides
+  })
+
+  beforeEach(() => { localStorage.clear(); vi.clearAllMocks() })
+  afterEach(() => { localStorage.clear() })
+
+  describe('getDefaultStoredState / getDefaultFlatState', () => {
+    it('returns expected default structures', () => {
+      expect(getDefaultStoredState()).toMatchObject({ activeModuleType: 'cannon', modules: {} })
+      expect(getDefaultFlatState()).toMatchObject({
+        moduleType: 'cannon', moduleLevel: 141, moduleRarity: 'ancestral', selections: [], confidenceLevel: 'medium'
+      })
+      expect(getDefaultFlatState('generator').moduleType).toBe('generator')
+    })
+  })
+
+  describe('loadModuleCalcState', () => {
+    it('returns defaults when localStorage is empty', () => {
+      expect(loadModuleCalcState()).toMatchObject({ moduleType: 'cannon', selections: [] })
+    })
+
+    it('loads state for active module type', () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(createStoredState({
+        activeModuleType: 'armor',
+        modules: { armor: createModuleTypeState({ moduleLevel: 120, selections: [createSelection('e1', { minRarity: 'epic' })] }) }
+      })))
+      const loaded = loadModuleCalcState()
+      expect(loaded.moduleType).toBe('armor')
+      expect(loaded.moduleLevel).toBe(120)
+      expect(loaded.selections).toHaveLength(1)
+    })
+
+    it('loads state for specific module type when requested', () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(createStoredState({
+        modules: { cannon: createModuleTypeState({ moduleLevel: 100 }), generator: createModuleTypeState({ moduleLevel: 150 }) }
+      })))
+      expect(loadModuleCalcState('generator').moduleLevel).toBe(150)
+    })
+
+    it('returns defaults when module type has no stored state', () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(createStoredState({ modules: { cannon: createModuleTypeState() } })))
+      expect(loadModuleCalcState('generator').moduleLevel).toBe(141)
+    })
+
+    it('returns defaults for invalid JSON', () => {
+      localStorage.setItem(STORAGE_KEY, 'invalid{')
+      expect(loadModuleCalcState().moduleType).toBe('cannon')
+    })
+
+    it('filters invalid selections and validates field values', () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(createStoredState({
+        modules: { cannon: createModuleTypeState({
+          moduleLevel: 999, moduleRarity: 'common' as 'ancestral', confidenceLevel: 'ultra' as 'medium',
+          selections: [createSelection('valid', { minRarity: 'epic' }), { effectId: 'bad' } as EffectSelection]
+        }) }
+      })))
+      const loaded = loadModuleCalcState()
+      expect(loaded.moduleLevel).toBe(141)
+      expect(loaded.moduleRarity).toBe('ancestral')
+      expect(loaded.confidenceLevel).toBe('medium')
+      expect(loaded.selections).toHaveLength(1)
+      expect(loaded.selections[0].effectId).toBe('valid')
+    })
+
+    it('accepts locked and banned effects', () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(createStoredState({
+        modules: { cannon: createModuleTypeState({
+          selections: [createSelection('locked', { isLocked: true, lockedRarity: 'legendary' }), createSelection('banned', { isBanned: true })]
+        }) }
+      })))
+      const loaded = loadModuleCalcState()
+      expect(loaded.selections[0].isLocked).toBe(true)
+      expect(loaded.selections[1].isBanned).toBe(true)
+    })
+  })
+
+  describe('loadModuleCalcStateRaw', () => {
+    it('returns the full stored structure', () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(createStoredState({
+        activeModuleType: 'generator', modules: { cannon: createModuleTypeState(), generator: createModuleTypeState() }
+      })))
+      const raw = loadModuleCalcStateRaw()
+      expect(raw.activeModuleType).toBe('generator')
+      expect(Object.keys(raw.modules)).toEqual(['cannon', 'generator'])
+    })
+  })
+
+  describe('saveModuleCalcState', () => {
+    it('saves state for specific module type and updates activeModuleType', () => {
+      saveModuleCalcState(createFlatState({ moduleType: 'generator', moduleLevel: 180 }))
+      const parsed = JSON.parse(localStorage.getItem(STORAGE_KEY)!) as StoredModuleCalcState
+      expect(parsed.activeModuleType).toBe('generator')
+      expect(parsed.modules.generator?.moduleLevel).toBe(180)
+    })
+
+    it('preserves state for other module types', () => {
+      saveModuleCalcState(createFlatState({ moduleType: 'cannon', moduleLevel: 100 }))
+      saveModuleCalcState(createFlatState({ moduleType: 'generator', moduleLevel: 150 }))
+      const parsed = JSON.parse(localStorage.getItem(STORAGE_KEY)!) as StoredModuleCalcState
+      expect(parsed.modules.cannon?.moduleLevel).toBe(100)
+      expect(parsed.modules.generator?.moduleLevel).toBe(150)
+    })
+
+    it('handles localStorage errors gracefully', () => {
+      vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => { throw new Error('quota') })
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      expect(() => saveModuleCalcState(createFlatState())).not.toThrow()
+      expect(spy).toHaveBeenCalled()
+    })
+  })
+
+  describe('clearModuleCalcState', () => {
+    it('removes state and handles errors', () => {
+      saveModuleCalcState(createFlatState())
+      expect(localStorage.getItem(STORAGE_KEY)).not.toBeNull()
+      clearModuleCalcState()
+      expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
+
+      vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => { throw new Error('err') })
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      expect(() => clearModuleCalcState()).not.toThrow()
+      expect(spy).toHaveBeenCalled()
+    })
+  })
+
+  describe('serializeSelections / deserializeSelections', () => {
+    it('converts between Map and array, filtering empty selections', () => {
+      const map = new Map([
+        ['target', createSelection('target', { minRarity: 'epic' })],
+        ['empty', createSelection('empty')],
+        ['banned', createSelection('banned', { isBanned: true })]
+      ])
+      const serialized = serializeSelections(map)
+      expect(serialized).toHaveLength(2)
+      expect(serialized.map(s => s.effectId).sort()).toEqual(['banned', 'target'])
+
+      const deserialized = deserializeSelections(serialized)
+      expect(deserialized.size).toBe(2)
+      expect(deserialized.get('target')?.minRarity).toBe('epic')
+    })
+
+    it('handles empty inputs', () => {
+      expect(serializeSelections(new Map())).toEqual([])
+      expect(deserializeSelections([]).size).toBe(0)
+    })
+  })
+
+  describe('roundtrip persistence', () => {
+    it('preserves complex state and multiple module types', () => {
+      const cannon = createFlatState({ moduleType: 'cannon', moduleLevel: 100, selections: [createSelection('c1', { isBanned: true })] })
+      const generator = createFlatState({ moduleType: 'generator', moduleLevel: 150, moduleRarity: 'legendary', confidenceLevel: 'high',
+        selections: [createSelection('g1', { isLocked: true, lockedRarity: 'epic' })] })
+
+      saveModuleCalcState(cannon)
+      saveModuleCalcState(generator)
+
+      const loadedCannon = loadModuleCalcState('cannon')
+      const loadedGenerator = loadModuleCalcState('generator')
+
+      expect(loadedCannon.moduleLevel).toBe(100)
+      expect(loadedCannon.selections[0].effectId).toBe('c1')
+      expect(loadedGenerator.moduleLevel).toBe(150)
+      expect(loadedGenerator.moduleRarity).toBe('legendary')
+      expect(loadedGenerator.confidenceLevel).toBe('high')
+      expect(loadedGenerator.selections[0].effectId).toBe('g1')
+    })
+
+    it.each([
+      ['module types', ['cannon', 'armor', 'generator', 'core']],
+      ['rarities', ['rare', 'epic', 'legendary', 'ancestral']],
+      ['confidence', ['low', 'medium', 'high']]
+    ] as const)('preserves all %s', (_, values) => {
+      for (const v of values) {
+        const key = _ === 'module types' ? 'moduleType' : _ === 'rarities' ? 'moduleRarity' : 'confidenceLevel'
+        const state = createFlatState({ [key]: v })
+        saveModuleCalcState(state)
+        expect(loadModuleCalcState(state.moduleType)[key]).toBe(v)
+      }
+    })
+  })
+})

--- a/src/features/tools/module-calculator/persistence/module-calc-persistence.ts
+++ b/src/features/tools/module-calculator/persistence/module-calc-persistence.ts
@@ -1,0 +1,358 @@
+/**
+ * Module Calculator Persistence
+ *
+ * Handles localStorage persistence for module calculator selections,
+ * storing state separately for each module type (cannon, armor, generator, core).
+ */
+
+import type { ModuleType, Rarity } from '@/shared/domain/module-data'
+import type { EffectSelection, ConfidenceLevel } from '../types'
+import { DEFAULT_CONFIDENCE_LEVEL } from '../results/confidence-level-logic'
+import { ROLLABLE_MODULE_RARITIES } from '../configuration/module-config-logic'
+
+const STORAGE_KEY = 'tower-tracking-module-calc-state'
+
+/**
+ * Serializable format for effect selections (Map doesn't serialize to JSON)
+ */
+interface SerializedEffectSelection {
+  effectId: string
+  minRarity: Rarity | null
+  targetSlots: number[]
+  isBanned: boolean
+  isLocked: boolean
+  lockedRarity: Rarity | null
+}
+
+/**
+ * State stored for a single module type
+ */
+export interface ModuleTypeState {
+  moduleLevel: number
+  moduleRarity: Rarity
+  selections: SerializedEffectSelection[]
+  confidenceLevel: ConfidenceLevel
+}
+
+/**
+ * Root state persisted to localStorage - stores state per module type
+ */
+export interface StoredModuleCalcState {
+  /** Which module type is currently active */
+  activeModuleType: ModuleType
+  /** State for each module type (keyed by module type) */
+  modules: Partial<Record<ModuleType, ModuleTypeState>>
+  lastUpdated: number
+}
+
+/**
+ * Flattened state for a specific module type (used by hooks)
+ */
+export interface FlatModuleCalcState {
+  moduleType: ModuleType
+  moduleLevel: number
+  moduleRarity: Rarity
+  selections: SerializedEffectSelection[]
+  confidenceLevel: ConfidenceLevel
+  lastUpdated: number
+}
+
+/**
+ * Default state for a single module type
+ */
+function getDefaultModuleTypeState(): ModuleTypeState {
+  return {
+    moduleLevel: 141,
+    moduleRarity: 'ancestral',
+    selections: [],
+    confidenceLevel: DEFAULT_CONFIDENCE_LEVEL
+  }
+}
+
+/**
+ * Default root state when nothing is stored or validation fails
+ */
+export function getDefaultStoredState(): StoredModuleCalcState {
+  return {
+    activeModuleType: 'cannon',
+    modules: {},
+    lastUpdated: Date.now()
+  }
+}
+
+/**
+ * Get default flattened state for a specific module type
+ */
+export function getDefaultFlatState(moduleType: ModuleType = 'cannon'): FlatModuleCalcState {
+  const typeState = getDefaultModuleTypeState()
+  return {
+    moduleType,
+    moduleLevel: typeState.moduleLevel,
+    moduleRarity: typeState.moduleRarity,
+    selections: typeState.selections,
+    confidenceLevel: typeState.confidenceLevel,
+    lastUpdated: Date.now()
+  }
+}
+
+/**
+ * Valid module types for validation
+ */
+const VALID_MODULE_TYPES: ModuleType[] = ['cannon', 'armor', 'generator', 'core']
+
+/**
+ * Valid rarities for validation
+ */
+const VALID_RARITIES: Rarity[] = ['common', 'rare', 'epic', 'legendary', 'mythic', 'ancestral']
+
+/**
+ * Valid confidence levels for validation
+ */
+const VALID_CONFIDENCE_LEVELS: ConfidenceLevel[] = ['low', 'medium', 'high']
+
+/**
+ * Type guard for module type
+ */
+function isValidModuleType(value: unknown): value is ModuleType {
+  return typeof value === 'string' && VALID_MODULE_TYPES.includes(value as ModuleType)
+}
+
+/**
+ * Type guard for rarity
+ */
+function isValidRarity(value: unknown): value is Rarity {
+  return typeof value === 'string' && VALID_RARITIES.includes(value as Rarity)
+}
+
+/**
+ * Type guard for rollable rarity (excludes common/uncommon)
+ */
+function isValidRollableRarity(value: unknown): value is Rarity {
+  return isValidRarity(value) && ROLLABLE_MODULE_RARITIES.includes(value as Rarity)
+}
+
+/**
+ * Type guard for confidence level
+ */
+function isValidConfidenceLevel(value: unknown): value is ConfidenceLevel {
+  return typeof value === 'string' && VALID_CONFIDENCE_LEVELS.includes(value as ConfidenceLevel)
+}
+
+/**
+ * Validate optional rarity field (allows null)
+ */
+function isValidOptionalRarity(value: unknown): boolean {
+  return value === null || isValidRarity(value)
+}
+
+/**
+ * Validate target slots array
+ */
+function isValidTargetSlots(value: unknown): boolean {
+  return Array.isArray(value) && value.every((s) => typeof s === 'number')
+}
+
+/**
+ * Type guard for effect selection
+ */
+function isValidEffectSelection(value: unknown): value is SerializedEffectSelection {
+  if (!value || typeof value !== 'object') return false
+
+  const sel = value as Record<string, unknown>
+  return (
+    typeof sel.effectId === 'string' &&
+    isValidOptionalRarity(sel.minRarity) &&
+    isValidTargetSlots(sel.targetSlots) &&
+    typeof sel.isBanned === 'boolean' &&
+    typeof sel.isLocked === 'boolean' &&
+    isValidOptionalRarity(sel.lockedRarity)
+  )
+}
+
+/**
+ * Validate module level is within valid range
+ */
+function isValidModuleLevel(value: unknown): value is number {
+  return typeof value === 'number' && value >= 1 && value <= 200
+}
+
+/**
+ * Validate a single module type's state
+ */
+function validateModuleTypeState(data: unknown): ModuleTypeState {
+  const defaults = getDefaultModuleTypeState()
+
+  if (!data || typeof data !== 'object') {
+    return defaults
+  }
+
+  const stored = data as Record<string, unknown>
+
+  return {
+    moduleLevel: isValidModuleLevel(stored.moduleLevel) ? stored.moduleLevel : defaults.moduleLevel,
+    moduleRarity: isValidRollableRarity(stored.moduleRarity)
+      ? stored.moduleRarity
+      : defaults.moduleRarity,
+    selections: Array.isArray(stored.selections)
+      ? stored.selections.filter(isValidEffectSelection)
+      : defaults.selections,
+    confidenceLevel: isValidConfidenceLevel(stored.confidenceLevel)
+      ? stored.confidenceLevel
+      : defaults.confidenceLevel
+  }
+}
+
+/**
+ * Validate the modules object (state per module type)
+ */
+function validateModulesObject(data: unknown): Partial<Record<ModuleType, ModuleTypeState>> {
+  if (!data || typeof data !== 'object') {
+    return {}
+  }
+
+  const result: Partial<Record<ModuleType, ModuleTypeState>> = {}
+  const stored = data as Record<string, unknown>
+
+  for (const moduleType of VALID_MODULE_TYPES) {
+    if (moduleType in stored) {
+      result[moduleType] = validateModuleTypeState(stored[moduleType])
+    }
+  }
+
+  return result
+}
+
+/**
+ * Validate stored state and return defaults for invalid fields
+ */
+function validateStoredState(data: unknown): StoredModuleCalcState {
+  const defaults = getDefaultStoredState()
+
+  if (!data || typeof data !== 'object') {
+    return defaults
+  }
+
+  const stored = data as Record<string, unknown>
+
+  return {
+    activeModuleType: isValidModuleType(stored.activeModuleType)
+      ? stored.activeModuleType
+      : defaults.activeModuleType,
+    modules: validateModulesObject(stored.modules),
+    lastUpdated: typeof stored.lastUpdated === 'number' ? stored.lastUpdated : Date.now()
+  }
+}
+
+/**
+ * Load the full module calculator state from localStorage
+ * Returns default state if none exists or if parsing/validation fails
+ */
+export function loadModuleCalcStateRaw(): StoredModuleCalcState {
+  if (typeof window === 'undefined') {
+    return getDefaultStoredState()
+  }
+
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (!stored) {
+      return getDefaultStoredState()
+    }
+
+    const parsed = JSON.parse(stored)
+    return validateStoredState(parsed)
+  } catch (error) {
+    console.warn('Failed to load module calculator state from localStorage:', error)
+    return getDefaultStoredState()
+  }
+}
+
+/**
+ * Load state for a specific module type (flattened format for hooks)
+ * Falls back to defaults if no state exists for that module type
+ */
+export function loadModuleCalcState(moduleType?: ModuleType): FlatModuleCalcState {
+  const rootState = loadModuleCalcStateRaw()
+  const targetType = moduleType ?? rootState.activeModuleType
+  const typeState = rootState.modules[targetType] ?? getDefaultModuleTypeState()
+
+  return {
+    moduleType: targetType,
+    moduleLevel: typeState.moduleLevel,
+    moduleRarity: typeState.moduleRarity,
+    selections: typeState.selections,
+    confidenceLevel: typeState.confidenceLevel,
+    lastUpdated: rootState.lastUpdated
+  }
+}
+
+/**
+ * Save state for a specific module type to localStorage
+ * Preserves state for other module types
+ */
+export function saveModuleCalcState(state: FlatModuleCalcState): void {
+  if (typeof window === 'undefined') return
+
+  try {
+    // Load existing state to preserve other module types
+    const existingState = loadModuleCalcStateRaw()
+
+    // Update the state for this specific module type
+    const updatedModules: Partial<Record<ModuleType, ModuleTypeState>> = {
+      ...existingState.modules,
+      [state.moduleType]: {
+        moduleLevel: state.moduleLevel,
+        moduleRarity: state.moduleRarity,
+        selections: state.selections,
+        confidenceLevel: state.confidenceLevel
+      }
+    }
+
+    const updated: StoredModuleCalcState = {
+      activeModuleType: state.moduleType,
+      modules: updatedModules,
+      lastUpdated: Date.now()
+    }
+
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(updated))
+  } catch (error) {
+    console.error('Failed to save module calculator state to localStorage:', error)
+  }
+}
+
+/**
+ * Convert selections Map to serializable array
+ */
+export function serializeSelections(selections: Map<string, EffectSelection>): SerializedEffectSelection[] {
+  return Array.from(selections.values()).filter(
+    // Only persist selections that have meaningful data
+    (sel) =>
+      sel.minRarity !== null ||
+      sel.targetSlots.length > 0 ||
+      sel.isBanned ||
+      sel.isLocked
+  )
+}
+
+/**
+ * Convert serialized selections array back to Map
+ */
+export function deserializeSelections(serialized: SerializedEffectSelection[]): Map<string, EffectSelection> {
+  const map = new Map<string, EffectSelection>()
+  for (const sel of serialized) {
+    map.set(sel.effectId, sel)
+  }
+  return map
+}
+
+/**
+ * Clear module calculator state from localStorage
+ */
+export function clearModuleCalcState(): void {
+  if (typeof window === 'undefined') return
+
+  try {
+    localStorage.removeItem(STORAGE_KEY)
+  } catch (error) {
+    console.error('Failed to clear module calculator state from localStorage:', error)
+  }
+}

--- a/src/features/tools/module-calculator/persistence/use-module-calc-persistence.ts
+++ b/src/features/tools/module-calculator/persistence/use-module-calc-persistence.ts
@@ -1,0 +1,117 @@
+/**
+ * Module Calculator Persistence Hook
+ *
+ * Handles loading initial state from localStorage and saving state changes
+ * with debouncing to avoid blocking UI during rapid updates.
+ */
+
+import { useEffect, useRef } from 'react';
+import type { ModuleType, Rarity } from '@/shared/domain/module-data';
+import type { EffectSelection, ConfidenceLevel } from '../types';
+import type { InitialModuleConfigValues } from '../configuration/use-module-config';
+import {
+  loadModuleCalcState,
+  saveModuleCalcState,
+  serializeSelections,
+  deserializeSelections,
+  type FlatModuleCalcState,
+} from './module-calc-persistence';
+
+/** Debounce delay for localStorage saves (matches pattern from use-data.ts) */
+const PERSISTENCE_DEBOUNCE_MS = 300;
+
+/**
+ * Initial state loaded from localStorage
+ */
+interface PersistedModuleCalcState {
+  configValues: InitialModuleConfigValues;
+  selections: Map<string, EffectSelection>;
+  confidenceLevel: ConfidenceLevel;
+}
+
+/**
+ * Current state to persist
+ */
+interface CurrentModuleCalcState {
+  moduleType: ModuleType;
+  moduleLevel: number;
+  moduleRarity: Rarity;
+  selections: Map<string, EffectSelection>;
+  confidenceLevel: ConfidenceLevel;
+}
+
+/**
+ * Load persisted state and prepare initial values for hooks
+ */
+export function loadPersistedState(): PersistedModuleCalcState {
+  const stored = loadModuleCalcState();
+  return {
+    configValues: {
+      moduleType: stored.moduleType,
+      moduleLevel: stored.moduleLevel,
+      moduleRarity: stored.moduleRarity,
+    },
+    selections: deserializeSelections(stored.selections),
+    confidenceLevel: stored.confidenceLevel,
+  };
+}
+
+/**
+ * Hook for persisting module calculator state to localStorage
+ *
+ * Saves state changes with debouncing to avoid blocking UI during rapid updates.
+ * Skips the first save to avoid overwriting the initially loaded state.
+ *
+ * NOTE: Initial state loading should be done with `loadPersistedState()` before
+ * calling this hook, so that sub-hooks can be initialized with persisted values.
+ */
+export function useModuleCalcPersistenceSave(
+  currentState: CurrentModuleCalcState
+): void {
+  // Track if we've initialized to avoid saving on first render
+  const isInitialized = useRef(false);
+
+  // Ref for debouncing localStorage saves
+  const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Persist state to localStorage whenever relevant values change (debounced)
+  useEffect(() => {
+    // Skip the first render to avoid overwriting persisted state
+    if (!isInitialized.current) {
+      isInitialized.current = true;
+      return;
+    }
+
+    // Clear any pending save to implement debouncing
+    if (saveTimeoutRef.current) {
+      clearTimeout(saveTimeoutRef.current);
+    }
+
+    // Debounce the save operation to avoid blocking UI during rapid changes
+    saveTimeoutRef.current = setTimeout(() => {
+      const stateToSave: FlatModuleCalcState = {
+        moduleType: currentState.moduleType,
+        moduleLevel: currentState.moduleLevel,
+        moduleRarity: currentState.moduleRarity,
+        selections: serializeSelections(currentState.selections),
+        confidenceLevel: currentState.confidenceLevel,
+        lastUpdated: Date.now(),
+      };
+
+      saveModuleCalcState(stateToSave);
+    }, PERSISTENCE_DEBOUNCE_MS);
+
+    // Cleanup timeout on unmount or dependency change
+    return () => {
+      if (saveTimeoutRef.current) {
+        clearTimeout(saveTimeoutRef.current);
+      }
+    };
+  }, [
+    currentState.moduleType,
+    currentState.moduleLevel,
+    currentState.moduleRarity,
+    currentState.selections,
+    currentState.confidenceLevel,
+  ]);
+}

--- a/src/features/tools/module-calculator/results/use-simulation-results.ts
+++ b/src/features/tools/module-calculator/results/use-simulation-results.ts
@@ -65,7 +65,9 @@ function buildSimulationSetup(config: CalculatorConfig, confidenceLevel: Confide
   return { simConfig, estimatedMs, run, cancel };
 }
 
-export function useSimulationResults(): UseSimulationResultsReturn {
+export function useSimulationResults(
+  initialConfidenceLevel?: ConfidenceLevel
+): UseSimulationResultsReturn {
   const [results, setResults] = useState<SimulationResults | null>(null);
   const [isRunning, setIsRunning] = useState(false);
   const [progress, setProgress] = useState(0);
@@ -73,7 +75,9 @@ export function useSimulationResults(): UseSimulationResultsReturn {
   const [estimatedTime, setEstimatedTime] = useState<number | null>(null);
   const [elapsedTimeMs, setElapsedTimeMs] = useState<number | null>(null);
   const [cancelFn, setCancelFn] = useState<(() => void) | null>(null);
-  const [confidenceLevel, setConfidenceLevel] = useState<ConfidenceLevel>(DEFAULT_CONFIDENCE_LEVEL);
+  const [confidenceLevel, setConfidenceLevel] = useState<ConfidenceLevel>(
+    initialConfidenceLevel ?? DEFAULT_CONFIDENCE_LEVEL
+  );
 
   const resetForNewRun = useCallback(() => {
     setError(null);

--- a/src/features/tools/module-calculator/sub-effect-table/sub-effect-table.tsx
+++ b/src/features/tools/module-calculator/sub-effect-table/sub-effect-table.tsx
@@ -12,10 +12,10 @@ import { SlotHeader } from './slot-selector';
 import type { UseSubEffectTableResult } from './use-sub-effect-table';
 
 /**
- * Props for SubEffectTable - excludes programmatic lock/unlock functions
- * which are for internal bidirectional sync with manual mode.
+ * Props for SubEffectTable - excludes internal functions used for
+ * bidirectional sync with manual mode and persistence loading.
  */
-interface SubEffectTableProps extends Omit<UseSubEffectTableResult, 'programmaticLock' | 'programmaticUnlock'> {
+interface SubEffectTableProps extends Omit<UseSubEffectTableResult, 'programmaticLock' | 'programmaticUnlock' | 'setSelections'> {
   moduleRarity: Rarity;
   availableSlots: number[];
 }

--- a/src/features/tools/module-calculator/sub-effect-table/use-sub-effect-table.ts
+++ b/src/features/tools/module-calculator/sub-effect-table/use-sub-effect-table.ts
@@ -5,7 +5,7 @@
  * Manages the selection state for the sub-effect table.
  */
 
-import { useState, useCallback, useMemo } from 'react';
+import React, { useState, useCallback, useMemo } from 'react';
 import type { ModuleType, Rarity, SubEffectConfig } from '@/shared/domain/module-data';
 import { getSubEffectsForModule, filterByModuleRarity } from '@/shared/domain/module-data';
 import type { EffectSelection, SlotTarget, PreLockedEffect } from '../types';
@@ -44,6 +44,8 @@ export interface UseSubEffectTableResult {
   programmaticLock: (effectId: string, rarity: Rarity) => void;
   /** Unlock an effect programmatically (for bidirectional sync with manual mode) */
   programmaticUnlock: (effectId: string) => void;
+  /** Set selections directly (for loading from persistence) */
+  setSelections: React.Dispatch<React.SetStateAction<Map<string, EffectSelection>>>;
 }
 
 /**
@@ -81,9 +83,12 @@ function useDerivedSelectionValues(selectionsArray: EffectSelection[], slotCount
 export function useSubEffectTable(
   moduleType: ModuleType,
   moduleRarity: Rarity,
-  slotCount: number
+  slotCount: number,
+  initialSelections?: Map<string, EffectSelection>
 ): UseSubEffectTableResult {
-  const [selections, setSelections] = useState<Map<string, EffectSelection>>(() => new Map());
+  const [selections, setSelections] = useState<Map<string, EffectSelection>>(
+    () => initialSelections ?? new Map()
+  );
 
   const effects = useMemo(() => getSubEffectsForModule(moduleType), [moduleType]);
   const availableEffects = useMemo(() => filterByModuleRarity(effects, moduleRarity), [effects, moduleRarity]);
@@ -193,5 +198,7 @@ export function useSubEffectTable(
     clearAllSelections,
     programmaticLock,
     programmaticUnlock,
+    /** Set selections directly (for loading from persistence) */
+    setSelections,
   };
 }


### PR DESCRIPTION
## Summary
Module calculator settings now persist across browser sessions. Users no longer lose their module configuration, sub-effect selections, and confidence level when navigating away or closing the calculator. State is restored automatically on page load.

## Technical Details
- Created `persistence/` directory with pure logic layer and React hook
- Added `module-calc-persistence.ts` with load/save/serialize functions and comprehensive validation
- Added `use-module-calc-persistence.ts` hook with debounced saves (300ms) to avoid UI blocking
- Modified `use-module-config`, `use-sub-effect-table`, and `use-simulation-results` to accept initial values
- Added ref tracking in `use-module-calculator` to prevent clearing selections on initial load with persisted state
- Comprehensive unit tests covering validation, roundtrip persistence, and error handling

## Context
The module calculator has 80+ configurable sub-effect selections. Users need these settings preserved when switching between pages or across browser sessions.