### PR TITLE
BUG: Fix auto-roll stopping on wrong priority targets

### DIFF
--- a/src/features/tools/module-calculator/manual-mode/types.ts
+++ b/src/features/tools/module-calculator/manual-mode/types.ts
@@ -45,6 +45,13 @@ export interface ManualModeState {
   /** Current roll pool (effects remaining after locks) */
   pool: PreparedPool;
 
+  /**
+   * Remaining targets that haven't been fulfilled yet.
+   * Updated when effects are locked - locked effects are removed from
+   * each target's acceptableEffects array, matching Monte Carlo behavior.
+   */
+  remainingTargets: SlotTarget[];
+
   /** Number of rolls performed */
   rollCount: number;
 
@@ -79,6 +86,13 @@ export interface RollResult {
 
   /** Whether any slot hit a target */
   hasTargetHit: boolean;
+
+  /**
+   * Whether any slot hit a target in the CURRENT priority group.
+   * This is what should stop auto-rolling - we only stop when we hit
+   * a target we're currently rolling for, not a future priority target.
+   */
+  hasCurrentPriorityHit: boolean;
 
   /** Indexes of slots that were filled */
   filledSlotIndexes: number[];

--- a/src/features/tools/module-calculator/manual-mode/use-manual-mode.ts
+++ b/src/features/tools/module-calculator/manual-mode/use-manual-mode.ts
@@ -212,8 +212,9 @@ export function useManualMode(
 
     setState(stateWithLog);
 
-    // If auto-rolling and we hit a target, stop
-    if (state.isAutoRolling && result.hasTargetHit) {
+    // If auto-rolling and we hit a CURRENT PRIORITY target, stop
+    // (Only stop for targets we're actively rolling for, not future priority targets)
+    if (state.isAutoRolling && result.hasCurrentPriorityHit) {
       stopAutoRollInternal();
     }
   }, [state, modeConfig, config.slotTargets, stopAutoRollInternal, logEnabled, minimumLogRarity]);
@@ -305,8 +306,9 @@ export function useManualMode(
         });
         const stateWithLog = { ...newState, logEntries: updatedLogEntries };
 
-        // Stop on target hit (let user decide to lock)
-        if (result.hasTargetHit) {
+        // Stop on CURRENT PRIORITY target hit (let user decide to lock)
+        // Only stop for targets in the current priority group, not future priorities
+        if (result.hasCurrentPriorityHit) {
           if (autoRollIntervalRef.current) {
             clearInterval(autoRollIntervalRef.current);
             autoRollIntervalRef.current = null;

--- a/src/features/tools/module-calculator/simulation/simulation-engine.test.ts
+++ b/src/features/tools/module-calculator/simulation/simulation-engine.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect } from 'vitest';
+import type { SlotTarget } from '../types';
+import { buildInitialPool, preparePool } from './pool-dynamics';
+import {
+  rollRound,
+  rollUntilPriorityHit,
+  lockEffect,
+  isSimulationComplete,
+  buildMinRarityMap,
+} from './simulation-engine';
+
+describe('simulation-engine', () => {
+  const createTestPool = () => {
+    const pool = buildInitialPool('cannon', 'ancestral', []);
+    return preparePool(pool);
+  };
+
+  describe('rollRound', () => {
+    it('returns results for each slot', () => {
+      const pool = createTestPool();
+      const targets: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['attackSpeed'], minRarity: 'common' },
+      ];
+      const minRarityMap = buildMinRarityMap(targets);
+
+      const result = rollRound(pool, 4, targets, minRarityMap);
+
+      expect(result.slotResults).toHaveLength(4);
+      result.slotResults.forEach((sr) => {
+        expect(sr.entry).toBeDefined();
+        expect(sr.entry.effect).toBeDefined();
+        expect(sr.entry.rarity).toBeDefined();
+      });
+    });
+
+    it('returns empty results for empty pool', () => {
+      const emptyPool = { entries: [], cumulativeProbs: [] };
+      const targets: SlotTarget[] = [];
+      const minRarityMap = new Map();
+
+      const result = rollRound(emptyPool, 4, targets, minRarityMap);
+
+      expect(result.slotResults).toHaveLength(0);
+      expect(result.hasTargetHit).toBe(false);
+      expect(result.hasCurrentPriorityHit).toBe(false);
+    });
+
+    it('returns empty results for zero slots', () => {
+      const pool = createTestPool();
+      const targets: SlotTarget[] = [];
+      const minRarityMap = new Map();
+
+      const result = rollRound(pool, 0, targets, minRarityMap);
+
+      expect(result.slotResults).toHaveLength(0);
+    });
+
+    it('correctly identifies target matches', () => {
+      const pool = createTestPool();
+      const targets: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['attackSpeed'], minRarity: 'common' },
+      ];
+      const minRarityMap = buildMinRarityMap(targets);
+
+      // Roll many times to eventually hit a target
+      let hitFound = false;
+      for (let i = 0; i < 100 && !hitFound; i++) {
+        const result = rollRound(pool, 4, targets, minRarityMap);
+        if (result.hasTargetHit) {
+          hitFound = true;
+          expect(result.slotResults.some((sr) => sr.isTargetMatch)).toBe(true);
+        }
+      }
+
+      expect(hitFound).toBe(true);
+    });
+
+    it('distinguishes current priority from future priority targets', () => {
+      const pool = createTestPool();
+      // Two different priorities
+      const targets: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['attackSpeed'], minRarity: 'common' },
+        { slotNumber: 2, acceptableEffects: ['critFactor'], minRarity: 'common' },
+      ];
+      const minRarityMap = buildMinRarityMap(targets);
+
+      // Roll until we get a hit
+      let currentPriorityHit = false;
+      for (let i = 0; i < 100 && !currentPriorityHit; i++) {
+        const result = rollRound(pool, 4, targets, minRarityMap);
+        if (result.hasCurrentPriorityHit) {
+          currentPriorityHit = true;
+          expect(result.firstPriorityHit).not.toBeNull();
+          expect(result.firstPriorityHit?.target.slotNumber).toBe(1);
+        }
+      }
+
+      expect(currentPriorityHit).toBe(true);
+    });
+  });
+
+  describe('rollUntilPriorityHit', () => {
+    it('returns null for empty pool', () => {
+      const emptyPool = { entries: [], cumulativeProbs: [] };
+      const targets: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['attackSpeed'], minRarity: 'common' },
+      ];
+      const minRarityMap = buildMinRarityMap(targets);
+
+      const result = rollUntilPriorityHit({
+        pool: emptyPool,
+        openSlotCount: 4,
+        remainingTargets: targets,
+        minRarityMap,
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it('eventually hits a target', () => {
+      const pool = createTestPool();
+      const targets: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['attackSpeed'], minRarity: 'common' },
+      ];
+      const minRarityMap = buildMinRarityMap(targets);
+
+      const result = rollUntilPriorityHit({
+        pool,
+        openSlotCount: 4,
+        remainingTargets: targets,
+        minRarityMap,
+      });
+
+      expect(result).not.toBeNull();
+      expect(result!.entry.effect.id).toBe('attackSpeed');
+      expect(result!.rounds).toBeGreaterThan(0);
+    });
+
+    it('respects max rounds limit', () => {
+      const pool = createTestPool();
+      // Use a nonexistent effect to ensure we hit max rounds
+      const targets: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['nonexistent'], minRarity: 'common' },
+      ];
+      const minRarityMap = buildMinRarityMap(targets);
+
+      const result = rollUntilPriorityHit(
+        { pool, openSlotCount: 4, remainingTargets: targets, minRarityMap },
+        10
+      );
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('lockEffect', () => {
+    it('removes effect from pool', () => {
+      const pool = createTestPool();
+      const targets: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['attackSpeed', 'critChance'], minRarity: 'common' },
+      ];
+
+      const initialCount = pool.entries.filter((e) => e.effect.id === 'attackSpeed').length;
+      expect(initialCount).toBeGreaterThan(0);
+
+      const { newPool } = lockEffect(pool, targets, 'attackSpeed', 1);
+
+      const finalCount = newPool.entries.filter((e) => e.effect.id === 'attackSpeed').length;
+      expect(finalCount).toBe(0);
+    });
+
+    it('removes effect from remaining targets', () => {
+      const pool = createTestPool();
+      const targets: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['attackSpeed', 'critChance'], minRarity: 'common' },
+        { slotNumber: 2, acceptableEffects: ['attackSpeed', 'critChance'], minRarity: 'common' },
+      ];
+
+      const { newRemainingTargets } = lockEffect(pool, targets, 'attackSpeed', 1);
+
+      // Slot 1 should be removed (it was filled)
+      expect(newRemainingTargets.find((t) => t.slotNumber === 1)).toBeUndefined();
+
+      // Slot 2 should have attackSpeed removed from acceptable effects
+      const slot2 = newRemainingTargets.find((t) => t.slotNumber === 2);
+      expect(slot2?.acceptableEffects).not.toContain('attackSpeed');
+      expect(slot2?.acceptableEffects).toContain('critChance');
+    });
+
+    it('removes targets with empty acceptable effects', () => {
+      const pool = createTestPool();
+      const targets: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['attackSpeed'], minRarity: 'common' },
+        { slotNumber: 2, acceptableEffects: ['attackSpeed'], minRarity: 'common' },
+      ];
+
+      const { newRemainingTargets } = lockEffect(pool, targets, 'attackSpeed', 1);
+
+      // Both slots only accepted attackSpeed, so after locking:
+      // Slot 1 is removed (filled), Slot 2 has no more acceptable effects
+      expect(newRemainingTargets).toHaveLength(0);
+    });
+  });
+
+  describe('isSimulationComplete', () => {
+    it('returns true when no remaining targets', () => {
+      const pool = createTestPool();
+      expect(isSimulationComplete([], pool)).toBe(true);
+    });
+
+    it('returns true when pool is empty', () => {
+      const emptyPool = { entries: [], cumulativeProbs: [] };
+      const targets: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['attackSpeed'], minRarity: 'common' },
+      ];
+      expect(isSimulationComplete(targets, emptyPool)).toBe(true);
+    });
+
+    it('returns false when targets remain and pool has entries', () => {
+      const pool = createTestPool();
+      const targets: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['attackSpeed'], minRarity: 'common' },
+      ];
+      expect(isSimulationComplete(targets, pool)).toBe(false);
+    });
+  });
+
+  describe('integration: Monte Carlo and manual mode use same logic', () => {
+    it('rollRound produces consistent behavior across multiple calls', () => {
+      const pool = createTestPool();
+      const targets: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['attackSpeed'], minRarity: 'common' },
+      ];
+      const minRarityMap = buildMinRarityMap(targets);
+
+      // Both Monte Carlo and manual mode call this function
+      // Verify it works consistently
+      const results: boolean[] = [];
+      for (let i = 0; i < 50; i++) {
+        const result = rollRound(pool, 4, targets, minRarityMap);
+        results.push(result.hasTargetHit);
+      }
+
+      // Should have some hits and some misses (probabilistic but very likely over 50 rolls)
+      const hitCount = results.filter((r) => r).length;
+      expect(hitCount).toBeGreaterThan(0);
+      expect(hitCount).toBeLessThan(50);
+    });
+
+    it('lockEffect maintains correct state progression', () => {
+      let pool = createTestPool();
+      let targets: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['attackSpeed', 'critChance'], minRarity: 'common' },
+        { slotNumber: 2, acceptableEffects: ['attackSpeed', 'critChance'], minRarity: 'common' },
+        { slotNumber: 3, acceptableEffects: ['critFactor'], minRarity: 'common' },
+      ];
+
+      // Lock attackSpeed in slot 1
+      let result = lockEffect(pool, targets, 'attackSpeed', 1);
+      pool = result.newPool;
+      targets = result.newRemainingTargets;
+
+      // Slot 2 should now only have critChance
+      const slot2 = targets.find((t) => t.slotNumber === 2);
+      expect(slot2?.acceptableEffects).toEqual(['critChance']);
+
+      // Slot 3 should be unchanged
+      const slot3 = targets.find((t) => t.slotNumber === 3);
+      expect(slot3?.acceptableEffects).toEqual(['critFactor']);
+
+      // Lock critChance in slot 2
+      result = lockEffect(pool, targets, 'critChance', 2);
+      pool = result.newPool;
+      targets = result.newRemainingTargets;
+
+      // Only slot 3 should remain
+      expect(targets).toHaveLength(1);
+      expect(targets[0].slotNumber).toBe(3);
+
+      // Lock critFactor in slot 3
+      result = lockEffect(pool, targets, 'critFactor', 3);
+      targets = result.newRemainingTargets;
+
+      // All targets should be complete
+      expect(targets).toHaveLength(0);
+    });
+  });
+});

--- a/src/features/tools/module-calculator/simulation/simulation-engine.ts
+++ b/src/features/tools/module-calculator/simulation/simulation-engine.ts
@@ -1,0 +1,226 @@
+/**
+ * Simulation Engine
+ *
+ * SINGLE SOURCE OF TRUTH for all rolling logic.
+ * Both Monte Carlo simulation and manual practice mode use these primitives.
+ *
+ * This ensures identical behavior between:
+ * - Monte Carlo running 10,000+ simulations
+ * - Manual mode where user controls each step
+ */
+
+// Note: Using relative import for Web Worker compatibility
+import type { Rarity } from '../../../../shared/domain/module-data';
+import type { SlotTarget, PoolEntry } from '../types';
+import {
+  simulateRollFast,
+  checkTargetMatch,
+  removeEffectFromPreparedPool,
+  type PreparedPool,
+} from './pool-dynamics';
+import {
+  getCurrentPriorityTargets,
+  removeLockedEffectFromTargets,
+  buildMinRarityMap,
+} from './target-priority';
+
+// Re-export for consumers
+export {  removeLockedEffectFromTargets, buildMinRarityMap };
+
+/**
+ * Result of rolling a single slot
+ */
+interface SlotRollResult {
+  /** The effect that landed */
+  entry: PoolEntry;
+  /** Whether this entry matches any remaining target */
+  isTargetMatch: boolean;
+  /** The matched target, if any */
+  matchedTarget: SlotTarget | null;
+}
+
+/**
+ * Result of rolling all open slots in one round
+ */
+interface RollRoundResult {
+  /** Results for each slot rolled */
+  slotResults: SlotRollResult[];
+  /** Whether any slot hit any remaining target */
+  hasTargetHit: boolean;
+  /** Whether any slot hit a target in the CURRENT priority group */
+  hasCurrentPriorityHit: boolean;
+  /** The first current-priority target that was hit, if any */
+  firstPriorityHit: { entry: PoolEntry; target: SlotTarget } | null;
+}
+
+/**
+ * Context for rolling operations - bundles common parameters
+ */
+interface RollContext {
+  pool: PreparedPool;
+  openSlotCount: number;
+  remainingTargets: SlotTarget[];
+  minRarityMap: Map<string, Rarity>;
+}
+
+interface PriorityContext {
+  targets: SlotTarget[];
+  minRarityMap: Map<string, Rarity>;
+}
+
+interface RollAccumulator {
+  slotResults: SlotRollResult[];
+  hasTargetHit: boolean;
+  hasCurrentPriorityHit: boolean;
+  firstPriorityHit: { entry: PoolEntry; target: SlotTarget } | null;
+}
+
+interface SlotRollContext {
+  pool: PreparedPool;
+  remainingTargets: SlotTarget[];
+  minRarityMap: Map<string, Rarity>;
+  priorityContext: PriorityContext;
+}
+
+/**
+ * Process a single slot roll and update the accumulator
+ */
+function processSlotRoll(ctx: SlotRollContext, acc: RollAccumulator): void {
+  const entry = simulateRollFast(ctx.pool, Math.random());
+  const matchedTarget = checkTargetMatch(entry, ctx.remainingTargets, ctx.minRarityMap);
+  const isTargetMatch = matchedTarget !== null;
+
+  if (isTargetMatch) {
+    acc.hasTargetHit = true;
+    const priorityMatch = checkTargetMatch(
+      entry,
+      ctx.priorityContext.targets,
+      ctx.priorityContext.minRarityMap
+    );
+    if (priorityMatch && !acc.firstPriorityHit) {
+      acc.hasCurrentPriorityHit = true;
+      acc.firstPriorityHit = { entry, target: priorityMatch };
+    }
+  }
+
+  acc.slotResults.push({ entry, isTargetMatch, matchedTarget });
+}
+
+/**
+ * Roll all open slots once.
+ *
+ * This is the CORE rolling primitive used by both Monte Carlo and manual mode.
+ *
+ * @param pool - The current effect pool to roll from
+ * @param openSlotCount - Number of open slots to fill
+ * @param remainingTargets - Targets still being rolled for
+ * @param minRarityMap - Minimum rarity requirements per effect
+ * @returns Results for each slot and aggregate hit information
+ */
+export function rollRound(
+  pool: PreparedPool,
+  openSlotCount: number,
+  remainingTargets: SlotTarget[],
+  minRarityMap: Map<string, Rarity>
+): RollRoundResult {
+  const emptyResult: RollRoundResult = {
+    slotResults: [],
+    hasTargetHit: false,
+    hasCurrentPriorityHit: false,
+    firstPriorityHit: null,
+  };
+
+  if (pool.entries.length === 0 || openSlotCount === 0) {
+    return emptyResult;
+  }
+
+  const currentPriorityTargets = getCurrentPriorityTargets(remainingTargets);
+  const slotRollCtx: SlotRollContext = {
+    pool,
+    remainingTargets,
+    minRarityMap,
+    priorityContext: {
+      targets: currentPriorityTargets,
+      minRarityMap: buildMinRarityMap(currentPriorityTargets),
+    },
+  };
+
+  const acc: RollAccumulator = { ...emptyResult, slotResults: [] };
+
+  for (let i = 0; i < openSlotCount; i++) {
+    processSlotRoll(slotRollCtx, acc);
+  }
+
+  return acc;
+}
+
+/**
+ * Roll rounds until a current-priority target is hit.
+ *
+ * Used by Monte Carlo for bulk simulation. Each call simulates rolling
+ * until we hit something worth locking.
+ *
+ * @param context - Roll context containing pool, openSlotCount, remainingTargets, and minRarityMap
+ * @param maxRounds - Safety limit to prevent infinite loops
+ * @returns The hit result and number of rounds taken, or null if max reached
+ */
+export function rollUntilPriorityHit(
+  context: RollContext,
+  maxRounds: number = 1000000
+): { entry: PoolEntry; target: SlotTarget; rounds: number } | null {
+  const { pool, openSlotCount, remainingTargets, minRarityMap } = context;
+
+  for (let round = 1; round <= maxRounds; round++) {
+    const result = rollRound(pool, openSlotCount, remainingTargets, minRarityMap);
+
+    if (result.firstPriorityHit) {
+      return {
+        entry: result.firstPriorityHit.entry,
+        target: result.firstPriorityHit.target,
+        rounds: round,
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Lock an effect, updating pool and remaining targets.
+ *
+ * This is the CORE locking primitive used by both Monte Carlo and manual mode.
+ *
+ * @param pool - Current pool
+ * @param remainingTargets - Current remaining targets
+ * @param effectId - Effect to lock
+ * @param targetSlotNumber - The target slot that was filled (for target removal)
+ * @returns Updated pool and remaining targets
+ */
+export function lockEffect(
+  pool: PreparedPool,
+  remainingTargets: SlotTarget[],
+  effectId: string,
+  targetSlotNumber: number
+): { newPool: PreparedPool; newRemainingTargets: SlotTarget[] } {
+  // Remove ALL rarities of this effect from pool
+  const newPool = removeEffectFromPreparedPool(pool, effectId);
+
+  // Remove this effect from all remaining targets' acceptable effects
+  // Also remove the filled target slot
+  const newRemainingTargets = removeLockedEffectFromTargets(
+    remainingTargets.filter((t) => t.slotNumber !== targetSlotNumber),
+    effectId
+  );
+
+  return { newPool, newRemainingTargets };
+}
+
+/**
+ * Check if simulation is complete (all targets fulfilled or pool exhausted)
+ */
+export function isSimulationComplete(
+  remainingTargets: SlotTarget[],
+  pool: PreparedPool
+): boolean {
+  return remainingTargets.length === 0 || pool.entries.length === 0;
+}

--- a/src/features/tools/module-calculator/simulation/target-priority.test.ts
+++ b/src/features/tools/module-calculator/simulation/target-priority.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect } from 'vitest';
+import type { SlotTarget } from '../types';
+import {
+  getCurrentPriorityTargets,
+  removeLockedEffectFromTargets,
+  buildMinRarityMap,
+  isTargetInCurrentPriority,
+} from './target-priority';
+
+describe('target-priority', () => {
+  describe('getCurrentPriorityTargets', () => {
+    it('returns empty array for empty targets', () => {
+      expect(getCurrentPriorityTargets([])).toEqual([]);
+    });
+
+    it('returns single target when only one exists', () => {
+      const targets: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['attackSpeed'], minRarity: 'rare' },
+      ];
+
+      const result = getCurrentPriorityTargets(targets);
+      expect(result).toHaveLength(1);
+      expect(result[0].slotNumber).toBe(1);
+    });
+
+    it('returns only minimum slot number targets when effects differ', () => {
+      const targets: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['attackSpeed'], minRarity: 'rare' },
+        { slotNumber: 2, acceptableEffects: ['critChance'], minRarity: 'rare' },
+        { slotNumber: 3, acceptableEffects: ['critFactor'], minRarity: 'rare' },
+      ];
+
+      const result = getCurrentPriorityTargets(targets);
+
+      // Only slot 1 since it doesn't share effects with others
+      expect(result).toHaveLength(1);
+      expect(result[0].slotNumber).toBe(1);
+    });
+
+    it('returns all targets in same priority group (shared effects)', () => {
+      const targets: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['attackSpeed', 'critChance'], minRarity: 'rare' },
+        { slotNumber: 2, acceptableEffects: ['attackSpeed', 'critChance'], minRarity: 'rare' },
+        { slotNumber: 3, acceptableEffects: ['critFactor'], minRarity: 'rare' },
+      ];
+
+      const result = getCurrentPriorityTargets(targets);
+
+      // Slots 1 and 2 share effects, so they're in the same priority group
+      expect(result).toHaveLength(2);
+      expect(result.map((t) => t.slotNumber).sort()).toEqual([1, 2]);
+    });
+
+    it('correctly identifies priority after effect removal', () => {
+      // Simulate the state after one effect from a shared pool is locked
+      const targets: SlotTarget[] = [
+        // Slot 2 now only accepts critChance (attackSpeed was locked)
+        { slotNumber: 2, acceptableEffects: ['critChance'], minRarity: 'rare' },
+        { slotNumber: 3, acceptableEffects: ['critFactor'], minRarity: 'rare' },
+      ];
+
+      const result = getCurrentPriorityTargets(targets);
+
+      // Slot 2 is now the minimum, and it doesn't share effects with slot 3
+      expect(result).toHaveLength(1);
+      expect(result[0].slotNumber).toBe(2);
+    });
+
+    it('handles partial effect overlap', () => {
+      const targets: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['attackSpeed', 'critChance'], minRarity: 'rare' },
+        { slotNumber: 2, acceptableEffects: ['critChance', 'critFactor'], minRarity: 'rare' },
+        { slotNumber: 3, acceptableEffects: ['coinBonus'], minRarity: 'rare' },
+      ];
+
+      const result = getCurrentPriorityTargets(targets);
+
+      // Slots 1 and 2 share 'critChance', so they're in the same priority group
+      expect(result).toHaveLength(2);
+      expect(result.map((t) => t.slotNumber).sort()).toEqual([1, 2]);
+    });
+  });
+
+  describe('removeLockedEffectFromTargets', () => {
+    it('removes effect from all targets acceptable effects', () => {
+      const targets: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['attackSpeed', 'critChance'], minRarity: 'rare' },
+        { slotNumber: 2, acceptableEffects: ['attackSpeed', 'critChance'], minRarity: 'rare' },
+      ];
+
+      const result = removeLockedEffectFromTargets(targets, 'attackSpeed');
+
+      expect(result).toHaveLength(2);
+      expect(result[0].acceptableEffects).toEqual(['critChance']);
+      expect(result[1].acceptableEffects).toEqual(['critChance']);
+    });
+
+    it('filters out targets with empty acceptable effects', () => {
+      const targets: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['attackSpeed'], minRarity: 'rare' },
+        { slotNumber: 2, acceptableEffects: ['attackSpeed', 'critChance'], minRarity: 'rare' },
+      ];
+
+      const result = removeLockedEffectFromTargets(targets, 'attackSpeed');
+
+      // Slot 1 is removed because it only had attackSpeed
+      expect(result).toHaveLength(1);
+      expect(result[0].slotNumber).toBe(2);
+      expect(result[0].acceptableEffects).toEqual(['critChance']);
+    });
+
+    it('preserves targets that do not contain the removed effect', () => {
+      const targets: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['attackSpeed'], minRarity: 'rare' },
+        { slotNumber: 2, acceptableEffects: ['critChance'], minRarity: 'rare' },
+      ];
+
+      const result = removeLockedEffectFromTargets(targets, 'attackSpeed');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].slotNumber).toBe(2);
+      expect(result[0].acceptableEffects).toEqual(['critChance']);
+    });
+
+    it('returns empty array when all effects are removed', () => {
+      const targets: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['attackSpeed'], minRarity: 'rare' },
+      ];
+
+      const result = removeLockedEffectFromTargets(targets, 'attackSpeed');
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('buildMinRarityMap', () => {
+    it('returns empty map for empty targets', () => {
+      const result = buildMinRarityMap([]);
+      expect(result.size).toBe(0);
+    });
+
+    it('maps effect to its minimum rarity', () => {
+      const targets: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['attackSpeed'], minRarity: 'epic' },
+        { slotNumber: 2, acceptableEffects: ['critChance'], minRarity: 'legendary' },
+      ];
+
+      const result = buildMinRarityMap(targets);
+
+      expect(result.get('attackSpeed')).toBe('epic');
+      expect(result.get('critChance')).toBe('legendary');
+    });
+
+    it('uses lower rarity when effect appears in multiple targets', () => {
+      const targets: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['attackSpeed'], minRarity: 'legendary' },
+        { slotNumber: 2, acceptableEffects: ['attackSpeed'], minRarity: 'epic' },
+      ];
+
+      const result = buildMinRarityMap(targets);
+
+      // Should use 'epic' as it's the lower (more permissive) requirement
+      expect(result.get('attackSpeed')).toBe('epic');
+    });
+
+    it('handles multiple effects per target', () => {
+      const targets: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['attackSpeed', 'critChance'], minRarity: 'rare' },
+      ];
+
+      const result = buildMinRarityMap(targets);
+
+      expect(result.get('attackSpeed')).toBe('rare');
+      expect(result.get('critChance')).toBe('rare');
+    });
+  });
+
+  describe('isTargetInCurrentPriority', () => {
+    it('returns true for target in current priority group', () => {
+      const targets: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['attackSpeed'], minRarity: 'rare' },
+        { slotNumber: 2, acceptableEffects: ['critChance'], minRarity: 'rare' },
+      ];
+
+      const result = isTargetInCurrentPriority(targets[0], targets);
+      expect(result).toBe(true);
+    });
+
+    it('returns false for target not in current priority group', () => {
+      const targets: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['attackSpeed'], minRarity: 'rare' },
+        { slotNumber: 2, acceptableEffects: ['critChance'], minRarity: 'rare' },
+      ];
+
+      // Slot 2 is not in the current priority group (slot 1 is minimum)
+      const result = isTargetInCurrentPriority(targets[1], targets);
+      expect(result).toBe(false);
+    });
+
+    it('returns true for all targets in same priority group', () => {
+      const targets: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['attackSpeed', 'critChance'], minRarity: 'rare' },
+        { slotNumber: 2, acceptableEffects: ['attackSpeed', 'critChance'], minRarity: 'rare' },
+        { slotNumber: 3, acceptableEffects: ['critFactor'], minRarity: 'rare' },
+      ];
+
+      // Both slots 1 and 2 are in current priority group (they share effects)
+      expect(isTargetInCurrentPriority(targets[0], targets)).toBe(true);
+      expect(isTargetInCurrentPriority(targets[1], targets)).toBe(true);
+      expect(isTargetInCurrentPriority(targets[2], targets)).toBe(false);
+    });
+  });
+
+  describe('integration: priority progression simulation', () => {
+    it('correctly progresses through priority groups', () => {
+      // Simulate the progression of a manual/Monte Carlo session
+      let targets: SlotTarget[] = [
+        // Priority 1: slots 1 and 2 share attackSpeed and critChance
+        { slotNumber: 1, acceptableEffects: ['attackSpeed', 'critChance'], minRarity: 'rare' },
+        { slotNumber: 2, acceptableEffects: ['attackSpeed', 'critChance'], minRarity: 'rare' },
+        // Priority 2: slot 3 has a different effect
+        { slotNumber: 3, acceptableEffects: ['critFactor'], minRarity: 'rare' },
+      ];
+
+      // Step 1: Initial state - current priority should be slots 1 and 2
+      let currentPriority = getCurrentPriorityTargets(targets);
+      expect(currentPriority.map((t) => t.slotNumber).sort()).toEqual([1, 2]);
+
+      // Step 2: Lock attackSpeed in slot 1 - remove from remaining targets
+      targets = removeLockedEffectFromTargets(
+        targets.filter((t) => t.slotNumber !== 1), // Remove slot 1 (it's filled)
+        'attackSpeed' // Remove attackSpeed from remaining targets
+      );
+
+      // Now slot 2 should only accept critChance
+      expect(targets.find((t) => t.slotNumber === 2)?.acceptableEffects).toEqual(['critChance']);
+
+      // Current priority should now be slot 2 only (critChance doesn't overlap with slot 3)
+      currentPriority = getCurrentPriorityTargets(targets);
+      expect(currentPriority.map((t) => t.slotNumber)).toEqual([2]);
+
+      // Step 3: Lock critChance in slot 2
+      targets = removeLockedEffectFromTargets(
+        targets.filter((t) => t.slotNumber !== 2), // Remove slot 2 (it's filled)
+        'critChance'
+      );
+
+      // Now only slot 3 remains
+      expect(targets).toHaveLength(1);
+      expect(targets[0].slotNumber).toBe(3);
+
+      // Current priority should be slot 3
+      currentPriority = getCurrentPriorityTargets(targets);
+      expect(currentPriority.map((t) => t.slotNumber)).toEqual([3]);
+
+      // Step 4: Lock critFactor - all targets fulfilled
+      targets = removeLockedEffectFromTargets(
+        targets.filter((t) => t.slotNumber !== 3),
+        'critFactor'
+      );
+
+      expect(targets).toHaveLength(0);
+      expect(getCurrentPriorityTargets(targets)).toEqual([]);
+    });
+  });
+});

--- a/src/features/tools/module-calculator/simulation/target-priority.ts
+++ b/src/features/tools/module-calculator/simulation/target-priority.ts
@@ -1,0 +1,120 @@
+/**
+ * Target Priority Logic
+ *
+ * Shared priority-based target selection logic used by both Monte Carlo
+ * simulation and manual practice mode. This ensures both implementations
+ * use identical algorithms for determining which targets to roll for.
+ */
+
+// Note: Using relative import for Web Worker compatibility (path aliases don't resolve in worker bundles)
+import { RARITY_ORDER } from '../../../../shared/domain/module-data';
+import type { Rarity } from '../../../../shared/domain/module-data';
+import type { SlotTarget } from '../types';
+
+/**
+ * Get targets belonging to the current priority group.
+ *
+ * Priority groups are identified by slot number ranges created during target expansion.
+ * Same-priority effects share consecutive slot numbers and the same acceptable effects pool.
+ *
+ * This function returns all targets that share the minimum slot number's acceptable effects,
+ * which represents the current priority group we should be rolling for.
+ *
+ * Example:
+ * - Slots 1,2 accept [A,B] (priority group 1)
+ * - Slot 3 accepts [C] (priority group 2)
+ *
+ * When slot 1 is filled with A, remaining targets are:
+ * - Slot 2 accepts [B]
+ * - Slot 3 accepts [C]
+ *
+ * Now slot 2 is the minimum, and we only roll for [B] until it's filled,
+ * then move to slot 3 for [C].
+ */
+export function getCurrentPriorityTargets(targets: SlotTarget[]): SlotTarget[] {
+  if (targets.length === 0) return [];
+
+  const minSlotNumber = Math.min(...targets.map((t) => t.slotNumber));
+
+  // Find all targets that are part of the same priority group as the minimum slot.
+  // Same-priority targets have consecutive slot numbers AND share acceptable effects.
+  // After effects are removed from the pool, they may have fewer effects but still
+  // represent the same priority group.
+  const minSlotTarget = targets.find((t) => t.slotNumber === minSlotNumber)!;
+  const minSlotEffects = new Set(minSlotTarget.acceptableEffects);
+
+  // A target is in the same priority group if it has overlapping acceptable effects
+  // with the minimum slot target (they came from the same priority group originally)
+  return targets.filter((t) => {
+    // Always include the minimum slot
+    if (t.slotNumber === minSlotNumber) return true;
+
+    // Check if this target shares any acceptable effects with the min slot target
+    // (indicating they were originally in the same priority group)
+    return t.acceptableEffects.some((effect) => minSlotEffects.has(effect));
+  });
+}
+
+/**
+ * Remove a locked effect from all remaining targets' acceptable effects.
+ *
+ * When an effect is locked, it should no longer be considered for other slots.
+ * This is critical for same-priority groups where multiple slots initially share
+ * the same acceptable effects pool.
+ *
+ * Also removes any targets that now have empty acceptable effects (shouldn't happen
+ * with proper target construction, but included for safety).
+ */
+export function removeLockedEffectFromTargets(
+  targets: SlotTarget[],
+  lockedEffectId: string
+): SlotTarget[] {
+  return targets
+    .map((target) => ({
+      ...target,
+      acceptableEffects: target.acceptableEffects.filter((id) => id !== lockedEffectId),
+    }))
+    .filter((target) => target.acceptableEffects.length > 0);
+}
+
+/**
+ * Build a map of effect ID to minimum required rarity across all targets.
+ *
+ * When an effect appears in multiple targets with different min rarities,
+ * we use the lower (more permissive) minimum rarity.
+ */
+export function buildMinRarityMap(targets: SlotTarget[]): Map<string, Rarity> {
+  const map = new Map<string, Rarity>();
+
+  for (const target of targets) {
+    for (const effectId of target.acceptableEffects) {
+      const existing = map.get(effectId);
+      if (!existing) {
+        map.set(effectId, target.minRarity);
+      } else {
+        // Keep the lower minimum (more permissive)
+        const existingIndex = RARITY_ORDER.indexOf(existing);
+        const newIndex = RARITY_ORDER.indexOf(target.minRarity);
+        if (newIndex < existingIndex) {
+          map.set(effectId, target.minRarity);
+        }
+      }
+    }
+  }
+
+  return map;
+}
+
+/**
+ * Check if a target belongs to the current priority group.
+ *
+ * Used to determine if a hit should stop auto-rolling (only stop on
+ * current priority hits, not future priority hits).
+ */
+export function isTargetInCurrentPriority(
+  target: SlotTarget,
+  allRemainingTargets: SlotTarget[]
+): boolean {
+  const currentPriorityTargets = getCurrentPriorityTargets(allRemainingTargets);
+  return currentPriorityTargets.some((t) => t.slotNumber === target.slotNumber);
+}


### PR DESCRIPTION
## Summary
Fixed a bug where manual mode auto-roll would stop when hitting any target effect, even if that effect belonged to a future priority slot. Now auto-roll correctly stops only when hitting a target in the current priority group, matching expected user behavior.

This also consolidates all rolling logic into a single simulation engine, ensuring Monte Carlo simulation and manual practice mode behave identically.

## Technical Details
- Created `simulation-engine.ts` as the single source of truth for rolling/locking logic
- Created `target-priority.ts` for priority-based target selection algorithms
- Added `remainingTargets` field to `ManualModeState` to track unfulfilled targets
- Added `hasCurrentPriorityHit` flag to `RollResult` to distinguish priority groups
- Refactored `monte-carlo-simulation.ts` to use shared engine functions
- Refactored `manual-mode-logic.ts` to delegate rolling to the simulation engine
- Updated `use-manual-mode.ts` to stop auto-roll only on `hasCurrentPriorityHit`
- Added comprehensive tests for simulation engine and target priority logic

## Context
When users configure multi-slot targets with different priorities (e.g., attackSpeed for slot 1, critFactor for slot 2), auto-roll should only stop when hitting the current priority target. Previously it stopped on any target hit, causing premature interruptions.