### PR TITLE
Game Speed / Effective Multiplier

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -38,7 +38,9 @@
       "Skill(commit)",
       "Skill(commit:*)",
       "Bash(tree:*)",
-      "Bash(findstr:*)"
+      "Bash(findstr:*)",
+      "WebFetch(domain:github.com)",
+      "Bash(ls:*)"
     ],
     "defaultMode": "acceptEdits"
   },

--- a/src/features/analysis/activity-heatmap/activity-heatmap.tsx
+++ b/src/features/analysis/activity-heatmap/activity-heatmap.tsx
@@ -1,0 +1,163 @@
+/**
+ * Activity Heatmap Main Component
+ *
+ * Orchestrates the activity heatmap feature by wiring the orchestration hook
+ * to the presentation sub-components: week navigator, filters, grid, tooltip,
+ * and summary statistics.
+ *
+ * Thin presentation shell — all business logic lives in useActivityHeatmap.
+ */
+
+import { useActivityHeatmap, type UseActivityHeatmapReturn } from './use-activity-heatmap'
+import { WeekNavigator } from './navigation/week-navigator'
+import { HeatmapFilters } from './filters/heatmap-filters'
+import { HeatmapGridComponent } from './grid/heatmap-grid'
+import { CellTooltip } from './grid/cell-tooltip'
+import { HeatmapSummaryBar } from './heatmap-summary-bar'
+
+function EmptyState() {
+  return (
+    <div className="flex items-center justify-center min-h-[32rem] px-4 py-8">
+      <div className="max-w-lg text-center space-y-6">
+        <div className="flex justify-center">
+          <div className="w-24 h-24 rounded-full bg-gradient-to-br from-amber-500/20 to-orange-500/20 flex items-center justify-center border border-amber-500/30">
+            <svg
+              className="w-12 h-12 text-amber-400"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+              />
+            </svg>
+          </div>
+        </div>
+        <div className="space-y-2">
+          <h3 className="text-xl font-semibold text-slate-100">
+            No Data Available
+          </h3>
+          <p className="text-slate-400">
+            Import your game data to view your activity heatmap.
+            Head to the Data tab to get started.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function NoFilteredDataState() {
+  return (
+    <div className="flex items-center justify-center min-h-[20rem] px-4 py-8">
+      <div className="max-w-md text-center space-y-4">
+        <div className="flex justify-center">
+          <div className="w-16 h-16 rounded-full bg-slate-700/50 flex items-center justify-center border border-slate-600">
+            <svg
+              className="w-8 h-8 text-slate-400"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z"
+              />
+            </svg>
+          </div>
+        </div>
+        <div className="space-y-1">
+          <h3 className="text-lg font-medium text-slate-200">
+            No Activity This Week
+          </h3>
+          <p className="text-slate-400 text-sm">
+            No runs match the current filters for this week.
+            Try adjusting the tier or run type filters, or navigate to a different week.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function ActivityHeatmap() {
+  const heatmap = useActivityHeatmap()
+
+  if (!heatmap.hasRuns) {
+    return <EmptyState />
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Week Navigation */}
+      {heatmap.selectedWeek && (
+        <WeekNavigator
+          weekLabel={heatmap.selectedWeek.weekLabel}
+          canGoPrev={heatmap.canGoPrev}
+          canGoNext={heatmap.canGoNext}
+          onPrev={heatmap.onPrevWeek}
+          onNext={heatmap.onNextWeek}
+          onGoToLatest={heatmap.onGoToLatest}
+        />
+      )}
+
+      {/* Filters */}
+      <HeatmapFilters
+        selectedTier={heatmap.selectedTier}
+        onTierChange={heatmap.setSelectedTier}
+        availableTiers={heatmap.availableTiers}
+        selectedRunType={heatmap.selectedRunType}
+        onRunTypeChange={heatmap.setSelectedRunType}
+        activeHours={heatmap.activeHours}
+        onActiveHoursChange={heatmap.setActiveHours}
+      />
+
+      <HeatmapWeekContent heatmap={heatmap} />
+    </div>
+  )
+}
+
+function HeatmapWeekContent({ heatmap }: { heatmap: UseActivityHeatmapReturn }) {
+  const hasWeekActivity = heatmap.summary !== null && heatmap.summary.runCount > 0
+
+  if (!hasWeekActivity) {
+    return <NoFilteredDataState />
+  }
+
+  return (
+    <>
+      {/* Summary Statistics */}
+      {heatmap.summary && (
+        <HeatmapSummaryBar
+          summary={heatmap.summary}
+          activeHoursEnabled={heatmap.activeHours.enabled}
+          selectedRunType={heatmap.selectedRunType}
+        />
+      )}
+
+      {/* Heatmap Grid */}
+      {heatmap.grid && (
+        <HeatmapGridComponent
+          grid={heatmap.grid}
+          activeHours={heatmap.activeHours}
+          hoveredCell={heatmap.hoveredCell}
+          onCellHover={heatmap.setHoveredCell}
+          dailyCoverage={heatmap.summary?.dailyCoverage}
+        />
+      )}
+
+      {/* Cell Tooltip (fixed-positioned overlay) */}
+      {heatmap.hoveredCell && (
+        <CellTooltip
+          cell={heatmap.hoveredCell}
+          anchorRect={heatmap.tooltipAnchorRect}
+        />
+      )}
+    </>
+  )
+}

--- a/src/features/analysis/activity-heatmap/calculations/heatmap-grid-builder.test.ts
+++ b/src/features/analysis/activity-heatmap/calculations/heatmap-grid-builder.test.ts
@@ -1,0 +1,609 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { ParsedGameRun } from '@/shared/types/game-run.types'
+import type { RunTypeValue } from '@/shared/domain/run-types/types'
+import {
+  getRunTimeRange,
+  clipRunToWeek,
+  distributeRunToHours,
+  calculateCellCoverage,
+  buildHeatmapGrid,
+} from './heatmap-grid-builder'
+
+// ---------------------------------------------------------------------------
+// Mock formatWeekOfLabel to avoid locale store dependency in unit tests
+// ---------------------------------------------------------------------------
+vi.mock('@/shared/formatting/date-formatters', () => ({
+  formatWeekOfLabel: (date: Date) => {
+    const m = date.getMonth() + 1
+    const d = date.getDate()
+    return `Week of ${m}/${d}`
+  },
+}))
+
+// ---------------------------------------------------------------------------
+// Test helper
+// ---------------------------------------------------------------------------
+
+let nextId = 1
+
+/**
+ * Creates a minimal ParsedGameRun for testing the grid builder.
+ *
+ * @param overrides.endTime   - The run's end timestamp
+ * @param overrides.durationSeconds - Duration in seconds (used as realTime)
+ * @param overrides.runType   - Defaults to 'farm'
+ * @param overrides.tier      - Defaults to 11
+ * @param overrides.id        - Auto-generated if omitted
+ */
+function createTestRun(overrides: {
+  endTime: Date
+  durationSeconds: number
+  runType?: RunTypeValue
+  tier?: number
+  id?: string
+}): ParsedGameRun {
+  const id = overrides.id ?? `test-run-${nextId++}`
+  const tier = overrides.tier ?? 11
+  const runType = overrides.runType ?? 'farm'
+  const realTime = overrides.durationSeconds
+
+  return {
+    id,
+    timestamp: overrides.endTime,
+    fields: {},
+    tier,
+    wave: 100,
+    coinsEarned: 0,
+    cellsEarned: 0,
+    realTime,
+    runType,
+  } as ParsedGameRun
+}
+
+// ---------------------------------------------------------------------------
+// Shared week boundaries: Sun 2026-02-22 to Sat 2026-02-28
+// ---------------------------------------------------------------------------
+// 2026-02-22 is a Sunday
+const WEEK_START = new Date(2026, 1, 22, 0, 0, 0, 0) // Sun Feb 22
+const WEEK_END = new Date(2026, 1, 28, 23, 59, 59, 999) // Sat Feb 28
+
+/**
+ * Helper to create a local Date for the test week.
+ * dayOffset: 0=Sun, 1=Mon, 2=Tue, ... 6=Sat
+ */
+function weekDate(dayOffset: number, hour: number, minute = 0, second = 0): Date {
+  return new Date(2026, 1, 22 + dayOffset, hour, minute, second)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('heatmap-grid-builder', () => {
+  // -------------------------------------------------------------------------
+  // getRunTimeRange
+  // -------------------------------------------------------------------------
+  describe('getRunTimeRange', () => {
+    it('should derive start from timestamp minus realTime in seconds', () => {
+      const endTime = new Date(2026, 1, 23, 14, 0, 0) // Mon 14:00
+      const run = createTestRun({ endTime, durationSeconds: 3600 }) // 1 hour
+
+      const { start, end } = getRunTimeRange(run)
+
+      expect(end).toEqual(endTime)
+      expect(start).toEqual(new Date(2026, 1, 23, 13, 0, 0)) // Mon 13:00
+    })
+
+    it('should handle very short durations', () => {
+      const endTime = new Date(2026, 1, 23, 12, 0, 30) // 12:00:30
+      const run = createTestRun({ endTime, durationSeconds: 30 })
+
+      const { start } = getRunTimeRange(run)
+
+      expect(start).toEqual(new Date(2026, 1, 23, 12, 0, 0))
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // clipRunToWeek
+  // -------------------------------------------------------------------------
+  describe('clipRunToWeek', () => {
+    it('should return null for run entirely before the week', () => {
+      const runStart = new Date(2026, 1, 20, 10, 0, 0) // Friday before
+      const runEnd = new Date(2026, 1, 20, 12, 0, 0)
+
+      expect(clipRunToWeek(runStart, runEnd, WEEK_START, WEEK_END)).toBeNull()
+    })
+
+    it('should return null for run entirely after the week', () => {
+      const runStart = new Date(2026, 2, 1, 10, 0, 0) // Sunday after
+      const runEnd = new Date(2026, 2, 1, 12, 0, 0)
+
+      expect(clipRunToWeek(runStart, runEnd, WEEK_START, WEEK_END)).toBeNull()
+    })
+
+    it('should return null when run ends exactly at week start', () => {
+      // Run end equals weekStart boundary (no actual overlap)
+      const runStart = new Date(2026, 1, 21, 22, 0, 0) // Sat before
+      const runEnd = new Date(2026, 1, 22, 0, 0, 0, 0) // Exactly Sun 00:00:00.000
+
+      expect(clipRunToWeek(runStart, runEnd, WEEK_START, WEEK_END)).toBeNull()
+    })
+
+    it('should clip run starting before week to weekStart', () => {
+      const runStart = new Date(2026, 1, 21, 20, 0, 0) // Saturday before, 20:00
+      const runEnd = new Date(2026, 1, 22, 3, 0, 0) // Sun 03:00
+
+      const result = clipRunToWeek(runStart, runEnd, WEEK_START, WEEK_END)
+
+      expect(result).not.toBeNull()
+      expect(result!.clippedStart).toEqual(WEEK_START)
+      expect(result!.clippedEnd).toEqual(runEnd)
+    })
+
+    it('should clip run ending after week to weekEnd', () => {
+      const runStart = new Date(2026, 1, 28, 22, 0, 0) // Sat 22:00
+      const runEnd = new Date(2026, 2, 1, 3, 0, 0) // Sun after, 03:00
+
+      const result = clipRunToWeek(runStart, runEnd, WEEK_START, WEEK_END)
+
+      expect(result).not.toBeNull()
+      expect(result!.clippedStart).toEqual(runStart)
+      expect(result!.clippedEnd).toEqual(WEEK_END)
+    })
+
+    it('should return exact boundaries for run fully within week', () => {
+      const runStart = weekDate(3, 10, 0) // Wed 10:00
+      const runEnd = weekDate(3, 12, 0) // Wed 12:00
+
+      const result = clipRunToWeek(runStart, runEnd, WEEK_START, WEEK_END)
+
+      expect(result).not.toBeNull()
+      expect(result!.clippedStart).toEqual(runStart)
+      expect(result!.clippedEnd).toEqual(runEnd)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // distributeRunToHours
+  // -------------------------------------------------------------------------
+  describe('distributeRunToHours', () => {
+    it('should handle a run within a single hour', () => {
+      const start = weekDate(1, 14, 15) // Mon 14:15
+      const end = weekDate(1, 14, 45) // Mon 14:45
+
+      const entries = distributeRunToHours({ clippedStart: start, clippedEnd: end, runType: 'farm', tier: 11, runId: 'r1' })
+
+      expect(entries).toHaveLength(1)
+      expect(entries[0].dayIndex).toBe(1) // Monday
+      expect(entries[0].hour).toBe(14)
+      expect(entries[0].segment.startFraction).toBeCloseTo(0.25, 5)
+      expect(entries[0].segment.endFraction).toBeCloseTo(0.75, 5)
+      expect(entries[0].segment.runType).toBe('farm')
+      expect(entries[0].segment.tier).toBe(11)
+      expect(entries[0].segment.runId).toBe('r1')
+    })
+
+    it('should split a run spanning two hours', () => {
+      const start = weekDate(1, 10, 45) // Mon 10:45
+      const end = weekDate(1, 11, 15) // Mon 11:15
+
+      const entries = distributeRunToHours({ clippedStart: start, clippedEnd: end, runType: 'tournament', tier: 8, runId: 'r2' })
+
+      expect(entries).toHaveLength(2)
+
+      // Hour 10: 10:45 - 11:00
+      expect(entries[0].hour).toBe(10)
+      expect(entries[0].segment.startFraction).toBeCloseTo(0.75, 5)
+      expect(entries[0].segment.endFraction).toBeCloseTo(1.0, 5)
+
+      // Hour 11: 11:00 - 11:15
+      expect(entries[1].hour).toBe(11)
+      expect(entries[1].segment.startFraction).toBeCloseTo(0.0, 5)
+      expect(entries[1].segment.endFraction).toBeCloseTo(0.25, 5)
+    })
+
+    it('should handle a run spanning three hours', () => {
+      const start = weekDate(1, 14, 30) // Mon 14:30
+      const end = weekDate(1, 16, 15) // Mon 16:15
+
+      const entries = distributeRunToHours({ clippedStart: start, clippedEnd: end, runType: 'farm', tier: 11, runId: 'r3' })
+
+      expect(entries).toHaveLength(3)
+
+      // Hour 14: 14:30 - 15:00 → startFraction=0.5, endFraction=1.0
+      expect(entries[0].hour).toBe(14)
+      expect(entries[0].segment.startFraction).toBeCloseTo(0.5, 5)
+      expect(entries[0].segment.endFraction).toBeCloseTo(1.0, 5)
+
+      // Hour 15: full hour → startFraction=0.0, endFraction=1.0
+      expect(entries[1].hour).toBe(15)
+      expect(entries[1].segment.startFraction).toBeCloseTo(0.0, 5)
+      expect(entries[1].segment.endFraction).toBeCloseTo(1.0, 5)
+
+      // Hour 16: 16:00 - 16:15 → startFraction=0.0, endFraction=0.25
+      expect(entries[2].hour).toBe(16)
+      expect(entries[2].segment.startFraction).toBeCloseTo(0.0, 5)
+      expect(entries[2].segment.endFraction).toBeCloseTo(0.25, 5)
+    })
+
+    it('should cross midnight boundary correctly', () => {
+      const start = weekDate(0, 23, 30) // Sun 23:30
+      const end = weekDate(1, 0, 30) // Mon 00:30
+
+      const entries = distributeRunToHours({ clippedStart: start, clippedEnd: end, runType: 'farm', tier: 11, runId: 'r4' })
+
+      expect(entries).toHaveLength(2)
+
+      // Sun hour 23: 23:30 - 00:00
+      expect(entries[0].dayIndex).toBe(0) // Sunday
+      expect(entries[0].hour).toBe(23)
+      expect(entries[0].segment.startFraction).toBeCloseTo(0.5, 5)
+      expect(entries[0].segment.endFraction).toBeCloseTo(1.0, 5)
+
+      // Mon hour 0: 00:00 - 00:30
+      expect(entries[1].dayIndex).toBe(1) // Monday
+      expect(entries[1].hour).toBe(0)
+      expect(entries[1].segment.startFraction).toBeCloseTo(0.0, 5)
+      expect(entries[1].segment.endFraction).toBeCloseTo(0.5, 5)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // calculateCellCoverage
+  // -------------------------------------------------------------------------
+  describe('calculateCellCoverage', () => {
+    it('should return 0 for empty segments', () => {
+      expect(calculateCellCoverage([])).toBe(0)
+    })
+
+    it('should calculate coverage for a single segment', () => {
+      const coverage = calculateCellCoverage([
+        { startFraction: 0.25, endFraction: 0.75, runType: 'farm', tier: 11, runId: 'r1' },
+      ])
+      expect(coverage).toBeCloseTo(0.5, 5)
+    })
+
+    it('should sum coverage of multiple non-overlapping segments', () => {
+      const coverage = calculateCellCoverage([
+        { startFraction: 0.0, endFraction: 0.25, runType: 'farm', tier: 11, runId: 'r1' },
+        { startFraction: 0.5, endFraction: 0.75, runType: 'tournament', tier: 8, runId: 'r2' },
+      ])
+      expect(coverage).toBeCloseTo(0.5, 5)
+    })
+
+    it('should clamp coverage to 1.0 when segments exceed an hour', () => {
+      const coverage = calculateCellCoverage([
+        { startFraction: 0.0, endFraction: 0.6, runType: 'farm', tier: 11, runId: 'r1' },
+        { startFraction: 0.3, endFraction: 0.9, runType: 'farm', tier: 11, runId: 'r2' },
+      ])
+      // 0.6 + 0.6 = 1.2, clamped to 1.0
+      expect(coverage).toBe(1.0)
+    })
+
+    it('should handle full-hour segment', () => {
+      const coverage = calculateCellCoverage([
+        { startFraction: 0.0, endFraction: 1.0, runType: 'farm', tier: 11, runId: 'r1' },
+      ])
+      expect(coverage).toBe(1.0)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // buildHeatmapGrid - integration tests
+  // -------------------------------------------------------------------------
+  describe('buildHeatmapGrid', () => {
+    it('should return empty grid with correct structure for no runs', () => {
+      const grid = buildHeatmapGrid([], WEEK_START)
+
+      // 7 days x 24 hours
+      expect(grid.days).toHaveLength(7)
+      for (let day = 0; day < 7; day++) {
+        expect(grid.days[day]).toHaveLength(24)
+        for (let hour = 0; hour < 24; hour++) {
+          const cell = grid.days[day][hour]
+          expect(cell.dayIndex).toBe(day)
+          expect(cell.hour).toBe(hour)
+          expect(cell.segments).toHaveLength(0)
+          expect(cell.totalCoverage).toBe(0)
+        }
+      }
+
+      expect(grid.weekStart).toEqual(WEEK_START)
+      expect(grid.weekEnd).toEqual(WEEK_END)
+      expect(grid.weekLabel).toBe('Week of 2/22')
+    })
+
+    it('should place a single run within one hour', () => {
+      // Mon 14:15 - 14:45 (30 minutes)
+      const run = createTestRun({
+        endTime: weekDate(1, 14, 45),
+        durationSeconds: 30 * 60,
+        id: 'single-hour',
+      })
+
+      const grid = buildHeatmapGrid([run], WEEK_START)
+      const cell = grid.days[1][14] // Mon hour 14
+
+      expect(cell.segments).toHaveLength(1)
+      expect(cell.segments[0].startFraction).toBeCloseTo(0.25, 5)
+      expect(cell.segments[0].endFraction).toBeCloseTo(0.75, 5)
+      expect(cell.totalCoverage).toBeCloseTo(0.5, 5)
+
+      // Adjacent cells should be empty
+      expect(grid.days[1][13].segments).toHaveLength(0)
+      expect(grid.days[1][15].segments).toHaveLength(0)
+    })
+
+    it('should split a run spanning two hours', () => {
+      // Mon 10:45 - 11:15 (30 min)
+      const run = createTestRun({
+        endTime: weekDate(1, 11, 15),
+        durationSeconds: 30 * 60,
+        id: 'two-hours',
+      })
+
+      const grid = buildHeatmapGrid([run], WEEK_START)
+
+      // Hour 10: 10:45 - 11:00
+      const cell10 = grid.days[1][10]
+      expect(cell10.segments).toHaveLength(1)
+      expect(cell10.segments[0].startFraction).toBeCloseTo(0.75, 5)
+      expect(cell10.segments[0].endFraction).toBeCloseTo(1.0, 5)
+      expect(cell10.totalCoverage).toBeCloseTo(0.25, 5)
+
+      // Hour 11: 11:00 - 11:15
+      const cell11 = grid.days[1][11]
+      expect(cell11.segments).toHaveLength(1)
+      expect(cell11.segments[0].startFraction).toBeCloseTo(0.0, 5)
+      expect(cell11.segments[0].endFraction).toBeCloseTo(0.25, 5)
+      expect(cell11.totalCoverage).toBeCloseTo(0.25, 5)
+    })
+
+    it('should handle a run spanning midnight', () => {
+      // Sun 23:30 - Mon 00:30 (1 hour)
+      const run = createTestRun({
+        endTime: weekDate(1, 0, 30), // Mon 00:30
+        durationSeconds: 60 * 60,
+        id: 'midnight',
+      })
+
+      const grid = buildHeatmapGrid([run], WEEK_START)
+
+      // Sun hour 23
+      const sunCell = grid.days[0][23]
+      expect(sunCell.segments).toHaveLength(1)
+      expect(sunCell.segments[0].startFraction).toBeCloseTo(0.5, 5)
+      expect(sunCell.segments[0].endFraction).toBeCloseTo(1.0, 5)
+
+      // Mon hour 0
+      const monCell = grid.days[1][0]
+      expect(monCell.segments).toHaveLength(1)
+      expect(monCell.segments[0].startFraction).toBeCloseTo(0.0, 5)
+      expect(monCell.segments[0].endFraction).toBeCloseTo(0.5, 5)
+    })
+
+    it('should handle a run spanning multiple days', () => {
+      // Tue 22:00 - Thu 02:00 (28 hours)
+      const run = createTestRun({
+        endTime: weekDate(4, 2, 0), // Thu 02:00
+        durationSeconds: 28 * 3600,
+        id: 'multi-day',
+      })
+
+      const grid = buildHeatmapGrid([run], WEEK_START)
+
+      // Tue (dayIndex=2) hours 22, 23 should have full coverage
+      expect(grid.days[2][22].totalCoverage).toBeCloseTo(1.0, 5)
+      expect(grid.days[2][23].totalCoverage).toBeCloseTo(1.0, 5)
+
+      // Wed (dayIndex=3) all 24 hours should have full coverage
+      for (let h = 0; h < 24; h++) {
+        expect(grid.days[3][h].totalCoverage).toBeCloseTo(1.0, 5)
+      }
+
+      // Thu (dayIndex=4) hours 0, 1 should have full coverage
+      expect(grid.days[4][0].totalCoverage).toBeCloseTo(1.0, 5)
+      expect(grid.days[4][1].totalCoverage).toBeCloseTo(1.0, 5)
+
+      // Thu hour 2 should be empty (run ends at exactly 02:00)
+      expect(grid.days[4][2].segments).toHaveLength(0)
+
+      // Tue hour 21 should be empty
+      expect(grid.days[2][21].segments).toHaveLength(0)
+
+      // Total filled cells: 2 (Tue) + 24 (Wed) + 2 (Thu) = 28
+      let filledCount = 0
+      for (let d = 0; d < 7; d++) {
+        for (let h = 0; h < 24; h++) {
+          if (grid.days[d][h].segments.length > 0) filledCount++
+        }
+      }
+      expect(filledCount).toBe(28)
+    })
+
+    it('should clip a run starting before the week to weekStart', () => {
+      // Run starts Saturday before (Feb 21, 20:00) and ends Sunday 03:00
+      // Duration = 7 hours = 25200s
+      const run = createTestRun({
+        endTime: weekDate(0, 3, 0), // Sun 03:00
+        durationSeconds: 7 * 3600, // 7 hours (starts Sat 20:00)
+        id: 'clip-start',
+      })
+
+      const grid = buildHeatmapGrid([run], WEEK_START)
+
+      // Only Sun 00:00 - 03:00 should appear (3 hours)
+      expect(grid.days[0][0].totalCoverage).toBeCloseTo(1.0, 5)
+      expect(grid.days[0][1].totalCoverage).toBeCloseTo(1.0, 5)
+      expect(grid.days[0][2].totalCoverage).toBeCloseTo(1.0, 5)
+      expect(grid.days[0][3].segments).toHaveLength(0)
+
+      // Sun hour 0 should start at fraction 0.0 (clipped to weekStart)
+      expect(grid.days[0][0].segments[0].startFraction).toBeCloseTo(0.0, 5)
+    })
+
+    it('should clip a run ending after the week to weekEnd', () => {
+      // Sat 22:00 to Sun next week 03:00 (5 hours)
+      const run = createTestRun({
+        endTime: new Date(2026, 2, 1, 3, 0, 0), // Sun Mar 1 03:00 (next week)
+        durationSeconds: 5 * 3600,
+        id: 'clip-end',
+      })
+
+      const grid = buildHeatmapGrid([run], WEEK_START)
+
+      // Sat (dayIndex=6) hours 22, 23 should have segments
+      expect(grid.days[6][22].totalCoverage).toBeCloseTo(1.0, 5)
+      expect(grid.days[6][23].totalCoverage).toBeCloseTo(1.0, 5)
+
+      // Hour 23 segment should end at 1.0 (or close, clipped to 23:59:59.999)
+      const lastSegment = grid.days[6][23].segments[0]
+      expect(lastSegment.endFraction).toBeGreaterThan(0.99)
+    })
+
+    it('should produce no segments for a run entirely outside the week', () => {
+      // Run on the following Monday
+      const run = createTestRun({
+        endTime: new Date(2026, 2, 2, 14, 0, 0), // Mon Mar 2
+        durationSeconds: 3600,
+        id: 'outside',
+      })
+
+      const grid = buildHeatmapGrid([run], WEEK_START)
+
+      for (let d = 0; d < 7; d++) {
+        for (let h = 0; h < 24; h++) {
+          expect(grid.days[d][h].segments).toHaveLength(0)
+        }
+      }
+    })
+
+    it('should place multiple runs in the same hour as separate segments', () => {
+      // Run 1: Mon 14:00 - 14:20 (20 min)
+      const run1 = createTestRun({
+        endTime: weekDate(1, 14, 20),
+        durationSeconds: 20 * 60,
+        id: 'multi-1',
+      })
+
+      // Run 2: Mon 14:40 - 15:00 (20 min)
+      const run2 = createTestRun({
+        endTime: weekDate(1, 15, 0),
+        durationSeconds: 20 * 60,
+        id: 'multi-2',
+        runType: 'tournament',
+      })
+
+      const grid = buildHeatmapGrid([run1, run2], WEEK_START)
+      const cell = grid.days[1][14]
+
+      expect(cell.segments).toHaveLength(2)
+
+      // First segment: 14:00 - 14:20
+      const seg1 = cell.segments.find((s) => s.runId === 'multi-1')!
+      expect(seg1.startFraction).toBeCloseTo(0.0, 5)
+      expect(seg1.endFraction).toBeCloseTo(1 / 3, 5) // 20/60
+
+      // Second segment: 14:40 - 15:00
+      const seg2 = cell.segments.find((s) => s.runId === 'multi-2')!
+      expect(seg2.startFraction).toBeCloseTo(2 / 3, 5) // 40/60
+      expect(seg2.endFraction).toBeCloseTo(1.0, 5)
+
+      // Total coverage: 20min + 20min = 40/60
+      expect(cell.totalCoverage).toBeCloseTo(2 / 3, 5)
+    })
+
+    it('should handle a very short run (30 seconds)', () => {
+      // Mon 12:00:00 - 12:00:30
+      const run = createTestRun({
+        endTime: weekDate(1, 12, 0, 30),
+        durationSeconds: 30,
+        id: 'tiny',
+      })
+
+      const grid = buildHeatmapGrid([run], WEEK_START)
+      const cell = grid.days[1][12]
+
+      expect(cell.segments).toHaveLength(1)
+      expect(cell.segments[0].startFraction).toBeCloseTo(0.0, 5)
+      // 30 seconds / 3600 seconds = 0.00833...
+      expect(cell.segments[0].endFraction).toBeCloseTo(30 / 3600, 5)
+      expect(cell.totalCoverage).toBeCloseTo(30 / 3600, 5)
+    })
+
+    it('should fill all 168 cells for a full-week run', () => {
+      // Run spanning entire week: Sun 00:00 to Sat 23:59:59.999
+      const runEnd = new Date(2026, 2, 2, 12, 0, 0) // Well past week end
+      const runDuration = 10 * 24 * 3600 // 10 days in seconds (will be clipped)
+
+      const run = createTestRun({
+        endTime: runEnd,
+        durationSeconds: runDuration,
+        id: 'full-week',
+      })
+
+      const grid = buildHeatmapGrid([run], WEEK_START)
+
+      let allCellsFilled = true
+      for (let d = 0; d < 7; d++) {
+        for (let h = 0; h < 24; h++) {
+          const cell = grid.days[d][h]
+          if (cell.segments.length === 0) {
+            allCellsFilled = false
+          }
+          // All complete hours should have coverage of 1.0
+          // The last hour (Sat 23:xx) may be slightly less due to weekEnd = 23:59:59.999
+          if (d < 6 || h < 23) {
+            expect(cell.totalCoverage).toBeCloseTo(1.0, 3)
+          }
+        }
+      }
+
+      expect(allCellsFilled).toBe(true)
+
+      // Sat hour 23 should have near-full coverage (59 min 59.999s / 60 min)
+      const lastCell = grid.days[6][23]
+      expect(lastCell.totalCoverage).toBeGreaterThan(0.99)
+    })
+
+    it('should set correct date for each day in the grid', () => {
+      const grid = buildHeatmapGrid([], WEEK_START)
+
+      // dayIndex 0 = Sunday Feb 22
+      expect(grid.days[0][0].date.getDate()).toBe(22)
+      expect(grid.days[0][0].date.getMonth()).toBe(1) // February
+
+      // dayIndex 1 = Monday Feb 23
+      expect(grid.days[1][0].date.getDate()).toBe(23)
+
+      // dayIndex 6 = Saturday Feb 28
+      expect(grid.days[6][0].date.getDate()).toBe(28)
+      expect(grid.days[6][0].date.getMonth()).toBe(1) // February
+    })
+
+    it('should preserve run metadata (runType, tier, runId) in segments', () => {
+      const run = createTestRun({
+        endTime: weekDate(4, 15, 30), // Thu 15:30
+        durationSeconds: 30 * 60,
+        runType: 'tournament',
+        tier: 5,
+        id: 'metadata-check',
+      })
+
+      const grid = buildHeatmapGrid([run], WEEK_START)
+      const cell = grid.days[4][15] // Thu hour 15
+
+      expect(cell.segments).toHaveLength(1)
+      expect(cell.segments[0].runType).toBe('tournament')
+      expect(cell.segments[0].tier).toBe(5)
+      expect(cell.segments[0].runId).toBe('metadata-check')
+    })
+
+    it('should generate correct weekLabel', () => {
+      const grid = buildHeatmapGrid([], WEEK_START)
+
+      expect(grid.weekLabel).toBe('Week of 2/22')
+    })
+  })
+})

--- a/src/features/analysis/activity-heatmap/calculations/heatmap-grid-builder.ts
+++ b/src/features/analysis/activity-heatmap/calculations/heatmap-grid-builder.ts
@@ -1,0 +1,203 @@
+/**
+ * Heatmap Grid Builder
+ *
+ * Pure functions that transform ParsedGameRun data into a 7x24 HeatmapGrid.
+ * Each cell represents one hour of one day, with segments showing which
+ * portions of the hour were occupied by game runs.
+ *
+ * Algorithm:
+ * 1. For each run, derive its start/end time range
+ * 2. Clip the range to the target week
+ * 3. Distribute the clipped range across hour cells as fractional segments
+ * 4. Calculate total coverage for each cell
+ */
+
+import type { ParsedGameRun } from '@/shared/types/game-run.types'
+import type { RunTypeValue } from '@/shared/domain/run-types/types'
+import type { HeatmapSegment, HeatmapCell, HeatmapGrid } from '../types'
+import { getWeekEnd, getDayIndex } from '../week-utils'
+import { formatWeekOfLabel } from '@/shared/formatting/date-formatters'
+
+/**
+ * Derives the start and end time of a game run.
+ * Start time is calculated by subtracting the run duration from the end timestamp.
+ *
+ * @param run - The parsed game run
+ * @returns Object with start and end dates
+ */
+export function getRunTimeRange(run: ParsedGameRun): { start: Date; end: Date } {
+  const end = run.timestamp
+  const start = new Date(end.getTime() - run.realTime * 1000)
+  return { start, end }
+}
+
+/**
+ * Clips a run's time range to the boundaries of a given week.
+ * Returns null if the run does not overlap the week at all.
+ *
+ * @param runStart - Start time of the run
+ * @param runEnd - End time of the run
+ * @param weekStart - Sunday 00:00:00.000 of the week
+ * @param weekEnd - Saturday 23:59:59.999 of the week
+ * @returns Clipped start/end or null if no overlap
+ */
+export function clipRunToWeek(
+  runStart: Date,
+  runEnd: Date,
+  weekStart: Date,
+  weekEnd: Date
+): { clippedStart: Date; clippedEnd: Date } | null {
+  // No overlap if run ends before week starts or starts after week ends
+  if (runEnd.getTime() <= weekStart.getTime() || runStart.getTime() > weekEnd.getTime()) {
+    return null
+  }
+
+  const clippedStart = runStart.getTime() < weekStart.getTime() ? weekStart : runStart
+  const clippedEnd = runEnd.getTime() > weekEnd.getTime() ? weekEnd : runEnd
+
+  return { clippedStart, clippedEnd }
+}
+
+/** Run metadata needed to create segments during hour distribution */
+interface RunSegmentInfo {
+  clippedStart: Date
+  clippedEnd: Date
+  runType: RunTypeValue
+  tier: number
+  runId: string
+}
+
+/**
+ * Distributes a clipped run across the hour cells it touches.
+ * For each hour, calculates the fractional start and end position (0-1).
+ *
+ * @param info - Clipped time range and run metadata
+ * @returns Array of hour entries with dayIndex, hour, and segment data
+ *
+ * @example
+ * // Run from 14:30 to 16:15 produces:
+ * // hour 14: startFraction=0.5, endFraction=1.0
+ * // hour 15: startFraction=0.0, endFraction=1.0
+ * // hour 16: startFraction=0.0, endFraction=0.25
+ */
+export function distributeRunToHours(
+  info: RunSegmentInfo
+): Array<{ dayIndex: number; hour: number; segment: HeatmapSegment }> {
+  const { clippedStart, clippedEnd, runType, tier, runId } = info
+  const results: Array<{ dayIndex: number; hour: number; segment: HeatmapSegment }> = []
+
+  // Walk hour-by-hour from clippedStart to clippedEnd
+  const cursor = new Date(clippedStart)
+  cursor.setMinutes(0, 0, 0) // Snap to start of the hour containing clippedStart
+
+  while (cursor.getTime() < clippedEnd.getTime()) {
+    const hourStart = new Date(cursor)
+    const hourEnd = new Date(cursor)
+    hourEnd.setHours(hourEnd.getHours() + 1) // Start of next hour
+
+    // Calculate fractional overlap within this hour
+    const overlapStart = Math.max(clippedStart.getTime(), hourStart.getTime())
+    const overlapEnd = Math.min(clippedEnd.getTime(), hourEnd.getTime())
+
+    if (overlapEnd > overlapStart) {
+      const hourDuration = hourEnd.getTime() - hourStart.getTime() // Always 3600000ms
+      const startFraction = (overlapStart - hourStart.getTime()) / hourDuration
+      const endFraction = (overlapEnd - hourStart.getTime()) / hourDuration
+
+      results.push({
+        dayIndex: getDayIndex(hourStart),
+        hour: hourStart.getHours(),
+        segment: {
+          startFraction,
+          endFraction,
+          runType,
+          tier,
+          runId,
+        },
+      })
+    }
+
+    // Advance cursor to the next hour
+    cursor.setHours(cursor.getHours() + 1)
+  }
+
+  return results
+}
+
+/**
+ * Calculates total coverage for a cell by summing segment durations.
+ * Clamped to a maximum of 1.0.
+ *
+ * @param segments - Array of segments in the cell
+ * @returns Total coverage fraction (0-1)
+ */
+export function calculateCellCoverage(segments: HeatmapSegment[]): number {
+  if (segments.length === 0) return 0
+
+  const total = segments.reduce(
+    (sum, segment) => sum + (segment.endFraction - segment.startFraction),
+    0
+  )
+
+  return Math.min(total, 1.0)
+}
+
+/**
+ * Builds the complete 7x24 HeatmapGrid for a given week from game run data.
+ *
+ * @param runs - All parsed game runs (will be filtered to the target week)
+ * @param weekStart - Sunday 00:00:00.000 of the target week
+ * @returns Complete HeatmapGrid with segments distributed across cells
+ */
+export function buildHeatmapGrid(runs: ParsedGameRun[], weekStart: Date): HeatmapGrid {
+  const weekEnd = getWeekEnd(weekStart)
+
+  // Initialize empty 7x24 grid
+  const days: HeatmapCell[][] = Array.from({ length: 7 }, (_, dayIndex) => {
+    const dayDate = new Date(weekStart)
+    dayDate.setDate(dayDate.getDate() + dayIndex)
+
+    return Array.from({ length: 24 }, (_, hour) => ({
+      hour,
+      dayIndex,
+      date: new Date(dayDate),
+      segments: [],
+      totalCoverage: 0,
+    }))
+  })
+
+  // Distribute each run's time range across the grid
+  for (const run of runs) {
+    const { start, end } = getRunTimeRange(run)
+    const clipped = clipRunToWeek(start, end, weekStart, weekEnd)
+    if (!clipped) continue
+
+    const hourEntries = distributeRunToHours({
+      clippedStart: clipped.clippedStart,
+      clippedEnd: clipped.clippedEnd,
+      runType: run.runType,
+      tier: run.tier,
+      runId: run.id,
+    })
+
+    for (const entry of hourEntries) {
+      days[entry.dayIndex][entry.hour].segments.push(entry.segment)
+    }
+  }
+
+  // Calculate total coverage for each cell
+  for (const dayCells of days) {
+    for (const cell of dayCells) {
+      cell.totalCoverage = calculateCellCoverage(cell.segments)
+    }
+  }
+
+  const weekLabel = formatWeekOfLabel(weekStart)
+
+  return {
+    weekStart,
+    weekEnd,
+    days,
+    weekLabel,
+  }
+}

--- a/src/features/analysis/activity-heatmap/calculations/heatmap-statistics.test.ts
+++ b/src/features/analysis/activity-heatmap/calculations/heatmap-statistics.test.ts
@@ -1,0 +1,770 @@
+import { describe, it, expect } from 'vitest'
+import type { HeatmapGrid, HeatmapCell, HeatmapSegment, ActiveHoursConfig } from '../types'
+import {
+  calculateOverallCoverage,
+  calculateDailyCoverage,
+  calculateActiveHoursCoverage,
+  calculateRunTypeBreakdown,
+  calculateRunTypeStats,
+  calculateTotalActiveSeconds,
+  calculateTotalIdleSeconds,
+  countRuns,
+  calculateHeatmapSummary,
+  isHourInActiveWindow,
+} from './heatmap-statistics'
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/** Creates a 7x24 empty HeatmapGrid with zero coverage in all cells. */
+function createEmptyGrid(): HeatmapGrid {
+  const weekStart = new Date(2026, 1, 22) // Sunday Feb 22
+  const weekEnd = new Date(2026, 1, 28, 23, 59, 59, 999) // Saturday Feb 28
+  const days: HeatmapCell[][] = Array.from({ length: 7 }, (_, dayIndex) => {
+    const dayDate = new Date(weekStart)
+    dayDate.setDate(dayDate.getDate() + dayIndex)
+    return Array.from({ length: 24 }, (_, hour) => ({
+      hour,
+      dayIndex,
+      date: new Date(dayDate),
+      segments: [],
+      totalCoverage: 0,
+    }))
+  })
+  return { weekStart, weekEnd, days, weekLabel: 'Week of Feb 22' }
+}
+
+/** Sets a single cell's coverage. Returns the cell for optional chaining (e.g. setting segments). */
+function setCellCoverage(
+  grid: HeatmapGrid,
+  dayIndex: number,
+  hour: number,
+  totalCoverage: number
+): HeatmapCell {
+  const cell = grid.days[dayIndex][hour]
+  cell.totalCoverage = totalCoverage
+  return cell
+}
+
+/** Creates a simple segment for testing. */
+function createSegment(overrides: Partial<HeatmapSegment> & { runId: string }): HeatmapSegment {
+  return {
+    startFraction: 0,
+    endFraction: 1,
+    runType: 'farm',
+    tier: 11,
+    ...overrides,
+  }
+}
+
+/** Creates a full-coverage grid (all 168 cells at 100%). */
+function createFullGrid(): HeatmapGrid {
+  const grid = createEmptyGrid()
+  for (let d = 0; d < 7; d++) {
+    for (let h = 0; h < 24; h++) {
+      setCellCoverage(grid, d, h, 1.0).segments = [
+        createSegment({ runId: 'full-run', startFraction: 0, endFraction: 1 }),
+      ]
+    }
+  }
+  return grid
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('heatmap-statistics', () => {
+  // -------------------------------------------------------------------------
+  // calculateOverallCoverage
+  // -------------------------------------------------------------------------
+  describe('calculateOverallCoverage', () => {
+    it('should return 0 for an empty grid', () => {
+      const grid = createEmptyGrid()
+
+      expect(calculateOverallCoverage(grid)).toBe(0)
+    })
+
+    it('should return correct average when one cell has 50% coverage', () => {
+      const grid = createEmptyGrid()
+      setCellCoverage(grid, 0, 0, 0.5)
+
+      // 0.5 / 168
+      expect(calculateOverallCoverage(grid)).toBeCloseTo(0.5 / 168, 10)
+    })
+
+    it('should return 1.0 for a full coverage grid', () => {
+      const grid = createFullGrid()
+
+      expect(calculateOverallCoverage(grid)).toBeCloseTo(1.0, 10)
+    })
+
+    it('should correctly average partial coverage across multiple cells', () => {
+      const grid = createEmptyGrid()
+      // Set 4 cells to 0.5 coverage each
+      setCellCoverage(grid, 0, 0, 0.5)
+      setCellCoverage(grid, 1, 12, 0.5)
+      setCellCoverage(grid, 3, 8, 0.5)
+      setCellCoverage(grid, 6, 23, 0.5)
+
+      // (0.5 * 4) / 168 = 2.0 / 168
+      expect(calculateOverallCoverage(grid)).toBeCloseTo(2.0 / 168, 10)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // calculateDailyCoverage
+  // -------------------------------------------------------------------------
+  describe('calculateDailyCoverage', () => {
+    it('should return 7 zeros for an empty grid', () => {
+      const grid = createEmptyGrid()
+      const result = calculateDailyCoverage(grid)
+
+      expect(result).toHaveLength(7)
+      expect(result).toEqual([0, 0, 0, 0, 0, 0, 0])
+    })
+
+    it('should return correct average for a day with mixed coverage', () => {
+      const grid = createEmptyGrid()
+      // Sunday: set 4 hours at 0.5 coverage, rest at 0
+      setCellCoverage(grid, 0, 8, 0.5)
+      setCellCoverage(grid, 0, 9, 0.5)
+      setCellCoverage(grid, 0, 10, 0.5)
+      setCellCoverage(grid, 0, 11, 0.5)
+
+      const result = calculateDailyCoverage(grid)
+
+      // Sunday average: (4 * 0.5) / 24 = 2/24
+      expect(result[0]).toBeCloseTo(2 / 24, 10)
+      // All other days should be 0
+      for (let d = 1; d < 7; d++) {
+        expect(result[d]).toBe(0)
+      }
+    })
+
+    it('should return correct values per day independently', () => {
+      const grid = createEmptyGrid()
+      // Sunday: all 24 hours at full coverage
+      for (let h = 0; h < 24; h++) {
+        setCellCoverage(grid, 0, h, 1.0)
+      }
+      // Tuesday: all 24 hours at 50%
+      for (let h = 0; h < 24; h++) {
+        setCellCoverage(grid, 2, h, 0.5)
+      }
+      // Saturday: 12 hours at 100%
+      for (let h = 0; h < 12; h++) {
+        setCellCoverage(grid, 6, h, 1.0)
+      }
+
+      const result = calculateDailyCoverage(grid)
+
+      expect(result[0]).toBeCloseTo(1.0, 10) // Sunday
+      expect(result[1]).toBe(0) // Monday
+      expect(result[2]).toBeCloseTo(0.5, 10) // Tuesday
+      expect(result[3]).toBe(0) // Wednesday
+      expect(result[4]).toBe(0) // Thursday
+      expect(result[5]).toBe(0) // Friday
+      expect(result[6]).toBeCloseTo(0.5, 10) // Saturday (12/24)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // calculateActiveHoursCoverage
+  // -------------------------------------------------------------------------
+  describe('calculateActiveHoursCoverage', () => {
+    it('should average only hours within standard range (8-23)', () => {
+      const grid = createEmptyGrid()
+      // Set hours 8-22 (15 hours) to full coverage on Sunday
+      for (let h = 8; h < 23; h++) {
+        setCellCoverage(grid, 0, h, 1.0)
+      }
+
+      const result = calculateActiveHoursCoverage(grid, 8, 23)
+
+      // Active hours: 8-22 (15 hours per day), total active cells: 15 * 7 = 105
+      // Only Sunday has coverage: 15 cells at 1.0
+      expect(result).toBeCloseTo(15 / 105, 10)
+    })
+
+    it('should handle overnight range (22-6) correctly', () => {
+      const grid = createEmptyGrid()
+      // Set hours 22-23 and 0-5 on Sunday (8 hours total active window per day)
+      setCellCoverage(grid, 0, 22, 1.0)
+      setCellCoverage(grid, 0, 23, 1.0)
+      for (let h = 0; h < 6; h++) {
+        setCellCoverage(grid, 0, h, 1.0)
+      }
+
+      const result = calculateActiveHoursCoverage(grid, 22, 6)
+
+      // Active hours: 22-23 (2 hours) + 0-5 (6 hours) = 8 hours per day
+      // Total active cells: 8 * 7 = 56
+      // Sunday has 8 cells at 1.0
+      expect(result).toBeCloseTo(8 / 56, 10)
+    })
+
+    it('should handle single hour range', () => {
+      const grid = createEmptyGrid()
+      // Set hour 12 on all days to 0.5 coverage
+      for (let d = 0; d < 7; d++) {
+        setCellCoverage(grid, d, 12, 0.5)
+      }
+
+      const result = calculateActiveHoursCoverage(grid, 12, 13)
+
+      // Active hours: 12-12 (1 hour), total active cells: 1 * 7 = 7
+      // All 7 cells at 0.5
+      expect(result).toBeCloseTo(0.5, 10)
+    })
+
+    it('should exclude hours outside the active window', () => {
+      const grid = createEmptyGrid()
+      // Set hour 7 (outside 8-23 window) to full coverage on all days
+      for (let d = 0; d < 7; d++) {
+        setCellCoverage(grid, d, 7, 1.0)
+      }
+
+      const result = calculateActiveHoursCoverage(grid, 8, 23)
+
+      // No coverage within active window
+      expect(result).toBe(0)
+    })
+
+    it('should return 0 for empty grid regardless of window', () => {
+      const grid = createEmptyGrid()
+
+      expect(calculateActiveHoursCoverage(grid, 8, 23)).toBe(0)
+      expect(calculateActiveHoursCoverage(grid, 22, 6)).toBe(0)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // calculateRunTypeBreakdown
+  // -------------------------------------------------------------------------
+  describe('calculateRunTypeBreakdown', () => {
+    it('should return empty object for empty grid', () => {
+      const grid = createEmptyGrid()
+
+      expect(calculateRunTypeBreakdown(grid)).toEqual({})
+    })
+
+    it('should return { runType: 1.0 } for single run type', () => {
+      const grid = createEmptyGrid()
+      setCellCoverage(grid, 0, 10, 0.5).segments = [
+        createSegment({ runId: 'r1', runType: 'farm', startFraction: 0, endFraction: 0.5 }),
+      ]
+
+      const result = calculateRunTypeBreakdown(grid)
+
+      expect(result).toEqual({ farm: 1.0 })
+    })
+
+    it('should return normalized fractions for multiple run types', () => {
+      const grid = createEmptyGrid()
+      // Farm segment: 0.6 coverage
+      // Tournament segment: 0.4 coverage
+      setCellCoverage(grid, 0, 10, 1.0).segments = [
+        createSegment({ runId: 'r1', runType: 'farm', startFraction: 0, endFraction: 0.6 }),
+        createSegment({
+          runId: 'r2',
+          runType: 'tournament',
+          startFraction: 0.6,
+          endFraction: 1.0,
+        }),
+      ]
+
+      const result = calculateRunTypeBreakdown(grid)
+
+      expect(result.farm).toBeCloseTo(0.6, 10)
+      expect(result.tournament).toBeCloseTo(0.4, 10)
+    })
+
+    it('should aggregate across multiple cells', () => {
+      const grid = createEmptyGrid()
+      // Cell 1: farm covers 0.5
+      setCellCoverage(grid, 0, 10, 0.5).segments = [
+        createSegment({ runId: 'r1', runType: 'farm', startFraction: 0, endFraction: 0.5 }),
+      ]
+      // Cell 2: tournament covers 0.5
+      setCellCoverage(grid, 1, 14, 0.5).segments = [
+        createSegment({
+          runId: 'r2',
+          runType: 'tournament',
+          startFraction: 0,
+          endFraction: 0.5,
+        }),
+      ]
+
+      const result = calculateRunTypeBreakdown(grid)
+
+      // Equal coverage -> 50/50
+      expect(result.farm).toBeCloseTo(0.5, 10)
+      expect(result.tournament).toBeCloseTo(0.5, 10)
+    })
+
+    it('should handle three run types with correct proportions', () => {
+      const grid = createEmptyGrid()
+      // farm: 0.5, tournament: 0.3, milestone: 0.2
+      setCellCoverage(grid, 0, 10, 1.0).segments = [
+        createSegment({ runId: 'r1', runType: 'farm', startFraction: 0, endFraction: 0.5 }),
+        createSegment({
+          runId: 'r2',
+          runType: 'tournament',
+          startFraction: 0.5,
+          endFraction: 0.8,
+        }),
+        createSegment({
+          runId: 'r3',
+          runType: 'milestone',
+          startFraction: 0.8,
+          endFraction: 1.0,
+        }),
+      ]
+
+      const result = calculateRunTypeBreakdown(grid)
+
+      expect(result.farm).toBeCloseTo(0.5, 10)
+      expect(result.tournament).toBeCloseTo(0.3, 10)
+      expect(result.milestone).toBeCloseTo(0.2, 10)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // calculateRunTypeStats
+  // -------------------------------------------------------------------------
+  describe('calculateRunTypeStats', () => {
+    it('should return empty object for empty grid', () => {
+      const grid = createEmptyGrid()
+
+      expect(calculateRunTypeStats(grid)).toEqual({})
+    })
+
+    it('should return absolute coverage fraction of 168-cell week', () => {
+      const grid = createEmptyGrid()
+      // One cell with farm covering 0.5
+      setCellCoverage(grid, 0, 10, 0.5).segments = [
+        createSegment({ runId: 'r1', runType: 'farm', startFraction: 0, endFraction: 0.5 }),
+      ]
+
+      const result = calculateRunTypeStats(grid)
+
+      // coverage = 0.5 / 168 (absolute fraction of 168 cells)
+      expect(result.farm.coverage).toBeCloseTo(0.5 / 168, 10)
+      // activeSeconds = 0.5 * 3600 = 1800
+      expect(result.farm.activeSeconds).toBeCloseTo(1800, 5)
+      expect(result.farm.runCount).toBe(1)
+    })
+
+    it('should compute separate stats for multiple run types', () => {
+      const grid = createEmptyGrid()
+      // Farm: 0.6 in one cell
+      setCellCoverage(grid, 0, 10, 1.0).segments = [
+        createSegment({ runId: 'r1', runType: 'farm', startFraction: 0, endFraction: 0.6 }),
+        createSegment({
+          runId: 'r2',
+          runType: 'tournament',
+          startFraction: 0.6,
+          endFraction: 1.0,
+        }),
+      ]
+
+      const result = calculateRunTypeStats(grid)
+
+      // Farm: coverage = 0.6 / 168, activeSeconds = 0.6 * 3600
+      expect(result.farm.coverage).toBeCloseTo(0.6 / 168, 10)
+      expect(result.farm.activeSeconds).toBeCloseTo(0.6 * 3600, 5)
+      expect(result.farm.runCount).toBe(1)
+
+      // Tournament: coverage = 0.4 / 168, activeSeconds = 0.4 * 3600
+      expect(result.tournament.coverage).toBeCloseTo(0.4 / 168, 10)
+      expect(result.tournament.activeSeconds).toBeCloseTo(0.4 * 3600, 5)
+      expect(result.tournament.runCount).toBe(1)
+    })
+
+    it('should aggregate across multiple cells and deduplicate run IDs', () => {
+      const grid = createEmptyGrid()
+      // Same farm run spans two cells
+      setCellCoverage(grid, 0, 10, 0.5).segments = [
+        createSegment({ runId: 'r1', runType: 'farm', startFraction: 0.5, endFraction: 1.0 }),
+      ]
+      setCellCoverage(grid, 0, 11, 0.25).segments = [
+        createSegment({ runId: 'r1', runType: 'farm', startFraction: 0, endFraction: 0.25 }),
+      ]
+      // Different tournament run in another cell
+      setCellCoverage(grid, 2, 14, 0.5).segments = [
+        createSegment({
+          runId: 'r2',
+          runType: 'tournament',
+          startFraction: 0,
+          endFraction: 0.5,
+        }),
+      ]
+
+      const result = calculateRunTypeStats(grid)
+
+      // Farm: 0.5 + 0.25 = 0.75 total segment coverage
+      expect(result.farm.coverage).toBeCloseTo(0.75 / 168, 10)
+      expect(result.farm.activeSeconds).toBeCloseTo(0.75 * 3600, 5)
+      expect(result.farm.runCount).toBe(1) // run-1 counted once
+
+      // Tournament: 0.5 total segment coverage
+      expect(result.tournament.coverage).toBeCloseTo(0.5 / 168, 10)
+      expect(result.tournament.activeSeconds).toBeCloseTo(0.5 * 3600, 5)
+      expect(result.tournament.runCount).toBe(1)
+    })
+
+    it('should count multiple unique runs per type', () => {
+      const grid = createEmptyGrid()
+      setCellCoverage(grid, 0, 10, 0.5).segments = [
+        createSegment({ runId: 'r1', runType: 'farm', startFraction: 0, endFraction: 0.25 }),
+        createSegment({ runId: 'r2', runType: 'farm', startFraction: 0.25, endFraction: 0.5 }),
+      ]
+
+      const result = calculateRunTypeStats(grid)
+
+      expect(result.farm.runCount).toBe(2)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // calculateTotalActiveSeconds
+  // -------------------------------------------------------------------------
+  describe('calculateTotalActiveSeconds', () => {
+    it('should return 0 for empty grid', () => {
+      const grid = createEmptyGrid()
+
+      expect(calculateTotalActiveSeconds(grid)).toBe(0)
+    })
+
+    it('should return 1800 for a single cell at 50% coverage', () => {
+      const grid = createEmptyGrid()
+      setCellCoverage(grid, 0, 0, 0.5)
+
+      expect(calculateTotalActiveSeconds(grid)).toBeCloseTo(1800, 5)
+    })
+
+    it('should return 168 * 3600 for full coverage grid', () => {
+      const grid = createFullGrid()
+
+      expect(calculateTotalActiveSeconds(grid)).toBeCloseTo(168 * 3600, 5)
+    })
+
+    it('should sum across multiple cells correctly', () => {
+      const grid = createEmptyGrid()
+      setCellCoverage(grid, 0, 0, 0.25) // 900 seconds
+      setCellCoverage(grid, 3, 12, 0.75) // 2700 seconds
+
+      expect(calculateTotalActiveSeconds(grid)).toBeCloseTo(3600, 5) // 900 + 2700
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // calculateTotalIdleSeconds
+  // -------------------------------------------------------------------------
+  describe('calculateTotalIdleSeconds', () => {
+    const activeHoursEnabled: ActiveHoursConfig = {
+      startHour: 8,
+      endHour: 23,
+      enabled: true,
+    }
+
+    const activeHoursDisabled: ActiveHoursConfig = {
+      startHour: 8,
+      endHour: 23,
+      enabled: false,
+    }
+
+    it('should count idle across all 168 hours when active hours disabled', () => {
+      const grid = createEmptyGrid()
+
+      const result = calculateTotalIdleSeconds(grid, activeHoursDisabled)
+
+      // All 168 cells are fully idle
+      expect(result).toBeCloseTo(168 * 3600, 5)
+    })
+
+    it('should return 0 idle for full coverage grid with disabled active hours', () => {
+      const grid = createFullGrid()
+
+      const result = calculateTotalIdleSeconds(grid, activeHoursDisabled)
+
+      expect(result).toBeCloseTo(0, 5)
+    })
+
+    it('should only count idle within active window when enabled', () => {
+      const grid = createEmptyGrid()
+
+      const result = calculateTotalIdleSeconds(grid, activeHoursEnabled)
+
+      // Active hours 8-22 = 15 hours/day, 7 days = 105 cells, all idle
+      expect(result).toBeCloseTo(105 * 3600, 5)
+    })
+
+    it('should subtract coverage from idle within active window', () => {
+      const grid = createEmptyGrid()
+      // Set hour 10 on Sunday to 50% coverage (within 8-23 window)
+      setCellCoverage(grid, 0, 10, 0.5)
+
+      const result = calculateTotalIdleSeconds(grid, activeHoursEnabled)
+
+      // 105 cells idle, but one cell is only 50% idle
+      // Total: (104 * 3600) + (0.5 * 3600) = 104.5 * 3600
+      expect(result).toBeCloseTo(104.5 * 3600, 5)
+    })
+
+    it('should not count hours outside active window in idle calculation', () => {
+      const grid = createEmptyGrid()
+      // Set hour 3 (outside 8-23 window) to 0 coverage
+      // This should NOT contribute to idle time when active hours are enabled
+
+      const idleWithActiveHours = calculateTotalIdleSeconds(grid, activeHoursEnabled)
+      // Should only count 15 hours/day * 7 days = 105 hours of idle
+      expect(idleWithActiveHours).toBeCloseTo(105 * 3600, 5)
+    })
+
+    it('should handle overnight active hours window', () => {
+      const overnightConfig: ActiveHoursConfig = {
+        startHour: 22,
+        endHour: 6,
+        enabled: true,
+      }
+      const grid = createEmptyGrid()
+
+      const result = calculateTotalIdleSeconds(grid, overnightConfig)
+
+      // Overnight window: hours 22-23 (2) + 0-5 (6) = 8 hours/day
+      // 8 * 7 = 56 cells of idle
+      expect(result).toBeCloseTo(56 * 3600, 5)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // countRuns
+  // -------------------------------------------------------------------------
+  describe('countRuns', () => {
+    it('should return 0 for empty grid', () => {
+      const grid = createEmptyGrid()
+
+      expect(countRuns(grid)).toBe(0)
+    })
+
+    it('should count segments with the same runId only once', () => {
+      const grid = createEmptyGrid()
+      // Same run spanning two hours
+      setCellCoverage(grid, 0, 10, 0.5).segments = [
+        createSegment({ runId: 'run-1', startFraction: 0.5, endFraction: 1.0 }),
+      ]
+      setCellCoverage(grid, 0, 11, 0.25).segments = [
+        createSegment({ runId: 'run-1', startFraction: 0, endFraction: 0.25 }),
+      ]
+
+      expect(countRuns(grid)).toBe(1)
+    })
+
+    it('should count multiple different runIds correctly', () => {
+      const grid = createEmptyGrid()
+      setCellCoverage(grid, 0, 10, 0.5).segments = [
+        createSegment({ runId: 'run-1', startFraction: 0, endFraction: 0.5 }),
+      ]
+      setCellCoverage(grid, 0, 14, 0.3).segments = [
+        createSegment({ runId: 'run-2', startFraction: 0, endFraction: 0.3 }),
+      ]
+      setCellCoverage(grid, 2, 8, 0.75).segments = [
+        createSegment({ runId: 'run-3', startFraction: 0, endFraction: 0.75 }),
+      ]
+
+      expect(countRuns(grid)).toBe(3)
+    })
+
+    it('should handle multiple segments in the same cell with different runIds', () => {
+      const grid = createEmptyGrid()
+      setCellCoverage(grid, 0, 10, 0.8).segments = [
+        createSegment({ runId: 'run-1', startFraction: 0, endFraction: 0.4 }),
+        createSegment({ runId: 'run-2', startFraction: 0.4, endFraction: 0.8 }),
+      ]
+
+      expect(countRuns(grid)).toBe(2)
+    })
+
+    it('should deduplicate runIds across multiple cells and days', () => {
+      const grid = createEmptyGrid()
+      // run-1 appears in 3 cells across 2 days
+      setCellCoverage(grid, 0, 22, 0.5).segments = [
+        createSegment({ runId: 'run-1', startFraction: 0.5, endFraction: 1.0 }),
+      ]
+      setCellCoverage(grid, 0, 23, 1.0).segments = [
+        createSegment({ runId: 'run-1', startFraction: 0, endFraction: 1.0 }),
+      ]
+      setCellCoverage(grid, 1, 0, 0.25).segments = [
+        createSegment({ runId: 'run-1', startFraction: 0, endFraction: 0.25 }),
+      ]
+      // run-2 in one cell
+      setCellCoverage(grid, 3, 12, 0.5).segments = [
+        createSegment({ runId: 'run-2', startFraction: 0, endFraction: 0.5 }),
+      ]
+
+      expect(countRuns(grid)).toBe(2)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // calculateHeatmapSummary - integration test
+  // -------------------------------------------------------------------------
+  describe('calculateHeatmapSummary', () => {
+    it('should compute all summary fields from a grid with known data', () => {
+      const grid = createEmptyGrid()
+
+      // Sunday hour 10: farm run covers 60% of the hour
+      setCellCoverage(grid, 0, 10, 0.6).segments = [
+        createSegment({ runId: 'farm-1', runType: 'farm', startFraction: 0, endFraction: 0.6 }),
+      ]
+      // Sunday hour 11: farm run covers 40%
+      setCellCoverage(grid, 0, 11, 0.4).segments = [
+        createSegment({ runId: 'farm-1', runType: 'farm', startFraction: 0, endFraction: 0.4 }),
+      ]
+      // Tuesday hour 14: tournament run covers 50%
+      setCellCoverage(grid, 2, 14, 0.5).segments = [
+        createSegment({
+          runId: 'tourn-1',
+          runType: 'tournament',
+          startFraction: 0.25,
+          endFraction: 0.75,
+        }),
+      ]
+
+      const activeHours: ActiveHoursConfig = {
+        startHour: 8,
+        endHour: 23,
+        enabled: true,
+      }
+
+      const summary = calculateHeatmapSummary(grid, activeHours)
+
+      // overallCoverage: (0.6 + 0.4 + 0.5) / 168
+      expect(summary.overallCoverage).toBeCloseTo(1.5 / 168, 10)
+
+      // dailyCoverage: Sun = (0.6 + 0.4)/24, Tue = 0.5/24, rest = 0
+      expect(summary.dailyCoverage).toHaveLength(7)
+      expect(summary.dailyCoverage[0]).toBeCloseTo(1.0 / 24, 10) // Sunday
+      expect(summary.dailyCoverage[1]).toBe(0) // Monday
+      expect(summary.dailyCoverage[2]).toBeCloseTo(0.5 / 24, 10) // Tuesday
+      expect(summary.dailyCoverage[3]).toBe(0) // Wednesday
+      expect(summary.dailyCoverage[4]).toBe(0) // Thursday
+      expect(summary.dailyCoverage[5]).toBe(0) // Friday
+      expect(summary.dailyCoverage[6]).toBe(0) // Saturday
+
+      // activeHoursCoverage: active window 8-22 (15 hours/day, 105 cells)
+      // All three populated cells (hours 10, 11, 14) fall within [8,23)
+      expect(summary.activeHoursCoverage).toBeCloseTo(1.5 / 105, 10)
+
+      // runTypeBreakdown: farm = (0.6 + 0.4) / (0.6 + 0.4 + 0.5), tournament = 0.5 / 1.5
+      expect(summary.runTypeBreakdown.farm).toBeCloseTo(1.0 / 1.5, 10)
+      expect(summary.runTypeBreakdown.tournament).toBeCloseTo(0.5 / 1.5, 10)
+
+      // totalActiveSeconds: (0.6 + 0.4 + 0.5) * 3600 = 5400
+      expect(summary.totalActiveSeconds).toBeCloseTo(5400, 5)
+
+      // totalIdleSeconds: 105 active cells, 3 have partial coverage
+      // (105 - 0.6 - 0.4 - 0.5) * 3600 = 103.5 * 3600
+      expect(summary.totalIdleSeconds).toBeCloseTo(103.5 * 3600, 5)
+
+      // runTypeStats: per-type absolute coverage and run counts
+      expect(summary.runTypeStats.farm.coverage).toBeCloseTo(1.0 / 168, 10)
+      expect(summary.runTypeStats.farm.activeSeconds).toBeCloseTo(1.0 * 3600, 5)
+      expect(summary.runTypeStats.farm.runCount).toBe(1)
+      expect(summary.runTypeStats.tournament.coverage).toBeCloseTo(0.5 / 168, 10)
+      expect(summary.runTypeStats.tournament.activeSeconds).toBeCloseTo(0.5 * 3600, 5)
+      expect(summary.runTypeStats.tournament.runCount).toBe(1)
+
+      // runCount: 2 unique runs (farm-1, tourn-1)
+      expect(summary.runCount).toBe(2)
+    })
+
+    it('should use overallCoverage for activeHoursCoverage when disabled', () => {
+      const grid = createEmptyGrid()
+      setCellCoverage(grid, 0, 3, 1.0).segments = [
+        createSegment({ runId: 'r1', startFraction: 0, endFraction: 1.0 }),
+      ]
+
+      const activeHoursDisabled: ActiveHoursConfig = {
+        startHour: 8,
+        endHour: 23,
+        enabled: false,
+      }
+
+      const summary = calculateHeatmapSummary(grid, activeHoursDisabled)
+
+      // When disabled, activeHoursCoverage should equal overallCoverage
+      expect(summary.activeHoursCoverage).toBe(summary.overallCoverage)
+      expect(summary.activeHoursCoverage).toBeCloseTo(1 / 168, 10)
+    })
+
+    it('should return zero summary for empty grid', () => {
+      const grid = createEmptyGrid()
+      const activeHours: ActiveHoursConfig = {
+        startHour: 8,
+        endHour: 23,
+        enabled: true,
+      }
+
+      const summary = calculateHeatmapSummary(grid, activeHours)
+
+      expect(summary.overallCoverage).toBe(0)
+      expect(summary.dailyCoverage).toEqual([0, 0, 0, 0, 0, 0, 0])
+      expect(summary.activeHoursCoverage).toBe(0)
+      expect(summary.runTypeBreakdown).toEqual({})
+      expect(summary.runTypeStats).toEqual({})
+      expect(summary.totalActiveSeconds).toBe(0)
+      // 15 hours/day * 7 days = 105 active cells, all idle
+      expect(summary.totalIdleSeconds).toBeCloseTo(105 * 3600, 5)
+      expect(summary.runCount).toBe(0)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // isHourInActiveWindow
+  // -------------------------------------------------------------------------
+  describe('isHourInActiveWindow', () => {
+    describe('standard range (startHour < endHour)', () => {
+      it('should return true for hour within range', () => {
+        expect(isHourInActiveWindow(10, 8, 23)).toBe(true)
+      })
+
+      it('should return false for hour outside range', () => {
+        expect(isHourInActiveWindow(5, 8, 23)).toBe(false)
+      })
+
+      it('should include startHour (inclusive)', () => {
+        expect(isHourInActiveWindow(8, 8, 23)).toBe(true)
+      })
+
+      it('should exclude endHour (exclusive)', () => {
+        expect(isHourInActiveWindow(23, 8, 23)).toBe(false)
+      })
+    })
+
+    describe('overnight range (startHour >= endHour)', () => {
+      it('should return true for hour after startHour', () => {
+        expect(isHourInActiveWindow(23, 22, 6)).toBe(true)
+      })
+
+      it('should return true for hour before endHour', () => {
+        expect(isHourInActiveWindow(3, 22, 6)).toBe(true)
+      })
+
+      it('should return false for hour in the gap', () => {
+        expect(isHourInActiveWindow(10, 22, 6)).toBe(false)
+      })
+
+      it('should include startHour (inclusive)', () => {
+        expect(isHourInActiveWindow(22, 22, 6)).toBe(true)
+      })
+
+      it('should exclude endHour (exclusive)', () => {
+        expect(isHourInActiveWindow(6, 22, 6)).toBe(false)
+      })
+    })
+  })
+})

--- a/src/features/analysis/activity-heatmap/calculations/heatmap-statistics.ts
+++ b/src/features/analysis/activity-heatmap/calculations/heatmap-statistics.ts
@@ -1,0 +1,286 @@
+/**
+ * Heatmap Statistics
+ *
+ * Pure functions that compute coverage metrics and summary statistics
+ * from a HeatmapGrid. These functions analyze the 7x24 grid to produce
+ * aggregate metrics like overall coverage, daily breakdowns, active hours
+ * analysis, run type distributions, and time accounting.
+ *
+ * All functions are deterministic with no side effects.
+ */
+
+import type { HeatmapGrid, HeatmapSummary, ActiveHoursConfig, RunTypeStats } from '../types'
+
+const HOURS_PER_DAY = 24
+const DAYS_PER_WEEK = 7
+const TOTAL_CELLS = DAYS_PER_WEEK * HOURS_PER_DAY // 168
+const SECONDS_PER_HOUR = 3600
+
+/**
+ * Calculates the average totalCoverage across all 168 cells in the grid.
+ *
+ * @param grid - The heatmap grid to analyze
+ * @returns Overall coverage fraction (0-1)
+ */
+export function calculateOverallCoverage(grid: HeatmapGrid): number {
+  let sum = 0
+  for (const dayCells of grid.days) {
+    for (const cell of dayCells) {
+      sum += cell.totalCoverage
+    }
+  }
+  return sum / TOTAL_CELLS
+}
+
+/**
+ * Calculates average coverage for each day of the week.
+ * Returns an array of 7 values where index 0=Sunday through 6=Saturday.
+ * Each value is the average totalCoverage of that day's 24 hour cells.
+ *
+ * @param grid - The heatmap grid to analyze
+ * @returns Array of 7 daily coverage fractions (each 0-1)
+ */
+export function calculateDailyCoverage(grid: HeatmapGrid): number[] {
+  return grid.days.map((dayCells) => {
+    const daySum = dayCells.reduce((sum, cell) => sum + cell.totalCoverage, 0)
+    return daySum / HOURS_PER_DAY
+  })
+}
+
+/**
+ * Checks whether a given hour falls within an active hours window.
+ * Handles both standard ranges (e.g., 8-23) and overnight ranges (e.g., 22-6).
+ *
+ * @param hour - The hour to check (0-23)
+ * @param startHour - Start of active window (inclusive)
+ * @param endHour - End of active window (exclusive)
+ * @returns Whether the hour is within the active window
+ */
+export function isHourInActiveWindow(hour: number, startHour: number, endHour: number): boolean {
+  if (startHour < endHour) {
+    // Standard range: e.g., 8-23 means hours [8, 23)
+    return hour >= startHour && hour < endHour
+  }
+  // Overnight range: e.g., 22-6 means hours [22, 24) and [0, 6)
+  return hour >= startHour || hour < endHour
+}
+
+/**
+ * Counts the number of hours in the active window.
+ *
+ * @param startHour - Start of active window (inclusive)
+ * @param endHour - End of active window (exclusive)
+ * @returns Number of hours in the active window
+ */
+function countActiveHours(startHour: number, endHour: number): number {
+  if (startHour < endHour) {
+    return endHour - startHour
+  }
+  // Overnight: hours from startHour to 24, plus hours from 0 to endHour
+  return (HOURS_PER_DAY - startHour) + endHour
+}
+
+/**
+ * Calculates average totalCoverage only for cells within the active hours window.
+ * Supports both standard (e.g., 8-23) and overnight (e.g., 22-6) ranges.
+ *
+ * @param grid - The heatmap grid to analyze
+ * @param startHour - Start of active window (inclusive, 0-23)
+ * @param endHour - End of active window (exclusive, 0-23)
+ * @returns Active hours coverage fraction (0-1)
+ */
+export function calculateActiveHoursCoverage(
+  grid: HeatmapGrid,
+  startHour: number,
+  endHour: number
+): number {
+  const activeHourCount = countActiveHours(startHour, endHour)
+  if (activeHourCount === 0) return 0
+
+  let sum = 0
+  for (const dayCells of grid.days) {
+    for (const cell of dayCells) {
+      if (isHourInActiveWindow(cell.hour, startHour, endHour)) {
+        sum += cell.totalCoverage
+      }
+    }
+  }
+
+  const totalActiveCells = DAYS_PER_WEEK * activeHourCount
+  return sum / totalActiveCells
+}
+
+/**
+ * Calculates the fraction of total segment coverage each run type represents.
+ * Values are normalized so they sum to 1.0.
+ *
+ * @param grid - The heatmap grid to analyze
+ * @returns Record mapping run type to its fraction of total coverage (values sum to 1.0)
+ *
+ * @example
+ * // If farm segments cover 60% and tournament segments cover 40%:
+ * // Returns { farm: 0.6, tournament: 0.4 }
+ */
+export function calculateRunTypeBreakdown(grid: HeatmapGrid): Record<string, number> {
+  const coverageByType: Record<string, number> = {}
+  let totalCoverage = 0
+
+  for (const dayCells of grid.days) {
+    for (const cell of dayCells) {
+      for (const segment of cell.segments) {
+        const segmentCoverage = segment.endFraction - segment.startFraction
+        coverageByType[segment.runType] = (coverageByType[segment.runType] ?? 0) + segmentCoverage
+        totalCoverage += segmentCoverage
+      }
+    }
+  }
+
+  if (totalCoverage === 0) return {}
+
+  // Normalize so values sum to 1.0
+  const breakdown: Record<string, number> = {}
+  for (const [runType, coverage] of Object.entries(coverageByType)) {
+    breakdown[runType] = coverage / totalCoverage
+  }
+
+  return breakdown
+}
+
+/**
+ * Calculates per-run-type statistics including absolute coverage, active seconds,
+ * and unique run count.
+ *
+ * Coverage is calculated as an absolute fraction of the 168-cell week (not relative
+ * to total coverage). Each segment's fractional coverage within its cell is summed
+ * and divided by total cells.
+ *
+ * @param grid - The heatmap grid to analyze
+ * @returns Record mapping run type to its stats (coverage, activeSeconds, runCount)
+ */
+export function calculateRunTypeStats(grid: HeatmapGrid): Record<string, RunTypeStats> {
+  const coverageByType: Record<string, number> = {}
+  const runIdsByType: Record<string, Set<string>> = {}
+
+  for (const dayCells of grid.days) {
+    for (const cell of dayCells) {
+      for (const segment of cell.segments) {
+        const segmentCoverage = segment.endFraction - segment.startFraction
+        const runType = segment.runType
+
+        coverageByType[runType] = (coverageByType[runType] ?? 0) + segmentCoverage
+
+        if (!runIdsByType[runType]) {
+          runIdsByType[runType] = new Set()
+        }
+        runIdsByType[runType].add(segment.runId)
+      }
+    }
+  }
+
+  const stats: Record<string, RunTypeStats> = {}
+  for (const [runType, totalSegmentCoverage] of Object.entries(coverageByType)) {
+    stats[runType] = {
+      coverage: totalSegmentCoverage / TOTAL_CELLS,
+      activeSeconds: totalSegmentCoverage * SECONDS_PER_HOUR,
+      runCount: runIdsByType[runType]?.size ?? 0,
+    }
+  }
+
+  return stats
+}
+
+/**
+ * Calculates the total number of seconds of active play time across the grid.
+ * Each cell represents 1 hour, so coverage * 3600 = seconds active in that hour.
+ *
+ * @param grid - The heatmap grid to analyze
+ * @returns Total active seconds across all cells
+ */
+export function calculateTotalActiveSeconds(grid: HeatmapGrid): number {
+  let total = 0
+  for (const dayCells of grid.days) {
+    for (const cell of dayCells) {
+      total += cell.totalCoverage * SECONDS_PER_HOUR
+    }
+  }
+  return total
+}
+
+/**
+ * Calculates total idle (uncovered) seconds within the relevant time window.
+ * If active hours are enabled, only counts idle time within the active hours window.
+ * If active hours are disabled, counts idle time across all 168 hours.
+ *
+ * @param grid - The heatmap grid to analyze
+ * @param activeHours - Active hours configuration
+ * @returns Total idle seconds within the relevant window
+ */
+export function calculateTotalIdleSeconds(
+  grid: HeatmapGrid,
+  activeHours: ActiveHoursConfig
+): number {
+  let total = 0
+
+  for (const dayCells of grid.days) {
+    for (const cell of dayCells) {
+      if (activeHours.enabled) {
+        if (isHourInActiveWindow(cell.hour, activeHours.startHour, activeHours.endHour)) {
+          total += (1 - cell.totalCoverage) * SECONDS_PER_HOUR
+        }
+      } else {
+        total += (1 - cell.totalCoverage) * SECONDS_PER_HOUR
+      }
+    }
+  }
+
+  return total
+}
+
+/**
+ * Counts the number of unique runs represented in the grid.
+ * A run that spans multiple cells is counted only once.
+ *
+ * @param grid - The heatmap grid to analyze
+ * @returns Number of unique run IDs across all segments
+ */
+export function countRuns(grid: HeatmapGrid): number {
+  const runIds = new Set<string>()
+
+  for (const dayCells of grid.days) {
+    for (const cell of dayCells) {
+      for (const segment of cell.segments) {
+        runIds.add(segment.runId)
+      }
+    }
+  }
+
+  return runIds.size
+}
+
+/**
+ * Main entry point: computes all summary statistics from a heatmap grid.
+ * Delegates to individual calculation functions for each metric.
+ *
+ * @param grid - The heatmap grid to analyze
+ * @param activeHours - Active hours configuration for window-based calculations
+ * @returns Complete HeatmapSummary with all coverage metrics
+ */
+export function calculateHeatmapSummary(
+  grid: HeatmapGrid,
+  activeHours: ActiveHoursConfig
+): HeatmapSummary {
+  const overallCoverage = calculateOverallCoverage(grid)
+
+  return {
+    overallCoverage,
+    dailyCoverage: calculateDailyCoverage(grid),
+    activeHoursCoverage: activeHours.enabled
+      ? calculateActiveHoursCoverage(grid, activeHours.startHour, activeHours.endHour)
+      : overallCoverage,
+    runTypeBreakdown: calculateRunTypeBreakdown(grid),
+    runTypeStats: calculateRunTypeStats(grid),
+    totalActiveSeconds: calculateTotalActiveSeconds(grid),
+    totalIdleSeconds: calculateTotalIdleSeconds(grid, activeHours),
+    runCount: countRuns(grid),
+  }
+}

--- a/src/features/analysis/activity-heatmap/filters/heatmap-filters.tsx
+++ b/src/features/analysis/activity-heatmap/filters/heatmap-filters.tsx
@@ -1,0 +1,126 @@
+/**
+ * Heatmap Filters Component
+ *
+ * Filter bar for the Activity Heatmap feature. Renders tier selector,
+ * run type selector, and active hours configuration controls.
+ *
+ * Reuses shared TierSelector and RunTypeSelector components.
+ * Thin presentation shell — all filter state lives in the orchestration hook.
+ */
+
+import { TierSelector } from '@/shared/domain/filters/tier/tier-selector'
+import { RunTypeSelector } from '@/shared/domain/run-types/run-type-selector'
+import { FormControl, ToggleSwitch } from '@/components/ui'
+import type { TierFilter } from '@/shared/domain/filters/types'
+import type { RunTypeFilter } from '@/features/analysis/shared/filtering/run-type-filter'
+import type { ActiveHoursConfig } from '../types'
+import { formatHourOption } from '../grid/grid-labels'
+
+interface HeatmapFiltersProps {
+  selectedTier: TierFilter
+  onTierChange: (tier: TierFilter) => void
+  availableTiers: number[]
+  selectedRunType: RunTypeFilter
+  onRunTypeChange: (runType: RunTypeFilter) => void
+  activeHours: ActiveHoursConfig
+  onActiveHoursChange: (config: ActiveHoursConfig) => void
+}
+
+const HOUR_OPTIONS = Array.from({ length: 24 }, (_, i) => i)
+
+export function HeatmapFilters({
+  selectedTier,
+  onTierChange,
+  availableTiers,
+  selectedRunType,
+  onRunTypeChange,
+  activeHours,
+  onActiveHoursChange,
+}: HeatmapFiltersProps) {
+  return (
+    <div className="space-y-4">
+      {/* Row 1: Run Type & Tier */}
+      <div className="flex flex-wrap gap-4 items-end">
+        <RunTypeSelector
+          selectedType={selectedRunType}
+          onTypeChange={onRunTypeChange}
+          accentColor="orange"
+          layout="vertical"
+        />
+
+        <TierSelector
+          selectedTier={selectedTier}
+          onTierChange={onTierChange}
+          availableTiers={availableTiers}
+          accentColor="orange"
+          layout="vertical"
+        />
+      </div>
+
+      {/* Row 2: Active Hours */}
+      <ActiveHoursControls
+        activeHours={activeHours}
+        onChange={onActiveHoursChange}
+      />
+    </div>
+  )
+}
+
+interface ActiveHoursControlsProps {
+  activeHours: ActiveHoursConfig
+  onChange: (config: ActiveHoursConfig) => void
+}
+
+function ActiveHoursControls({ activeHours, onChange }: ActiveHoursControlsProps) {
+  return (
+    <div className="flex flex-wrap items-end gap-4">
+      <FormControl label="Active Hours" layout="vertical">
+        <div className="flex items-center gap-3">
+          <ToggleSwitch
+            checked={activeHours.enabled}
+            onCheckedChange={(enabled) => onChange({ ...activeHours, enabled })}
+            aria-label="Toggle active hours highlight"
+          />
+          {activeHours.enabled && (
+            <div className="flex items-center gap-1.5">
+              <HourSelect
+                value={activeHours.startHour}
+                onChange={(startHour) => onChange({ ...activeHours, startHour })}
+                ariaLabel="Active hours start"
+              />
+              <span className="text-xs text-slate-500">to</span>
+              <HourSelect
+                value={activeHours.endHour}
+                onChange={(endHour) => onChange({ ...activeHours, endHour })}
+                ariaLabel="Active hours end"
+              />
+            </div>
+          )}
+        </div>
+      </FormControl>
+    </div>
+  )
+}
+
+interface HourSelectProps {
+  value: number
+  onChange: (hour: number) => void
+  ariaLabel: string
+}
+
+function HourSelect({ value, onChange, ariaLabel }: HourSelectProps) {
+  return (
+    <select
+      value={value}
+      onChange={(e) => onChange(Number(e.target.value))}
+      aria-label={ariaLabel}
+      className="rounded border border-slate-600 bg-slate-700/60 px-2 py-1 text-xs text-slate-200 transition-colors focus-visible:border-amber-500/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/30 hover:border-slate-500"
+    >
+      {HOUR_OPTIONS.map((hour) => (
+        <option key={hour} value={hour}>
+          {formatHourOption(hour)}
+        </option>
+      ))}
+    </select>
+  )
+}

--- a/src/features/analysis/activity-heatmap/filters/run-filtering.test.ts
+++ b/src/features/analysis/activity-heatmap/filters/run-filtering.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Heatmap Run Filtering Tests
+ *
+ * Tests for the filterHeatmapRuns pure function.
+ */
+
+import { describe, it, expect } from 'vitest'
+import type { ParsedGameRun } from '@/shared/types/game-run.types'
+import type { RunTypeValue } from '@/shared/domain/run-types/types'
+import { filterHeatmapRuns } from './run-filtering'
+
+// ---------------------------------------------------------------------------
+// Test helper
+// ---------------------------------------------------------------------------
+
+let nextId = 1
+
+/**
+ * Creates a minimal ParsedGameRun for testing run filtering.
+ */
+function createTestRun(
+  tier: number,
+  runType: RunTypeValue,
+  overrides?: Partial<ParsedGameRun>
+): ParsedGameRun {
+  const defaults = {
+    id: `test-run-${nextId++}`,
+    timestamp: new Date(2026, 1, 25, 14, 0, 0),
+    realTime: 3600,
+    tier,
+    wave: 100,
+    coinsEarned: 1000,
+    cellsEarned: 10,
+    runType,
+    fields: {},
+  }
+  return { ...defaults, ...overrides } as ParsedGameRun
+}
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+function createMixedRuns(): ParsedGameRun[] {
+  return [
+    createTestRun(11, 'farm', { id: 't11-farm' }),
+    createTestRun(11, 'tournament', { id: 't11-tourney' }),
+    createTestRun(8, 'farm', { id: 't8-farm' }),
+    createTestRun(8, 'tournament', { id: 't8-tourney' }),
+    createTestRun(5, 'farm', { id: 't5-farm' }),
+  ]
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('run-filtering', () => {
+  describe('filterHeatmapRuns', () => {
+    it('should return all runs when tier=0 and runType=all', () => {
+      const runs = createMixedRuns()
+
+      const result = filterHeatmapRuns(runs, { tier: 0, runType: 'all' })
+
+      expect(result).toHaveLength(5)
+    })
+
+    it('should filter by specific tier', () => {
+      const runs = createMixedRuns()
+
+      const result = filterHeatmapRuns(runs, { tier: 11, runType: 'all' })
+
+      expect(result).toHaveLength(2)
+      expect(result.every((r) => r.tier === 11)).toBe(true)
+    })
+
+    it('should filter by specific run type', () => {
+      const runs = createMixedRuns()
+
+      const result = filterHeatmapRuns(runs, { tier: 0, runType: 'farm' })
+
+      expect(result).toHaveLength(3)
+      expect(result.every((r) => r.runType === 'farm')).toBe(true)
+    })
+
+    it('should combine tier and run type filters', () => {
+      const runs = createMixedRuns()
+
+      const result = filterHeatmapRuns(runs, { tier: 8, runType: 'tournament' })
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe('t8-tourney')
+    })
+
+    it('should return empty array when no matches', () => {
+      const runs = createMixedRuns()
+
+      const result = filterHeatmapRuns(runs, { tier: 5, runType: 'tournament' })
+
+      expect(result).toHaveLength(0)
+    })
+
+    it('should return empty array for empty input', () => {
+      const result = filterHeatmapRuns([], { tier: 0, runType: 'all' })
+
+      expect(result).toHaveLength(0)
+    })
+  })
+})

--- a/src/features/analysis/activity-heatmap/filters/run-filtering.ts
+++ b/src/features/analysis/activity-heatmap/filters/run-filtering.ts
@@ -1,0 +1,44 @@
+/**
+ * Heatmap Run Filtering
+ *
+ * Pure function for filtering game runs by tier and run type before
+ * building the activity heatmap grid. Reuses the shared filterRunsByType
+ * utility for run type filtering.
+ */
+
+import type { ParsedGameRun } from '@/shared/types/game-run.types'
+import type { RunTypeValue } from '@/shared/domain/run-types/types'
+import { filterRunsByType } from '@/features/analysis/shared/filtering/run-type-filter'
+
+/** Filter parameters for the heatmap run filter */
+interface HeatmapRunFilters {
+  /** Tier number to filter by; 0 means all tiers */
+  tier: number
+  /** Run type to filter by; 'all' means all run types */
+  runType: RunTypeValue | 'all'
+}
+
+/**
+ * Filters runs by tier and run type for the activity heatmap.
+ *
+ * Applies tier filter (0 = all tiers) and run type filter ('all' = all types).
+ * Reuses the shared filterRunsByType utility for run type filtering.
+ *
+ * @param runs - Array of parsed game runs to filter
+ * @param filters - Tier and run type filter criteria
+ * @returns Filtered array of runs matching both criteria
+ */
+export function filterHeatmapRuns(
+  runs: ParsedGameRun[],
+  filters: HeatmapRunFilters
+): ParsedGameRun[] {
+  // Apply run type filter using shared utility
+  const typeFiltered = filterRunsByType(runs, filters.runType)
+
+  // Apply tier filter (0 = all tiers)
+  if (filters.tier === 0) {
+    return typeFiltered
+  }
+
+  return typeFiltered.filter((run) => run.tier === filters.tier)
+}

--- a/src/features/analysis/activity-heatmap/grid/cell-rendering.test.ts
+++ b/src/features/analysis/activity-heatmap/grid/cell-rendering.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { CELL_BG_NORMAL, CELL_BG_ACTIVE, toPercent } from './cell-rendering'
+
+describe('cell background constants', () => {
+  it('exports CELL_BG_NORMAL as a hex color string', () => {
+    expect(CELL_BG_NORMAL).toMatch(/^#[0-9a-f]{6}$/i)
+  })
+
+  it('exports CELL_BG_ACTIVE as a hex color string', () => {
+    expect(CELL_BG_ACTIVE).toMatch(/^#[0-9a-f]{6}$/i)
+  })
+
+  it('CELL_BG_ACTIVE differs from CELL_BG_NORMAL', () => {
+    expect(CELL_BG_ACTIVE).not.toBe(CELL_BG_NORMAL)
+  })
+})
+
+describe('toPercent', () => {
+  it('converts 0 fraction to 0%', () => {
+    expect(toPercent(0)).toBe(0)
+  })
+
+  it('converts 1 fraction to 100%', () => {
+    expect(toPercent(1)).toBe(100)
+  })
+
+  it('converts 0.5 fraction to 50%', () => {
+    expect(toPercent(0.5)).toBe(50)
+  })
+
+  it('converts 0.25 fraction to 25%', () => {
+    expect(toPercent(0.25)).toBe(25)
+  })
+
+  it('rounds to 2 decimal places', () => {
+    // 0.333... * 10000 = 3333.33..., rounded = 3333, / 100 = 33.33
+    expect(toPercent(1 / 3)).toBe(33.33)
+  })
+
+  it('handles small fractions correctly', () => {
+    expect(toPercent(0.001)).toBe(0.1)
+  })
+})

--- a/src/features/analysis/activity-heatmap/grid/cell-rendering.ts
+++ b/src/features/analysis/activity-heatmap/grid/cell-rendering.ts
@@ -1,0 +1,30 @@
+/**
+ * Cell Rendering Utilities
+ *
+ * Constants and helpers for rendering heatmap grid cells.
+ * Provides opaque background colors for cell states and a fraction-to-percent
+ * converter for positioning segment elements within cells.
+ */
+
+/**
+ * Opaque dark background colors for heatmap cell states.
+ *
+ * Using `transparent` (which is `rgba(0,0,0,0)`) causes sub-pixel rendering
+ * artifacts at hard-stop boundaries — browsers anti-alias between
+ * fully-transparent-black and the opaque segment color, producing ghost
+ * slivers of color on both edges of partial cells.
+ *
+ * These opaque colors match the composited visual background of heatmap cells
+ * (page bg #0f172a -> bg-slate-800/20 container -> cell background layer).
+ */
+
+/** Effective color for normal (non-active-hour) cells. */
+export const CELL_BG_NORMAL = '#181d29'
+
+/** Effective color for active-hour cells (subtle amber tint). */
+export const CELL_BG_ACTIVE = '#1b202c'
+
+/** Convert a 0-1 fraction to a percentage with 2 decimal places. */
+export function toPercent(fraction: number): number {
+  return Math.round(fraction * 10000) / 100
+}

--- a/src/features/analysis/activity-heatmap/grid/cell-tooltip.tsx
+++ b/src/features/analysis/activity-heatmap/grid/cell-tooltip.tsx
@@ -1,0 +1,93 @@
+/**
+ * Cell Tooltip Component
+ *
+ * Displays detailed information about a hovered heatmap cell.
+ * Shows the date/time, coverage percentage, and segment breakdown.
+ * Uses the shared TooltipContentWrapper for consistent styling.
+ *
+ * Positioned as a fixed overlay anchored to the cell's DOM rect,
+ * with automatic viewport-edge detection to prevent overflow.
+ *
+ * Thin presentation shell — all data is pre-computed and passed as props.
+ */
+
+import type { HeatmapCell } from '../types'
+import { formatDisplayDate } from '@/shared/formatting/date-formatters'
+import { getRunTypeDisplayLabel } from '@/features/analysis/shared/filtering/run-type-filter'
+import { getRunTypeColor } from '@/shared/domain/run-types/run-type-display'
+import { TooltipContentWrapper } from '@/components/ui/tooltip-content'
+import { formatHourLabel } from './grid-labels'
+import { formatCoveragePercent, formatMinuteDisplay, sortSegmentsByTime } from '../summary-formatters'
+import type { RunTypeValue } from '@/shared/domain/run-types/types'
+
+interface CellTooltipProps {
+  cell: HeatmapCell
+  anchorRect: DOMRect | null
+}
+
+export function CellTooltip({ cell, anchorRect }: CellTooltipProps) {
+  if (!anchorRect) return null
+
+  const tooltipWidth = 260
+  const tooltipGap = 8
+
+  // Position above the cell by default; flip below if near top of viewport
+  const positionAbove = anchorRect.top > 160
+  const top = positionAbove
+    ? anchorRect.top - tooltipGap
+    : anchorRect.bottom + tooltipGap
+
+  // Center horizontally on the cell, clamp to viewport edges
+  const rawLeft = anchorRect.left + anchorRect.width / 2 - tooltipWidth / 2
+  const left = Math.max(8, Math.min(rawLeft, window.innerWidth - tooltipWidth - 8))
+
+  return (
+    <div
+      className="pointer-events-none fixed z-50"
+      style={{
+        top,
+        left,
+        width: tooltipWidth,
+        transform: positionAbove ? 'translateY(-100%)' : undefined,
+      }}
+      role="tooltip"
+    >
+      <TooltipContentWrapper variant="detailed" className="shadow-2xl backdrop-blur-md">
+        <div className="space-y-2">
+          {/* Date & time header */}
+          <div className="border-b border-slate-700/80 pb-2 text-xs font-medium text-slate-300">
+            {formatDisplayDate(cell.date)} — {formatHourLabel(cell.hour)}
+          </div>
+
+          {/* Coverage percentage */}
+          <div className="text-sm font-semibold text-white">
+            {formatCoveragePercent(cell.totalCoverage)} coverage
+          </div>
+
+          {/* Segment breakdown */}
+          {cell.segments.length > 0 && (
+            <div className="space-y-1.5 pt-0.5">
+              {sortSegmentsByTime(cell.segments).map((segment, index) => (
+                <div key={index} className="flex items-center gap-2 text-xs text-slate-300">
+                  <span
+                    className="inline-block h-2 w-2 shrink-0 rounded-full"
+                    style={{ backgroundColor: getRunTypeColor(segment.runType) }}
+                  />
+                  <span>{getRunTypeDisplayLabel(segment.runType as RunTypeValue)}</span>
+                  <span className="text-slate-500">T{segment.tier}</span>
+                  <span className="ml-auto tabular-nums text-slate-400">
+                    {formatMinuteDisplay(segment.startFraction)}&ndash;{formatMinuteDisplay(segment.endFraction)}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {cell.segments.length === 0 && (
+            <div className="text-xs text-slate-500">No activity</div>
+          )}
+        </div>
+      </TooltipContentWrapper>
+    </div>
+  )
+}

--- a/src/features/analysis/activity-heatmap/grid/grid-labels.test.ts
+++ b/src/features/analysis/activity-heatmap/grid/grid-labels.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/shared/locale/locale-store', () => ({
+  getDisplayLocale: () => 'en-US',
+}))
+
+import { formatDayHeaderLabel, formatHourLabel, formatHourOption, isHourActive } from './grid-labels'
+
+describe('formatDayHeaderLabel', () => {
+  it('returns weekday and day for first day of week', () => {
+    // Sunday Jan 7, 2024
+    const weekStart = new Date(2024, 0, 7)
+    const result = formatDayHeaderLabel(0, weekStart)
+    expect(result).toContain('Sun')
+    expect(result).toContain('7')
+  })
+
+  it('returns weekday and day for last day of week', () => {
+    // Sunday Jan 7 → Saturday Jan 13
+    const weekStart = new Date(2024, 0, 7)
+    const result = formatDayHeaderLabel(6, weekStart)
+    expect(result).toContain('Sat')
+    expect(result).toContain('13')
+  })
+
+  it('returns empty string for negative index', () => {
+    expect(formatDayHeaderLabel(-1, new Date())).toBe('')
+  })
+
+  it('returns empty string for index > 6', () => {
+    expect(formatDayHeaderLabel(7, new Date())).toBe('')
+  })
+
+  it('handles month boundary correctly', () => {
+    // Sunday Jan 28, 2024 → dayIndex 5 = Friday Feb 2
+    const weekStart = new Date(2024, 0, 28)
+    const result = formatDayHeaderLabel(5, weekStart)
+    expect(result).toContain('Fri')
+    expect(result).toContain('2')
+  })
+
+  it('produces unique labels for all 7 days', () => {
+    const weekStart = new Date(2024, 0, 7)
+    const labels = Array.from({ length: 7 }, (_, i) => formatDayHeaderLabel(i, weekStart))
+    const unique = new Set(labels)
+    expect(unique.size).toBe(7)
+  })
+})
+
+describe('isHourActive', () => {
+  it('returns false when disabled regardless of hour', () => {
+    expect(isHourActive(10, 8, 23, false)).toBe(false)
+    expect(isHourActive(0, 0, 24, false)).toBe(false)
+  })
+
+  describe('standard range (startHour < endHour)', () => {
+    it('returns true for hour within range', () => {
+      expect(isHourActive(10, 8, 23, true)).toBe(true)
+    })
+
+    it('returns false for hour outside range', () => {
+      expect(isHourActive(5, 8, 23, true)).toBe(false)
+    })
+
+    it('includes startHour (inclusive)', () => {
+      expect(isHourActive(8, 8, 23, true)).toBe(true)
+    })
+
+    it('excludes endHour (exclusive)', () => {
+      expect(isHourActive(23, 8, 23, true)).toBe(false)
+    })
+  })
+
+  describe('overnight range (startHour >= endHour)', () => {
+    it('returns true for hour after startHour', () => {
+      expect(isHourActive(23, 22, 6, true)).toBe(true)
+    })
+
+    it('returns true for hour before endHour', () => {
+      expect(isHourActive(3, 22, 6, true)).toBe(true)
+    })
+
+    it('returns false for hour in the gap', () => {
+      expect(isHourActive(10, 22, 6, true)).toBe(false)
+    })
+
+    it('includes startHour (inclusive)', () => {
+      expect(isHourActive(22, 22, 6, true)).toBe(true)
+    })
+
+    it('excludes endHour (exclusive)', () => {
+      expect(isHourActive(6, 22, 6, true)).toBe(false)
+    })
+  })
+})
+
+describe('formatHourLabel', () => {
+  it('returns a non-empty string for hour 0', () => {
+    expect(formatHourLabel(0).length).toBeGreaterThan(0)
+  })
+
+  it('returns a non-empty string for hour 12', () => {
+    expect(formatHourLabel(12).length).toBeGreaterThan(0)
+  })
+
+  it('returns a non-empty string for hour 23', () => {
+    expect(formatHourLabel(23).length).toBeGreaterThan(0)
+  })
+
+  it('produces different labels for different hours', () => {
+    const label0 = formatHourLabel(0)
+    const label12 = formatHourLabel(12)
+    const label6 = formatHourLabel(6)
+
+    expect(label0).not.toBe(label12)
+    expect(label0).not.toBe(label6)
+    expect(label12).not.toBe(label6)
+  })
+})
+
+describe('formatHourOption', () => {
+  it('returns a non-empty string for hour 0', () => {
+    expect(formatHourOption(0).length).toBeGreaterThan(0)
+  })
+
+  it('includes minutes in the output', () => {
+    // The option format includes minutes (e.g., "2:00 PM" or "14:00")
+    const result = formatHourOption(14)
+    expect(result).toContain('00')
+  })
+
+  it('produces different labels for different hours', () => {
+    const option0 = formatHourOption(0)
+    const option12 = formatHourOption(12)
+    const option6 = formatHourOption(6)
+
+    expect(option0).not.toBe(option12)
+    expect(option0).not.toBe(option6)
+    expect(option12).not.toBe(option6)
+  })
+
+  it('produces all 24 unique labels', () => {
+    const labels = Array.from({ length: 24 }, (_, i) => formatHourOption(i))
+    const unique = new Set(labels)
+    expect(unique.size).toBe(24)
+  })
+})

--- a/src/features/analysis/activity-heatmap/grid/grid-labels.ts
+++ b/src/features/analysis/activity-heatmap/grid/grid-labels.ts
@@ -1,0 +1,70 @@
+/**
+ * Grid Label Formatting
+ *
+ * Pure functions for generating locale-aware hour and day labels
+ * used by the heatmap grid component.
+ */
+
+import { getDisplayLocale } from '@/shared/locale/locale-store'
+import { isHourInActiveWindow } from '../calculations/heatmap-statistics'
+
+/**
+ * Format an hour (0-23) as a locale-aware time label.
+ * Uses Intl.DateTimeFormat for consistent 12h/24h display.
+ *
+ * @example
+ *   formatHourLabel(0)  // "12 AM" (en-US) or "00:00" (de-DE)
+ *   formatHourLabel(14) // "2 PM" (en-US) or "14:00" (de-DE)
+ */
+export function formatHourLabel(hour: number): string {
+  const date = new Date(2000, 0, 1, hour, 0, 0)
+  return new Intl.DateTimeFormat(getDisplayLocale(), {
+    hour: 'numeric',
+  }).format(date)
+}
+
+/**
+ * Format day header with weekday abbreviation and day-of-month.
+ * Combines locale-aware weekday name with the numeric day.
+ *
+ * @param dayIndex - Grid column index (0=Sun, 6=Sat)
+ * @param weekStart - The start date (Sunday) of the current week
+ * @returns Formatted string like "Sun 22" (en-US) or "So 22." (de-DE)
+ */
+export function formatDayHeaderLabel(dayIndex: number, weekStart: Date): string {
+  if (dayIndex < 0 || dayIndex > 6) return ''
+
+  const date = new Date(weekStart)
+  date.setDate(date.getDate() + dayIndex)
+
+  return new Intl.DateTimeFormat(getDisplayLocale(), {
+    weekday: 'short',
+    day: 'numeric',
+  }).format(date)
+}
+
+/**
+ * Checks whether a given hour falls within the active hours window.
+ * Returns false when the active hours feature is disabled.
+ * Delegates core logic to isHourInActiveWindow in the calculations layer.
+ */
+export function isHourActive(hour: number, startHour: number, endHour: number, enabled: boolean): boolean {
+  if (!enabled) return false
+  return isHourInActiveWindow(hour, startHour, endHour)
+}
+
+/**
+ * Format an hour (0-23) as a user-friendly label for select dropdowns.
+ * Includes minutes for explicit selection (e.g., "2:00 PM" or "14:00").
+ *
+ * @example
+ *   formatHourOption(0)  // "12:00 AM" (en-US) or "00:00" (de-DE)
+ *   formatHourOption(14) // "2:00 PM" (en-US) or "14:00" (de-DE)
+ */
+export function formatHourOption(hour: number): string {
+  const date = new Date(2000, 0, 1, hour, 0, 0)
+  return new Intl.DateTimeFormat(getDisplayLocale(), {
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(date)
+}

--- a/src/features/analysis/activity-heatmap/grid/heatmap-grid.tsx
+++ b/src/features/analysis/activity-heatmap/grid/heatmap-grid.tsx
@@ -1,0 +1,169 @@
+/**
+ * Heatmap Grid
+ *
+ * Renders the 24x7 (hours x days) activity grid. Each cell displays
+ * colored segments representing game run coverage within that hour slot.
+ *
+ * Thin presentation shell — grid data, label formatting, and segment
+ * colors are delegated to pure functions and the orchestration hook.
+ */
+
+import type { HeatmapGrid, HeatmapCell, ActiveHoursConfig } from '../types'
+import { CELL_BG_NORMAL, CELL_BG_ACTIVE, toPercent } from './cell-rendering'
+import { formatHourLabel, formatDayHeaderLabel, isHourActive } from './grid-labels'
+import { formatCoveragePercent } from '../summary-formatters'
+import { getRunTypeColor } from '@/shared/domain/run-types/run-type-display'
+
+interface HeatmapGridComponentProps {
+  grid: HeatmapGrid
+  activeHours: ActiveHoursConfig
+  hoveredCell: HeatmapCell | null
+  onCellHover: (cell: HeatmapCell | null, anchorRect?: DOMRect | null) => void
+  dailyCoverage?: number[]
+}
+
+export function HeatmapGridComponent({
+  grid,
+  activeHours,
+  hoveredCell,
+  onCellHover,
+  dailyCoverage,
+}: HeatmapGridComponentProps) {
+  return (
+    <div className="overflow-x-auto rounded-lg border border-slate-700/50 bg-slate-800/20 p-3 sm:p-4">
+      <table className="w-full border-collapse" role="grid" aria-label="Activity heatmap grid">
+        <thead>
+          <tr>
+            {/* Empty corner cell */}
+            <th className="w-14 p-0 sm:w-16" aria-hidden="true" />
+            {/* Day headers with weekday + date */}
+            {Array.from({ length: 7 }, (_, dayIndex) => (
+              <th
+                key={dayIndex}
+                className="px-0.5 pb-1 text-center text-[0.65rem] font-medium text-slate-400 sm:px-1 sm:text-xs"
+              >
+                {formatDayHeaderLabel(dayIndex, grid.weekStart)}
+              </th>
+            ))}
+          </tr>
+          {dailyCoverage && (
+            <tr>
+              <th className="w-14 p-0 sm:w-16" aria-hidden="true" />
+              {dailyCoverage.map((coverage, dayIndex) => (
+                <th
+                  key={dayIndex}
+                  className="px-0.5 pb-1.5 text-center text-[0.625rem] tabular-nums text-amber-400/70 sm:text-[0.7rem]"
+                  aria-label={`${formatDayHeaderLabel(dayIndex, grid.weekStart)} coverage: ${formatCoveragePercent(coverage)}`}
+                >
+                  {formatCoveragePercent(coverage)}
+                </th>
+              ))}
+            </tr>
+          )}
+        </thead>
+        <tbody>
+          {Array.from({ length: 24 }, (_, hour) => (
+            <HeatmapRow
+              key={hour}
+              hour={hour}
+              grid={grid}
+              activeHours={activeHours}
+              hoveredCell={hoveredCell}
+              onCellHover={onCellHover}
+            />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+interface HeatmapRowProps {
+  hour: number
+  grid: HeatmapGrid
+  activeHours: ActiveHoursConfig
+  hoveredCell: HeatmapCell | null
+  onCellHover: (cell: HeatmapCell | null, anchorRect?: DOMRect | null) => void
+}
+
+function HeatmapRow({ hour, grid, activeHours, hoveredCell, onCellHover }: HeatmapRowProps) {
+  const active = isHourActive(hour, activeHours.startHour, activeHours.endHour, activeHours.enabled)
+
+  return (
+    <tr>
+      {/* Hour label */}
+      <td
+        className={`pr-1.5 text-right text-[0.65rem] tabular-nums sm:pr-2 sm:text-xs ${active ? 'font-medium text-amber-400/80' : 'text-slate-500'}`}
+      >
+        {formatHourLabel(hour)}
+      </td>
+
+      {/* Day cells */}
+      {Array.from({ length: 7 }, (_, dayIndex) => {
+        const cell = grid.days[dayIndex][hour]
+        return (
+          <HeatmapCellComponent
+            key={dayIndex}
+            cell={cell}
+            isActiveHour={active}
+            isHovered={hoveredCell === cell}
+            onHover={onCellHover}
+          />
+        )
+      })}
+    </tr>
+  )
+}
+
+interface HeatmapCellComponentProps {
+  cell: HeatmapCell
+  isActiveHour: boolean
+  isHovered: boolean
+  onHover: (cell: HeatmapCell | null, anchorRect?: DOMRect | null) => void
+}
+
+function getCellBorderClass(isHovered: boolean, isActiveHour: boolean): string {
+  if (isHovered) return 'border-amber-400 ring-2 ring-amber-400/30'
+  if (isActiveHour) return 'border-amber-500/20'
+  return 'border-slate-700/40'
+}
+
+/** Returns the opaque solid background color for a cell based on active-hour state. */
+function getCellBackgroundColor(isActiveHour: boolean): string {
+  return isActiveHour ? CELL_BG_ACTIVE : CELL_BG_NORMAL
+}
+
+function HeatmapCellComponent({ cell, isActiveHour, isHovered, onHover }: HeatmapCellComponentProps) {
+  const hasSegments = cell.segments.length > 0
+  const bgColor = getCellBackgroundColor(isActiveHour)
+  const borderClass = getCellBorderClass(isHovered, isActiveHour)
+
+  return (
+    <td
+      className={`p-0.5 outline-none focus-visible:ring-2 focus-visible:ring-amber-400/40 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900 rounded-sm ${hasSegments ? 'cursor-pointer' : ''}`}
+      tabIndex={hasSegments ? 0 : -1}
+      aria-label={`${cell.segments.length} segment${cell.segments.length !== 1 ? 's' : ''}, ${formatCoveragePercent(cell.totalCoverage)} coverage`}
+      onMouseEnter={(e) => onHover(cell, (e.currentTarget as HTMLElement).getBoundingClientRect())}
+      onMouseLeave={() => onHover(null)}
+      onFocus={(e) => onHover(cell, (e.currentTarget as HTMLElement).getBoundingClientRect())}
+      onBlur={() => onHover(null)}
+    >
+      <div
+        className={`relative h-5 min-w-5 overflow-hidden rounded-sm border transition-colors duration-100 sm:h-6 sm:min-w-6 ${borderClass}`}
+        style={{ backgroundColor: bgColor }}
+      >
+        {hasSegments && cell.segments.map((segment, index) => (
+          <div
+            key={index}
+            className="absolute inset-y-0"
+            style={{
+              left: `${toPercent(segment.startFraction)}%`,
+              width: `${toPercent(segment.endFraction - segment.startFraction)}%`,
+              backgroundColor: getRunTypeColor(segment.runType),
+            }}
+          />
+        ))}
+      </div>
+    </td>
+  )
+}

--- a/src/features/analysis/activity-heatmap/heatmap-summary-bar.tsx
+++ b/src/features/analysis/activity-heatmap/heatmap-summary-bar.tsx
@@ -1,0 +1,82 @@
+/**
+ * Heatmap Summary Bar Component
+ *
+ * Displays key statistics for the current week's heatmap in a compact
+ * horizontal bar with middot separators. Thin presentation shell — formatting
+ * is delegated to summary-formatters.ts, co-located at the feature root.
+ */
+
+import type { RunTypeFilter } from '@/features/analysis/shared/filtering/run-type-filter'
+import type { HeatmapSummary } from './types'
+import { buildSummaryEntries, buildRunTypeBreakdownEntries } from './summary-formatters'
+import type { SummaryEntry, RunTypeBreakdownGroup } from './summary-formatters'
+
+interface HeatmapSummaryBarProps {
+  summary: HeatmapSummary
+  activeHoursEnabled: boolean
+  selectedRunType: RunTypeFilter
+}
+
+function SummaryEntryRow({ entries }: { entries: SummaryEntry[] }) {
+  return (
+    <div className="flex flex-wrap items-center gap-x-2 gap-y-2">
+      {entries.map((entry, index) => (
+        <span key={entry.label} className="flex items-baseline gap-1.5">
+          {index > 0 && (
+            <span className="text-slate-600" aria-hidden="true">&middot;</span>
+          )}
+          <span className="text-xs">{entry.label}</span>
+          <span className="tabular-nums font-medium text-amber-400">{entry.value}</span>
+        </span>
+      ))}
+    </div>
+  )
+}
+
+function BreakdownGroup({ group }: { group: RunTypeBreakdownGroup }) {
+  return (
+    <div className="flex flex-wrap items-center gap-x-2 gap-y-2">
+      <span className="flex items-center gap-1.5">
+        <span
+          className="inline-block h-2 w-2 shrink-0 rounded-full"
+          style={{ backgroundColor: group.color }}
+          aria-hidden="true"
+        />
+        <span className="text-xs font-medium text-slate-300">{group.label}</span>
+      </span>
+      {group.entries.map((entry) => (
+        <span key={entry.label} className="flex items-baseline gap-1.5">
+          <span className="text-slate-600" aria-hidden="true">&middot;</span>
+          <span className="text-xs">{entry.label}</span>
+          <span className="tabular-nums font-medium text-amber-400">{entry.value}</span>
+        </span>
+      ))}
+    </div>
+  )
+}
+
+export function HeatmapSummaryBar({ summary, activeHoursEnabled, selectedRunType }: HeatmapSummaryBarProps) {
+  const entries = buildSummaryEntries(summary, activeHoursEnabled)
+  const breakdownGroups = selectedRunType === 'all'
+    ? buildRunTypeBreakdownEntries(summary)
+    : []
+
+  return (
+    <div
+      className="space-y-2 rounded-lg border border-slate-700/50 bg-slate-800/30 px-4 py-3 text-sm text-slate-400"
+      role="status"
+      aria-live="polite"
+      aria-label="Weekly summary statistics"
+    >
+      <SummaryEntryRow entries={entries} />
+
+      {breakdownGroups.length > 0 && (
+        <div className="space-y-1 border-t border-slate-700/30 pt-2">
+          {breakdownGroups.map((group) => (
+            <BreakdownGroup key={group.runType} group={group} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/features/analysis/activity-heatmap/navigation/use-week-navigation.ts
+++ b/src/features/analysis/activity-heatmap/navigation/use-week-navigation.ts
@@ -1,0 +1,105 @@
+/**
+ * Week Navigation Hook
+ *
+ * Manages week selection state and navigation (prev/next/latest) for the
+ * activity heatmap. Derives available weeks from runs and auto-selects
+ * the most recent week on initialization.
+ */
+
+import { useState, useMemo, useCallback, useEffect, useRef } from 'react'
+import type { ParsedGameRun } from '@/shared/types/game-run.types'
+import type { WeekInfo } from '../types'
+import { deriveAvailableWeeks, getDefaultWeek, canNavigateNext, canNavigatePrev } from './week-navigation'
+import { isSameWeek } from '../week-utils'
+
+export interface UseWeekNavigationReturn {
+  selectedWeek: WeekInfo | null
+  availableWeeks: WeekInfo[]
+  canGoNext: boolean
+  canGoPrev: boolean
+  onPrevWeek: () => void
+  onNextWeek: () => void
+  onGoToLatest: () => void
+}
+
+/**
+ * Hook for week navigation state derived from all runs.
+ * Available weeks are derived from unfiltered runs so navigation
+ * remains stable regardless of filter changes.
+ */
+export function useWeekNavigation(runs: ParsedGameRun[]): UseWeekNavigationReturn {
+  const [selectedWeek, setSelectedWeek] = useState<WeekInfo | null>(null)
+  const initializedRef = useRef(false)
+
+  // Derive available weeks from ALL runs (unfiltered)
+  const availableWeeks = useMemo(
+    () => deriveAvailableWeeks(runs),
+    [runs]
+  )
+
+  // Auto-select default week when availableWeeks changes
+  useEffect(() => {
+    if (availableWeeks.length === 0) {
+      setSelectedWeek(null)
+      initializedRef.current = false
+      return
+    }
+
+    if (!initializedRef.current) {
+      setSelectedWeek(getDefaultWeek(availableWeeks))
+      initializedRef.current = true
+      return
+    }
+
+    if (selectedWeek && !availableWeeks.some(w => isSameWeek(w.weekStart, selectedWeek.weekStart))) {
+      setSelectedWeek(getDefaultWeek(availableWeeks))
+    }
+  }, [availableWeeks, selectedWeek])
+
+  const canGoNext = useMemo(() => {
+    if (!selectedWeek) return false
+    return canNavigateNext(selectedWeek.weekStart, availableWeeks)
+  }, [selectedWeek, availableWeeks])
+
+  const canGoPrev = useMemo(() => {
+    if (!selectedWeek) return false
+    return canNavigatePrev(selectedWeek.weekStart, availableWeeks)
+  }, [selectedWeek, availableWeeks])
+
+  const onNextWeek = useCallback(() => {
+    if (!selectedWeek || !canGoNext) return
+    const currentIndex = availableWeeks.findIndex(
+      w => isSameWeek(w.weekStart, selectedWeek.weekStart)
+    )
+    if (currentIndex > 0) {
+      setSelectedWeek(availableWeeks[currentIndex - 1])
+    }
+  }, [selectedWeek, canGoNext, availableWeeks])
+
+  const onPrevWeek = useCallback(() => {
+    if (!selectedWeek || !canGoPrev) return
+    const currentIndex = availableWeeks.findIndex(
+      w => isSameWeek(w.weekStart, selectedWeek.weekStart)
+    )
+    if (currentIndex >= 0 && currentIndex < availableWeeks.length - 1) {
+      setSelectedWeek(availableWeeks[currentIndex + 1])
+    }
+  }, [selectedWeek, canGoPrev, availableWeeks])
+
+  const onGoToLatest = useCallback(() => {
+    const latest = getDefaultWeek(availableWeeks)
+    if (latest) {
+      setSelectedWeek(latest)
+    }
+  }, [availableWeeks])
+
+  return {
+    selectedWeek,
+    availableWeeks,
+    canGoNext,
+    canGoPrev,
+    onPrevWeek,
+    onNextWeek,
+    onGoToLatest,
+  }
+}

--- a/src/features/analysis/activity-heatmap/navigation/week-navigation.test.ts
+++ b/src/features/analysis/activity-heatmap/navigation/week-navigation.test.ts
@@ -1,0 +1,314 @@
+/**
+ * Week Navigation Tests
+ *
+ * Tests for week navigation pure functions used by the activity heatmap.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import type { ParsedGameRun } from '@/shared/types/game-run.types'
+import {
+  deriveAvailableWeeks,
+  getDefaultWeek,
+  canNavigateNext,
+  canNavigatePrev,
+  getRunsForWeek,
+} from './week-navigation'
+
+// ---------------------------------------------------------------------------
+// Mock formatWeekOfLabel to avoid locale store dependency in unit tests
+// ---------------------------------------------------------------------------
+vi.mock('@/shared/formatting/date-formatters', () => ({
+  formatWeekOfLabel: (date: Date) => {
+    const m = date.getMonth() + 1
+    const d = date.getDate()
+    return `Week of ${m}/${d}`
+  },
+}))
+
+// ---------------------------------------------------------------------------
+// Test helper
+// ---------------------------------------------------------------------------
+
+let nextId = 1
+
+/**
+ * Creates a minimal ParsedGameRun for testing week navigation.
+ *
+ * @param endTime - The run's end timestamp
+ * @param durationSeconds - Duration in seconds (used as realTime)
+ * @param overrides - Optional field overrides
+ */
+function createTestRun(
+  endTime: Date,
+  durationSeconds: number,
+  overrides?: Partial<ParsedGameRun>
+): ParsedGameRun {
+  const defaults = {
+    id: `test-run-${nextId++}`,
+    timestamp: endTime,
+    realTime: durationSeconds,
+    tier: 1,
+    wave: 100,
+    coinsEarned: 1000,
+    cellsEarned: 10,
+    runType: 'farm' as const,
+    fields: {},
+  }
+  return { ...defaults, ...overrides } as ParsedGameRun
+}
+
+// ---------------------------------------------------------------------------
+// Shared week boundaries (Sunday-based)
+// ---------------------------------------------------------------------------
+// 2026-02-22 is a Sunday
+// Week 1: Sun Feb 22 - Sat Feb 28
+// Week 2: Sun Mar 1 - Sat Mar 7
+// Week 3: Sun Mar 8 - Sat Mar 14
+
+const WEEK1_START = new Date(2026, 1, 22, 0, 0, 0, 0) // Sun Feb 22
+const WEEK2_START = new Date(2026, 2, 1, 0, 0, 0, 0) // Sun Mar 1
+const WEEK3_START = new Date(2026, 2, 8, 0, 0, 0, 0) // Sun Mar 8
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('week-navigation', () => {
+  // -------------------------------------------------------------------------
+  // deriveAvailableWeeks
+  // -------------------------------------------------------------------------
+  describe('deriveAvailableWeeks', () => {
+    it('should return empty array for empty runs', () => {
+      const result = deriveAvailableWeeks([])
+
+      expect(result).toEqual([])
+    })
+
+    it('should return one week for a single run', () => {
+      // Run on Wed Feb 25 (within Week 1: Sun Feb 22 - Sat Feb 28)
+      const run = createTestRun(
+        new Date(2026, 1, 25, 14, 0, 0), // Wed Feb 25 14:00
+        3600 // 1 hour
+      )
+
+      const result = deriveAvailableWeeks([run])
+
+      expect(result).toHaveLength(1)
+      expect(result[0].weekStart).toEqual(WEEK1_START)
+      expect(result[0].weekLabel).toBe('Week of 2/22')
+    })
+
+    it('should return 3 WeekInfos for runs spanning 3 weeks, newest first', () => {
+      const runWeek1 = createTestRun(
+        new Date(2026, 1, 25, 14, 0, 0), // Wed Feb 25 (Week 1)
+        3600
+      )
+      const runWeek2 = createTestRun(
+        new Date(2026, 2, 4, 10, 0, 0), // Wed Mar 4 (Week 2)
+        3600
+      )
+      const runWeek3 = createTestRun(
+        new Date(2026, 2, 11, 10, 0, 0), // Wed Mar 11 (Week 3)
+        3600
+      )
+
+      const result = deriveAvailableWeeks([runWeek1, runWeek2, runWeek3])
+
+      expect(result).toHaveLength(3)
+      // Newest first
+      expect(result[0].weekStart).toEqual(WEEK3_START)
+      expect(result[1].weekStart).toEqual(WEEK2_START)
+      expect(result[2].weekStart).toEqual(WEEK1_START)
+    })
+
+    it('should return single WeekInfo for multiple runs in same week', () => {
+      const run1 = createTestRun(
+        new Date(2026, 1, 23, 12, 0, 0), // Mon Feb 23 12:00
+        3600
+      )
+      const run2 = createTestRun(
+        new Date(2026, 1, 25, 15, 0, 0), // Wed Feb 25 15:00
+        3600
+      )
+      const run3 = createTestRun(
+        new Date(2026, 1, 28, 20, 0, 0), // Sat Feb 28 20:00
+        3600
+      )
+
+      const result = deriveAvailableWeeks([run1, run2, run3])
+
+      expect(result).toHaveLength(1)
+      expect(result[0].weekStart).toEqual(WEEK1_START)
+    })
+
+    it('should include weeks for runs that span week boundaries', () => {
+      // Run that starts in Week 1 (Sat Feb 28) and ends in Week 2 (Sun Mar 1)
+      // End time: Sun Mar 1 at 02:00, duration: 6 hours => starts Sat Feb 28 at 20:00
+      const boundaryRun = createTestRun(
+        new Date(2026, 2, 1, 2, 0, 0), // Sun Mar 1 02:00 (Week 2)
+        6 * 3600 // 6 hours => starts Sat Feb 28 20:00 (Week 1)
+      )
+
+      const result = deriveAvailableWeeks([boundaryRun])
+
+      // Should include both Week 1 (start time) and Week 2 (end time)
+      expect(result).toHaveLength(2)
+      expect(result[0].weekStart).toEqual(WEEK2_START) // newest first
+      expect(result[1].weekStart).toEqual(WEEK1_START)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // getDefaultWeek
+  // -------------------------------------------------------------------------
+  describe('getDefaultWeek', () => {
+    it('should return first (newest) week', () => {
+      const weeks = [
+        { weekStart: WEEK3_START, weekLabel: 'Week of 3/8' },
+        { weekStart: WEEK2_START, weekLabel: 'Week of 3/1' },
+        { weekStart: WEEK1_START, weekLabel: 'Week of 2/22' },
+      ]
+
+      const result = getDefaultWeek(weeks)
+
+      expect(result).not.toBeNull()
+      expect(result!.weekStart).toEqual(WEEK3_START)
+    })
+
+    it('should return null for empty array', () => {
+      const result = getDefaultWeek([])
+
+      expect(result).toBeNull()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // canNavigateNext / canNavigatePrev
+  // -------------------------------------------------------------------------
+  describe('canNavigateNext', () => {
+    const weeks = [
+      { weekStart: WEEK3_START, weekLabel: 'Week of 3/8' },
+      { weekStart: WEEK2_START, weekLabel: 'Week of 3/1' },
+      { weekStart: WEEK1_START, weekLabel: 'Week of 2/22' },
+    ]
+
+    it('should return false when at the newest week', () => {
+      expect(canNavigateNext(WEEK3_START, weeks)).toBe(false)
+    })
+
+    it('should return true when at the middle week', () => {
+      expect(canNavigateNext(WEEK2_START, weeks)).toBe(true)
+    })
+
+    it('should return true when at the oldest week', () => {
+      expect(canNavigateNext(WEEK1_START, weeks)).toBe(true)
+    })
+
+    it('should return false for empty available weeks', () => {
+      expect(canNavigateNext(WEEK1_START, [])).toBe(false)
+    })
+  })
+
+  describe('canNavigatePrev', () => {
+    const weeks = [
+      { weekStart: WEEK3_START, weekLabel: 'Week of 3/8' },
+      { weekStart: WEEK2_START, weekLabel: 'Week of 3/1' },
+      { weekStart: WEEK1_START, weekLabel: 'Week of 2/22' },
+    ]
+
+    it('should return false when at the oldest week', () => {
+      expect(canNavigatePrev(WEEK1_START, weeks)).toBe(false)
+    })
+
+    it('should return true when at the middle week', () => {
+      expect(canNavigatePrev(WEEK2_START, weeks)).toBe(true)
+    })
+
+    it('should return true when at the newest week', () => {
+      expect(canNavigatePrev(WEEK3_START, weeks)).toBe(true)
+    })
+
+    it('should return false for empty available weeks', () => {
+      expect(canNavigatePrev(WEEK1_START, [])).toBe(false)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // getRunsForWeek
+  // -------------------------------------------------------------------------
+  describe('getRunsForWeek', () => {
+    it('should return only runs overlapping the week', () => {
+      // Run in Week 1
+      const runWeek1 = createTestRun(
+        new Date(2026, 1, 25, 14, 0, 0), // Wed Feb 25 14:00
+        3600,
+        { id: 'week1-run' }
+      )
+      // Run in Week 2
+      const runWeek2 = createTestRun(
+        new Date(2026, 2, 4, 10, 0, 0), // Wed Mar 4 10:00
+        3600,
+        { id: 'week2-run' }
+      )
+
+      const result = getRunsForWeek([runWeek1, runWeek2], WEEK1_START)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe('week1-run')
+    })
+
+    it('should include runs that partially overlap (start before week, end during)', () => {
+      // Run starts before Week 2 (Sat Feb 28 at 22:00) and ends during Week 2 (Sun Mar 1 at 02:00)
+      // End: Sun Mar 1 02:00, duration: 4 hours => start: Sat Feb 28 22:00 (Week 1)
+      const partialRun = createTestRun(
+        new Date(2026, 2, 1, 2, 0, 0), // Sun Mar 1 02:00
+        4 * 3600, // 4 hours => starts Sat Feb 28 22:00
+        { id: 'partial-overlap' }
+      )
+
+      const result = getRunsForWeek([partialRun], WEEK2_START)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe('partial-overlap')
+    })
+
+    it('should exclude runs entirely outside the week', () => {
+      // Run entirely in Week 3
+      const runWeek3 = createTestRun(
+        new Date(2026, 2, 11, 14, 0, 0), // Wed Mar 11 14:00
+        3600,
+        { id: 'week3-run' }
+      )
+
+      const result = getRunsForWeek([runWeek3], WEEK1_START)
+
+      expect(result).toHaveLength(0)
+    })
+
+    it('should return empty array for empty runs', () => {
+      const result = getRunsForWeek([], WEEK1_START)
+
+      expect(result).toHaveLength(0)
+    })
+
+    it('should include runs that start during week and end after week', () => {
+      // Run starts Sat Feb 28 at 22:00 (Week 1) and ends Sun Mar 1 at 04:00 (Week 2)
+      // End: Sun Mar 1 04:00, duration: 6 hours => start: Sat Feb 28 22:00
+      const spanRun = createTestRun(
+        new Date(2026, 2, 1, 4, 0, 0), // Sun Mar 1 04:00
+        6 * 3600, // 6 hours => starts Sat Feb 28 22:00
+        { id: 'span-run' }
+      )
+
+      // Should appear in Week 1 (start overlaps)
+      const resultWeek1 = getRunsForWeek([spanRun], WEEK1_START)
+      expect(resultWeek1).toHaveLength(1)
+      expect(resultWeek1[0].id).toBe('span-run')
+
+      // Should also appear in Week 2 (end overlaps)
+      const resultWeek2 = getRunsForWeek([spanRun], WEEK2_START)
+      expect(resultWeek2).toHaveLength(1)
+      expect(resultWeek2[0].id).toBe('span-run')
+    })
+  })
+})

--- a/src/features/analysis/activity-heatmap/navigation/week-navigation.ts
+++ b/src/features/analysis/activity-heatmap/navigation/week-navigation.ts
@@ -1,0 +1,116 @@
+/**
+ * Week Navigation
+ *
+ * Pure functions for navigating between weeks based on available game run data.
+ * Used by the activity heatmap to determine which weeks contain runs and to
+ * support prev/next navigation controls.
+ */
+
+import type { ParsedGameRun } from '@/shared/types/game-run.types'
+import type { WeekInfo } from '../types'
+import { getWeekStart, getWeekEnd, isSameWeek } from '../week-utils'
+import { getRunTimeRange, clipRunToWeek } from '../calculations/heatmap-grid-builder'
+import { formatWeekOfLabel } from '@/shared/formatting/date-formatters'
+
+/**
+ * Scans all runs and returns WeekInfo[] covering every week from the earliest
+ * to the latest run. Newest week first.
+ *
+ * Uses each run's start time (derived from timestamp minus duration) to
+ * determine which week it belongs to. Also includes weeks for run end times
+ * to cover runs that span week boundaries.
+ *
+ * @param runs - All parsed game runs
+ * @returns Array of WeekInfo objects, newest first. Empty if no runs.
+ */
+export function deriveAvailableWeeks(runs: ParsedGameRun[]): WeekInfo[] {
+  if (runs.length === 0) return []
+
+  const weekStarts = new Map<string, Date>()
+
+  for (const run of runs) {
+    const { start, end } = getRunTimeRange(run)
+
+    // Add the week containing the run start
+    const startWeek = getWeekStart(start)
+    const startKey = startWeek.getTime().toString()
+    if (!weekStarts.has(startKey)) {
+      weekStarts.set(startKey, startWeek)
+    }
+
+    // Add the week containing the run end (handles week-boundary spans)
+    const endWeek = getWeekStart(end)
+    const endKey = endWeek.getTime().toString()
+    if (!weekStarts.has(endKey)) {
+      weekStarts.set(endKey, endWeek)
+    }
+  }
+
+  // Sort by date descending (newest first)
+  const sortedWeeks = Array.from(weekStarts.values()).sort(
+    (a, b) => b.getTime() - a.getTime()
+  )
+
+  return sortedWeeks.map((weekStart) => ({
+    weekStart,
+    weekLabel: formatWeekOfLabel(weekStart),
+  }))
+}
+
+/**
+ * Returns the most recent week (first in the array), or null if empty.
+ *
+ * @param availableWeeks - Array of WeekInfo, expected newest first
+ * @returns The most recent WeekInfo, or null if the array is empty
+ */
+export function getDefaultWeek(availableWeeks: WeekInfo[]): WeekInfo | null {
+  return availableWeeks.length > 0 ? availableWeeks[0] : null
+}
+
+/**
+ * Returns true if there is a newer week available than the current one.
+ *
+ * @param currentWeek - The Sunday date of the currently selected week
+ * @param availableWeeks - Array of WeekInfo, expected newest first
+ * @returns True if navigation to a newer week is possible
+ */
+export function canNavigateNext(currentWeek: Date, availableWeeks: WeekInfo[]): boolean {
+  if (availableWeeks.length === 0) return false
+
+  // The newest week is the first element; if current is already the newest, can't go next
+  return !isSameWeek(currentWeek, availableWeeks[0].weekStart)
+}
+
+/**
+ * Returns true if there is an older week available than the current one.
+ *
+ * @param currentWeek - The Sunday date of the currently selected week
+ * @param availableWeeks - Array of WeekInfo, expected newest first
+ * @returns True if navigation to an older week is possible
+ */
+export function canNavigatePrev(currentWeek: Date, availableWeeks: WeekInfo[]): boolean {
+  if (availableWeeks.length === 0) return false
+
+  // The oldest week is the last element; if current is already the oldest, can't go prev
+  const lastWeek = availableWeeks[availableWeeks.length - 1]
+  return !isSameWeek(currentWeek, lastWeek.weekStart)
+}
+
+/**
+ * Returns runs whose time range overlaps the given week.
+ *
+ * Uses clipRunToWeek to determine overlap: if the clipped result is non-null,
+ * the run overlaps the week and is included.
+ *
+ * @param runs - All parsed game runs
+ * @param weekStart - Sunday 00:00:00.000 of the target week
+ * @returns Runs that overlap the given week
+ */
+export function getRunsForWeek(runs: ParsedGameRun[], weekStart: Date): ParsedGameRun[] {
+  const weekEnd = getWeekEnd(weekStart)
+
+  return runs.filter((run) => {
+    const { start, end } = getRunTimeRange(run)
+    return clipRunToWeek(start, end, weekStart, weekEnd) !== null
+  })
+}

--- a/src/features/analysis/activity-heatmap/navigation/week-navigator.tsx
+++ b/src/features/analysis/activity-heatmap/navigation/week-navigator.tsx
@@ -1,0 +1,74 @@
+/**
+ * Week Navigator Component
+ *
+ * Horizontal navigation bar for browsing between available weeks.
+ * Displays prev/next arrows, the current week label, and a "Latest" shortcut.
+ *
+ * Thin presentation shell — all navigation logic lives in the orchestration hook.
+ */
+
+interface WeekNavigatorProps {
+  weekLabel: string
+  canGoPrev: boolean
+  canGoNext: boolean
+  onPrev: () => void
+  onNext: () => void
+  onGoToLatest: () => void
+}
+
+const NAV_BUTTON_BASE =
+  'rounded-md border border-slate-600 bg-slate-700/50 px-2.5 py-1.5 text-sm text-slate-300 transition-colors hover:bg-slate-600/60 hover:text-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/50 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-slate-700/50 disabled:hover:text-slate-300 sm:px-3'
+
+export function WeekNavigator({
+  weekLabel,
+  canGoPrev,
+  canGoNext,
+  onPrev,
+  onNext,
+  onGoToLatest,
+}: WeekNavigatorProps) {
+  return (
+    <nav
+      className="flex items-center justify-center gap-2 sm:gap-3"
+      aria-label="Week navigation"
+    >
+      <button
+        type="button"
+        onClick={onPrev}
+        disabled={!canGoPrev}
+        aria-label="Previous week"
+        className={NAV_BUTTON_BASE}
+      >
+        <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+        </svg>
+      </button>
+
+      <span className="min-w-[8rem] text-center text-xs font-medium text-slate-200 sm:min-w-[10rem] sm:text-sm">
+        {weekLabel}
+      </span>
+
+      <button
+        type="button"
+        onClick={onNext}
+        disabled={!canGoNext}
+        aria-label="Next week"
+        className={NAV_BUTTON_BASE}
+      >
+        <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+        </svg>
+      </button>
+
+      <button
+        type="button"
+        onClick={onGoToLatest}
+        disabled={!canGoNext}
+        aria-label="Jump to latest week"
+        className="ml-0.5 rounded-md border border-amber-600/50 bg-amber-500/10 px-2.5 py-1.5 text-xs text-amber-400 transition-colors hover:bg-amber-500/20 hover:text-amber-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/50 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-amber-500/10 disabled:hover:text-amber-400 sm:ml-1 sm:px-3 sm:text-sm"
+      >
+        Latest
+      </button>
+    </nav>
+  )
+}

--- a/src/features/analysis/activity-heatmap/persistence/heatmap-persistence.test.ts
+++ b/src/features/analysis/activity-heatmap/persistence/heatmap-persistence.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  loadHeatmapConfig,
+  saveHeatmapConfig,
+  clearHeatmapConfig
+} from './heatmap-persistence'
+import { DEFAULT_ACTIVE_HOURS } from '../types'
+import type { ActiveHoursConfig } from '../types'
+
+describe('heatmap-persistence', () => {
+  const STORAGE_KEY = 'tower-tracking-activity-heatmap-config'
+
+  beforeEach(() => {
+    localStorage.clear()
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  describe('loadHeatmapConfig', () => {
+    it('should return default when localStorage is empty', () => {
+      const config = loadHeatmapConfig()
+
+      expect(config).toEqual(DEFAULT_ACTIVE_HOURS)
+    })
+
+    it('should return saved config when valid data exists', () => {
+      const savedConfig: ActiveHoursConfig = {
+        startHour: 6,
+        endHour: 22,
+        enabled: true
+      }
+
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(savedConfig))
+
+      const loaded = loadHeatmapConfig()
+      expect(loaded).toEqual(savedConfig)
+    })
+
+    it('should return default when localStorage has invalid JSON', () => {
+      localStorage.setItem(STORAGE_KEY, 'invalid json{')
+
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      const config = loadHeatmapConfig()
+      expect(config).toEqual(DEFAULT_ACTIVE_HOURS)
+
+      consoleSpy.mockRestore()
+    })
+
+    it('should return default when localStorage has wrong shape (missing fields)', () => {
+      const invalidConfig = {
+        startHour: 8,
+        // Missing endHour and enabled
+      }
+
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(invalidConfig))
+
+      const config = loadHeatmapConfig()
+      expect(config).toEqual(DEFAULT_ACTIVE_HOURS)
+    })
+
+    it('should return default when startHour is out of range', () => {
+      const invalidConfig = {
+        startHour: 25,
+        endHour: 22,
+        enabled: true
+      }
+
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(invalidConfig))
+
+      const config = loadHeatmapConfig()
+      expect(config).toEqual(DEFAULT_ACTIVE_HOURS)
+    })
+
+    it('should return default when endHour is out of range', () => {
+      const invalidConfig = {
+        startHour: 8,
+        endHour: -1,
+        enabled: true
+      }
+
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(invalidConfig))
+
+      const config = loadHeatmapConfig()
+      expect(config).toEqual(DEFAULT_ACTIVE_HOURS)
+    })
+
+    it('should return default when startHour is not an integer', () => {
+      const invalidConfig = {
+        startHour: 8.5,
+        endHour: 22,
+        enabled: true
+      }
+
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(invalidConfig))
+
+      const config = loadHeatmapConfig()
+      expect(config).toEqual(DEFAULT_ACTIVE_HOURS)
+    })
+
+    it('should return default when fields have wrong types', () => {
+      const invalidConfig = {
+        startHour: '8',
+        endHour: 22,
+        enabled: true
+      }
+
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(invalidConfig))
+
+      const config = loadHeatmapConfig()
+      expect(config).toEqual(DEFAULT_ACTIVE_HOURS)
+    })
+  })
+
+  describe('saveHeatmapConfig', () => {
+    it('should save config to localStorage', () => {
+      const config: ActiveHoursConfig = {
+        startHour: 6,
+        endHour: 22,
+        enabled: true
+      }
+
+      saveHeatmapConfig(config)
+
+      const stored = localStorage.getItem(STORAGE_KEY)
+      expect(stored).not.toBeNull()
+
+      const parsed = JSON.parse(stored!)
+      expect(parsed).toEqual(config)
+    })
+
+    it('should overwrite existing config', () => {
+      const first: ActiveHoursConfig = {
+        startHour: 6,
+        endHour: 22,
+        enabled: true
+      }
+      const second: ActiveHoursConfig = {
+        startHour: 9,
+        endHour: 17,
+        enabled: false
+      }
+
+      saveHeatmapConfig(first)
+      saveHeatmapConfig(second)
+
+      const stored = localStorage.getItem(STORAGE_KEY)
+      const parsed = JSON.parse(stored!)
+      expect(parsed).toEqual(second)
+    })
+
+    it('should handle localStorage errors gracefully', () => {
+      const config: ActiveHoursConfig = {
+        startHour: 8,
+        endHour: 23,
+        enabled: false
+      }
+
+      const setItemSpy = vi.spyOn(Storage.prototype, 'setItem')
+      setItemSpy.mockImplementation(() => {
+        throw new Error('Storage quota exceeded')
+      })
+
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      expect(() => saveHeatmapConfig(config)).not.toThrow()
+      expect(consoleSpy).toHaveBeenCalled()
+
+      setItemSpy.mockRestore()
+      consoleSpy.mockRestore()
+    })
+  })
+
+  describe('clearHeatmapConfig', () => {
+    it('should remove config from localStorage', () => {
+      const config: ActiveHoursConfig = {
+        startHour: 6,
+        endHour: 22,
+        enabled: true
+      }
+      saveHeatmapConfig(config)
+
+      expect(localStorage.getItem(STORAGE_KEY)).not.toBeNull()
+
+      clearHeatmapConfig()
+
+      expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
+    })
+
+    it('should not throw when key does not exist', () => {
+      expect(() => clearHeatmapConfig()).not.toThrow()
+    })
+
+    it('should handle localStorage errors gracefully', () => {
+      const removeItemSpy = vi.spyOn(Storage.prototype, 'removeItem')
+      removeItemSpy.mockImplementation(() => {
+        throw new Error('Storage error')
+      })
+
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      expect(() => clearHeatmapConfig()).not.toThrow()
+      expect(consoleSpy).toHaveBeenCalled()
+
+      removeItemSpy.mockRestore()
+      consoleSpy.mockRestore()
+    })
+  })
+
+  describe('roundtrip persistence', () => {
+    it('should preserve config through save and load', () => {
+      const original: ActiveHoursConfig = {
+        startHour: 10,
+        endHour: 20,
+        enabled: true
+      }
+
+      saveHeatmapConfig(original)
+      const loaded = loadHeatmapConfig()
+
+      expect(loaded).toEqual(original)
+    })
+  })
+})

--- a/src/features/analysis/activity-heatmap/persistence/heatmap-persistence.ts
+++ b/src/features/analysis/activity-heatmap/persistence/heatmap-persistence.ts
@@ -1,0 +1,74 @@
+import type { ActiveHoursConfig } from '../types'
+import { DEFAULT_ACTIVE_HOURS } from '../types'
+
+const STORAGE_KEY = 'tower-tracking-activity-heatmap-config'
+
+/**
+ * Load heatmap configuration from localStorage.
+ * Returns DEFAULT_ACTIVE_HOURS if not found, invalid, or during SSR.
+ */
+export function loadHeatmapConfig(): ActiveHoursConfig {
+  if (typeof window === 'undefined') {
+    return DEFAULT_ACTIVE_HOURS
+  }
+
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (!stored) {
+      return DEFAULT_ACTIVE_HOURS
+    }
+
+    const parsed = JSON.parse(stored) as ActiveHoursConfig
+    return validateStoredConfig(parsed)
+  } catch (error) {
+    console.warn('Failed to load heatmap config from localStorage:', error)
+    return DEFAULT_ACTIVE_HOURS
+  }
+}
+
+/**
+ * Save heatmap configuration to localStorage.
+ */
+export function saveHeatmapConfig(config: ActiveHoursConfig): void {
+  if (typeof window === 'undefined') return
+
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(config))
+  } catch (error) {
+    console.error('Failed to save heatmap config to localStorage:', error)
+  }
+}
+
+/**
+ * Clear heatmap configuration from localStorage.
+ */
+export function clearHeatmapConfig(): void {
+  if (typeof window === 'undefined') return
+
+  try {
+    localStorage.removeItem(STORAGE_KEY)
+  } catch (error) {
+    console.error('Failed to clear heatmap config from localStorage:', error)
+  }
+}
+
+function isValidHour(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0 && value <= 23
+}
+
+/**
+ * Validate that stored configuration has the correct shape and value ranges.
+ */
+function validateStoredConfig(config: unknown): ActiveHoursConfig {
+  if (!config || typeof config !== 'object') {
+    return DEFAULT_ACTIVE_HOURS
+  }
+
+  const record = config as Record<string, unknown>
+
+  if (!isValidHour(record.startHour) || !isValidHour(record.endHour) || typeof record.enabled !== 'boolean') {
+    return DEFAULT_ACTIVE_HOURS
+  }
+
+  return { startHour: record.startHour, endHour: record.endHour, enabled: record.enabled }
+}

--- a/src/features/analysis/activity-heatmap/summary-formatters.test.ts
+++ b/src/features/analysis/activity-heatmap/summary-formatters.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, it, vi } from 'vitest'
+import { buildSummaryEntries, buildRunTypeBreakdownEntries, formatCoveragePercent, formatTotalDuration, formatMinuteDisplay, sortSegmentsByTime } from './summary-formatters'
+import type { HeatmapSegment, HeatmapSummary } from './types'
+
+vi.mock('@/shared/formatting/run-display-formatters', () => ({
+  formatDurationHoursMinutes: (seconds: number) => {
+    const totalMinutes = Math.floor(seconds / 60)
+    const hours = Math.floor(totalMinutes / 60)
+    const minutes = totalMinutes % 60
+    if (hours === 0) return `${minutes}m`
+    if (minutes === 0) return `${hours}h`
+    return `${hours}h ${minutes}m`
+  },
+}))
+
+vi.mock('@/shared/formatting/number-scale', () => ({
+  formatPercentage: (value: number, decimals: number = 1) => {
+    const multiplier = Math.pow(10, decimals)
+    const rounded = Math.round(value * multiplier) / multiplier
+    return `${rounded}%`
+  },
+}))
+
+vi.mock('@/features/analysis/shared/filtering/run-type-filter', () => ({
+  getRunTypeDisplayLabel: (runType: string) => {
+    const labels: Record<string, string> = {
+      farm: 'Farm',
+      tournament: 'Tournament',
+      milestone: 'Milestone',
+    }
+    return labels[runType] ?? 'Unknown'
+  },
+}))
+
+vi.mock('@/shared/domain/run-types/run-type-display', () => ({
+  getRunTypeColor: (runType: string) => {
+    const colors: Record<string, string> = {
+      farm: '#10b981',
+      tournament: '#f59e0b',
+      milestone: '#8b5cf6',
+    }
+    return colors[runType] ?? '#888888'
+  },
+}))
+
+function makeSummary(overrides: Partial<HeatmapSummary> = {}): HeatmapSummary {
+  return {
+    overallCoverage: 0.5,
+    dailyCoverage: [0, 0, 0, 0, 0, 0, 0],
+    activeHoursCoverage: 0.75,
+    runTypeBreakdown: {},
+    runTypeStats: {},
+    totalActiveSeconds: 3600,
+    totalIdleSeconds: 0,
+    runCount: 10,
+    ...overrides,
+  }
+}
+
+describe('formatCoveragePercent', () => {
+  it('formats 0 as "0%"', () => {
+    expect(formatCoveragePercent(0)).toBe('0%')
+  })
+
+  it('formats 0.5 as "50%"', () => {
+    expect(formatCoveragePercent(0.5)).toBe('50%')
+  })
+
+  it('formats 1.0 as "100%"', () => {
+    expect(formatCoveragePercent(1.0)).toBe('100%')
+  })
+
+  it('rounds small values like 0.003 to "0%"', () => {
+    expect(formatCoveragePercent(0.003)).toBe('0%')
+  })
+})
+
+describe('formatTotalDuration', () => {
+  it('formats 0 seconds', () => {
+    expect(formatTotalDuration(0)).toBe('0m')
+  })
+
+  it('formats 3600 seconds as 1 hour', () => {
+    expect(formatTotalDuration(3600)).toBe('1h')
+  })
+
+  it('formats 5400 seconds as 1h 30m', () => {
+    expect(formatTotalDuration(5400)).toBe('1h 30m')
+  })
+})
+
+describe('buildSummaryEntries', () => {
+  it('returns 4 entries when activeHours is disabled', () => {
+    const summary = makeSummary()
+
+    const entries = buildSummaryEntries(summary, false)
+
+    expect(entries).toHaveLength(4)
+    expect(entries[0].label).toBe('Overall Coverage')
+    expect(entries[1].label).toBe('Total Play Time')
+    expect(entries[2].label).toBe('Idle Time')
+    expect(entries[3].label).toBe('Runs This Week')
+  })
+
+  it('returns 5 entries when activeHours is enabled', () => {
+    const summary = makeSummary()
+
+    const entries = buildSummaryEntries(summary, true)
+
+    expect(entries).toHaveLength(5)
+    expect(entries[4].label).toBe('Active Hours Coverage')
+  })
+
+  it('formats coverage values correctly', () => {
+    const summary = makeSummary({ overallCoverage: 0.42, activeHoursCoverage: 0.88 })
+
+    const entries = buildSummaryEntries(summary, true)
+
+    expect(entries[0].value).toBe('42%')
+    expect(entries[4].value).toBe('88%')
+  })
+
+  it('formats total play time using duration formatter', () => {
+    const summary = makeSummary({ totalActiveSeconds: 5400 })
+
+    const entries = buildSummaryEntries(summary, false)
+
+    expect(entries[1].value).toBe('1h 30m')
+  })
+
+  it('formats idle time using duration formatter', () => {
+    const summary = makeSummary({ totalIdleSeconds: 7200 })
+
+    const entries = buildSummaryEntries(summary, false)
+
+    expect(entries[2].label).toBe('Idle Time')
+    expect(entries[2].value).toBe('2h')
+  })
+
+  it('formats run count as a string', () => {
+    const summary = makeSummary({ runCount: 42 })
+
+    const entries = buildSummaryEntries(summary, false)
+
+    expect(entries[3].value).toBe('42')
+  })
+})
+
+describe('buildRunTypeBreakdownEntries', () => {
+  it('returns empty array when no runTypeStats', () => {
+    const summary = makeSummary({ runTypeStats: {} })
+
+    const groups = buildRunTypeBreakdownEntries(summary)
+
+    expect(groups).toEqual([])
+  })
+
+  it('returns empty array for single run type (no breakdown needed)', () => {
+    const summary = makeSummary({
+      runTypeStats: {
+        farm: { coverage: 0.1, activeSeconds: 3600, runCount: 5 },
+      },
+    })
+
+    const groups = buildRunTypeBreakdownEntries(summary)
+
+    expect(groups).toEqual([])
+  })
+
+  it('returns breakdown groups for multiple run types', () => {
+    const summary = makeSummary({
+      runTypeStats: {
+        farm: { coverage: 0.05, activeSeconds: 3600, runCount: 3 },
+        tournament: { coverage: 0.02, activeSeconds: 1800, runCount: 2 },
+      },
+    })
+
+    const groups = buildRunTypeBreakdownEntries(summary)
+
+    expect(groups).toHaveLength(2)
+
+    // Sorted alphabetically by label: Farm, Tournament
+    expect(groups[0].label).toBe('Farm')
+    expect(groups[0].runType).toBe('farm')
+    expect(groups[0].color).toBe('#10b981')
+    expect(groups[0].entries).toHaveLength(3)
+    expect(groups[0].entries[0]).toEqual({ label: 'Coverage', value: '5%' })
+    expect(groups[0].entries[1]).toEqual({ label: 'Play Time', value: '1h' })
+    expect(groups[0].entries[2]).toEqual({ label: 'Runs', value: '3' })
+
+    expect(groups[1].label).toBe('Tournament')
+    expect(groups[1].runType).toBe('tournament')
+    expect(groups[1].color).toBe('#f59e0b')
+    expect(groups[1].entries[0]).toEqual({ label: 'Coverage', value: '2%' })
+    expect(groups[1].entries[1]).toEqual({ label: 'Play Time', value: '30m' })
+    expect(groups[1].entries[2]).toEqual({ label: 'Runs', value: '2' })
+  })
+
+  it('handles three run types sorted alphabetically', () => {
+    const summary = makeSummary({
+      runTypeStats: {
+        tournament: { coverage: 0.01, activeSeconds: 600, runCount: 1 },
+        milestone: { coverage: 0.005, activeSeconds: 300, runCount: 1 },
+        farm: { coverage: 0.02, activeSeconds: 1200, runCount: 2 },
+      },
+    })
+
+    const groups = buildRunTypeBreakdownEntries(summary)
+
+    expect(groups).toHaveLength(3)
+    expect(groups[0].label).toBe('Farm')
+    expect(groups[1].label).toBe('Milestone')
+    expect(groups[2].label).toBe('Tournament')
+  })
+})
+
+describe('formatMinuteDisplay', () => {
+  it('formats 0 as ":00"', () => {
+    expect(formatMinuteDisplay(0)).toBe(':00')
+  })
+
+  it('formats 0.5 as ":30"', () => {
+    expect(formatMinuteDisplay(0.5)).toBe(':30')
+  })
+
+  it('formats 0.25 as ":15"', () => {
+    expect(formatMinuteDisplay(0.25)).toBe(':15')
+  })
+
+  it('formats 0.75 as ":45"', () => {
+    expect(formatMinuteDisplay(0.75)).toBe(':45')
+  })
+
+  it('clamps 1.0 to ":59" instead of ":60"', () => {
+    expect(formatMinuteDisplay(1.0)).toBe(':59')
+  })
+
+  it('clamps 0.99 to ":59"', () => {
+    expect(formatMinuteDisplay(0.99)).toBe(':59')
+  })
+
+  it('pads single-digit minutes with leading zero', () => {
+    // 5 minutes = 5/60 ~ 0.0833
+    expect(formatMinuteDisplay(5 / 60)).toBe(':05')
+  })
+})
+
+describe('sortSegmentsByTime', () => {
+  function makeSegment(start: number, end: number): HeatmapSegment {
+    return { startFraction: start, endFraction: end, runType: 'farm', tier: 1, runId: 'r1' }
+  }
+
+  it('returns empty array for empty input', () => {
+    expect(sortSegmentsByTime([])).toEqual([])
+  })
+
+  it('returns single segment unchanged', () => {
+    const segments = [makeSegment(0.5, 0.75)]
+    const result = sortSegmentsByTime(segments)
+    expect(result).toHaveLength(1)
+    expect(result[0].startFraction).toBe(0.5)
+  })
+
+  it('sorts segments by startFraction ascending', () => {
+    const segments = [
+      makeSegment(0.7, 0.9),
+      makeSegment(0.1, 0.3),
+      makeSegment(0.4, 0.6),
+    ]
+
+    const result = sortSegmentsByTime(segments)
+
+    expect(result[0].startFraction).toBe(0.1)
+    expect(result[1].startFraction).toBe(0.4)
+    expect(result[2].startFraction).toBe(0.7)
+  })
+
+  it('does not mutate the original array', () => {
+    const segments = [
+      makeSegment(0.7, 0.9),
+      makeSegment(0.1, 0.3),
+    ]
+
+    sortSegmentsByTime(segments)
+
+    expect(segments[0].startFraction).toBe(0.7)
+    expect(segments[1].startFraction).toBe(0.1)
+  })
+})

--- a/src/features/analysis/activity-heatmap/summary-formatters.ts
+++ b/src/features/analysis/activity-heatmap/summary-formatters.ts
@@ -1,0 +1,126 @@
+/**
+ * Summary Formatters
+ *
+ * Pure functions for formatting heatmap summary statistics for display.
+ */
+
+import { formatDurationHoursMinutes } from '@/shared/formatting/run-display-formatters'
+import { formatPercentage } from '@/shared/formatting/number-scale'
+import { getRunTypeDisplayLabel } from '@/features/analysis/shared/filtering/run-type-filter'
+import { getRunTypeColor } from '@/shared/domain/run-types/run-type-display'
+import type { RunTypeValue } from '@/shared/domain/run-types/types'
+import type { HeatmapSegment, HeatmapSummary } from './types'
+
+/**
+ * Format a coverage fraction (0-1) as a locale-aware percentage string.
+ * Delegates to the shared formatPercentage utility for locale-aware number formatting.
+ *
+ * @example
+ *   formatCoveragePercent(0.5)  // "50%" (en-US) or "50%" (de-DE)
+ *   formatCoveragePercent(0.003) // "0%" (rounded to 0 decimals)
+ */
+export function formatCoveragePercent(coverage: number): string {
+  return formatPercentage(coverage * 100, 0)
+}
+
+/** Format total seconds as a human-readable duration */
+export function formatTotalDuration(seconds: number): string {
+  return formatDurationHoursMinutes(seconds)
+}
+
+/** Build an array of summary stat entries for rendering */
+export function buildSummaryEntries(summary: HeatmapSummary, activeHoursEnabled: boolean): SummaryEntry[] {
+  const entries: SummaryEntry[] = [
+    {
+      label: 'Overall Coverage',
+      value: formatCoveragePercent(summary.overallCoverage),
+    },
+    {
+      label: 'Total Play Time',
+      value: formatTotalDuration(summary.totalActiveSeconds),
+    },
+    {
+      label: 'Idle Time',
+      value: formatTotalDuration(summary.totalIdleSeconds),
+    },
+    {
+      label: 'Runs This Week',
+      value: String(summary.runCount),
+    },
+  ]
+
+  if (activeHoursEnabled) {
+    entries.push({
+      label: 'Active Hours Coverage',
+      value: formatCoveragePercent(summary.activeHoursCoverage),
+    })
+  }
+
+  return entries
+}
+
+export interface SummaryEntry {
+  label: string
+  value: string
+}
+
+export interface RunTypeBreakdownGroup {
+  runType: string
+  label: string
+  color: string
+  entries: SummaryEntry[]
+}
+
+/**
+ * Build per-run-type breakdown groups for display below the overall summary.
+ * Each group contains coverage, play time, and run count for one run type.
+ * Only returns groups when there are 2+ run types present.
+ *
+ * @param summary - The heatmap summary with per-type stats
+ * @returns Array of breakdown groups sorted by run type label, or empty if single type
+ */
+export function buildRunTypeBreakdownEntries(summary: HeatmapSummary): RunTypeBreakdownGroup[] {
+  const runTypes = Object.keys(summary.runTypeStats)
+  if (runTypes.length < 2) return []
+
+  return runTypes
+    .map((runType) => {
+      const stats = summary.runTypeStats[runType]
+      return {
+        runType,
+        label: getRunTypeDisplayLabel(runType as RunTypeValue),
+        color: getRunTypeColor(runType as RunTypeValue),
+        entries: [
+          { label: 'Coverage', value: formatCoveragePercent(stats.coverage) },
+          { label: 'Play Time', value: formatTotalDuration(stats.activeSeconds) },
+          { label: 'Runs', value: String(stats.runCount) },
+        ],
+      }
+    })
+    .sort((a, b) => a.label.localeCompare(b.label))
+}
+
+/**
+ * Returns a copy of segments sorted by startFraction ascending.
+ * Used by the tooltip to display segments in chronological order.
+ *
+ * @param segments - Array of heatmap segments to sort
+ * @returns New array sorted by startFraction (ascending)
+ */
+export function sortSegmentsByTime(segments: HeatmapSegment[]): HeatmapSegment[] {
+  return [...segments].sort((a, b) => a.startFraction - b.startFraction)
+}
+
+/**
+ * Format a fraction (0-1) within an hour to a minute display.
+ * Used by the cell tooltip to show segment time ranges.
+ *
+ * @example
+ *   formatMinuteDisplay(0)    // ":00"
+ *   formatMinuteDisplay(0.5)  // ":30"
+ *   formatMinuteDisplay(0.75) // ":45"
+ */
+export function formatMinuteDisplay(fraction: number): string {
+  const minutes = Math.min(Math.round(fraction * 60), 59)
+  return `:${String(minutes).padStart(2, '0')}`
+}

--- a/src/features/analysis/activity-heatmap/types.ts
+++ b/src/features/analysis/activity-heatmap/types.ts
@@ -1,0 +1,73 @@
+/**
+ * Activity Heatmap Type Definitions
+ *
+ * Type definitions for the Activity Heatmap analysis feature.
+ * The heatmap displays a 24x7 grid (7 days Sun-Sat x 24 hours)
+ * showing when game runs occurred during a given week.
+ */
+
+import type { RunTypeValue } from '@/shared/domain/run-types/types'
+
+/** A single time segment within an hour cell */
+export interface HeatmapSegment {
+  startFraction: number // 0-1, position within the hour
+  endFraction: number // 0-1, position within the hour
+  runType: RunTypeValue
+  tier: number
+  runId: string
+}
+
+/** Data for a single cell in the 24x7 grid */
+export interface HeatmapCell {
+  hour: number // 0-23
+  dayIndex: number // 0=Sun, 1=Mon, ... 6=Sat
+  date: Date // actual calendar date for this cell
+  segments: HeatmapSegment[]
+  totalCoverage: number // 0-1, sum of segment coverage
+}
+
+/** The complete 24x7 grid for one week */
+export interface HeatmapGrid {
+  weekStart: Date // Sunday 00:00:00
+  weekEnd: Date // Saturday 23:59:59.999
+  days: HeatmapCell[][] // days[dayIndex][hourIndex] - 7 arrays of 24 cells
+  weekLabel: string
+}
+
+/** Week navigation info */
+export interface WeekInfo {
+  weekStart: Date
+  weekLabel: string
+}
+
+/** Active hours user configuration (persisted to localStorage) */
+export interface ActiveHoursConfig {
+  startHour: number // 0-23
+  endHour: number // 0-23 (exclusive)
+  enabled: boolean
+}
+
+/** Per-run-type statistics for breakdown display */
+export interface RunTypeStats {
+  coverage: number // absolute coverage fraction of 168-cell week (0-1)
+  activeSeconds: number // total play time seconds for this type
+  runCount: number // number of unique runs of this type
+}
+
+/** Summary statistics for one week */
+export interface HeatmapSummary {
+  overallCoverage: number // 0-1
+  dailyCoverage: number[] // 7 values (Sun-Sat), each 0-1
+  activeHoursCoverage: number // 0-1
+  runTypeBreakdown: Record<string, number> // fraction per run type
+  runTypeStats: Record<string, RunTypeStats> // per-type coverage, time, runs
+  totalActiveSeconds: number
+  totalIdleSeconds: number
+  runCount: number
+}
+
+export const DEFAULT_ACTIVE_HOURS: ActiveHoursConfig = {
+  startHour: 8,
+  endHour: 23,
+  enabled: false,
+}

--- a/src/features/analysis/activity-heatmap/use-activity-heatmap.ts
+++ b/src/features/analysis/activity-heatmap/use-activity-heatmap.ts
@@ -1,0 +1,136 @@
+/**
+ * Activity Heatmap Orchestration Hook
+ *
+ * Manages all state for the Activity Heatmap feature: week navigation,
+ * tier/run-type filtering, active hours configuration, grid building,
+ * and summary statistics. Components consume this hook as a thin shell.
+ *
+ * Data flow:
+ *   runs → filter by tier + runType → get runs for selected week →
+ *   build heatmap grid → calculate summary statistics
+ *
+ * Week navigation is delegated to useWeekNavigation to keep this hook focused.
+ */
+
+import { useState, useMemo, useCallback, useEffect } from 'react'
+import { useData } from '@/shared/domain/use-data'
+import type { RunTypeFilter } from '@/features/analysis/shared/filtering/run-type-filter'
+import type { HeatmapGrid, HeatmapSummary, HeatmapCell, ActiveHoursConfig } from './types'
+import { extractAvailableTiers, allToZeroTierAdapter } from '@/shared/domain/filters/tier/tier-filter-logic'
+import type { TierFilter } from '@/shared/domain/filters/types'
+import { buildHeatmapGrid } from './calculations/heatmap-grid-builder'
+import { getRunsForWeek } from './navigation/week-navigation'
+import { filterHeatmapRuns } from './filters/run-filtering'
+import { calculateHeatmapSummary } from './calculations/heatmap-statistics'
+import { loadHeatmapConfig, saveHeatmapConfig } from './persistence/heatmap-persistence'
+import { useWeekNavigation, type UseWeekNavigationReturn } from './navigation/use-week-navigation'
+
+export interface UseActivityHeatmapReturn extends UseWeekNavigationReturn {
+  // Grid data
+  grid: HeatmapGrid | null
+  summary: HeatmapSummary | null
+
+  // Filters
+  selectedTier: TierFilter
+  setSelectedTier: (tier: TierFilter) => void
+  availableTiers: number[]
+  selectedRunType: RunTypeFilter
+  setSelectedRunType: (runType: RunTypeFilter) => void
+  activeHours: ActiveHoursConfig
+  setActiveHours: (config: ActiveHoursConfig) => void
+
+  // Tooltip
+  hoveredCell: HeatmapCell | null
+  tooltipAnchorRect: DOMRect | null
+  setHoveredCell: (cell: HeatmapCell | null, anchorRect?: DOMRect | null) => void
+
+  // Data state
+  hasRuns: boolean
+}
+
+export function useActivityHeatmap(): UseActivityHeatmapReturn {
+  const { runs } = useData()
+
+  // Week navigation (delegated to sub-hook)
+  const weekNav = useWeekNavigation(runs)
+
+  // State: filters
+  const [selectedTier, setSelectedTier] = useState<TierFilter>('all')
+  const [selectedRunType, setSelectedRunType] = useState<RunTypeFilter>('all')
+
+  // State: active hours (initialized from persistence)
+  const [activeHours, setActiveHoursState] = useState<ActiveHoursConfig>(loadHeatmapConfig)
+
+  // State: tooltip hover + anchor rect for positioning
+  const [hoveredCell, setHoveredCellState] = useState<HeatmapCell | null>(null)
+  const [tooltipAnchorRect, setTooltipAnchorRect] = useState<DOMRect | null>(null)
+
+  const setHoveredCell = useCallback((cell: HeatmapCell | null, anchorRect?: DOMRect | null) => {
+    setHoveredCellState(cell)
+    setTooltipAnchorRect(anchorRect ?? null)
+  }, [])
+
+  // Derive available tiers from ALL runs
+  const availableTiers = useMemo(() => extractAvailableTiers(runs), [runs])
+
+  // Auto-reset tier to 'all' when the selected tier is no longer available
+  useEffect(() => {
+    if (selectedTier !== 'all' && !availableTiers.includes(selectedTier)) {
+      setSelectedTier('all')
+    }
+  }, [availableTiers, selectedTier])
+
+  // Filter runs by tier + run type
+  const filteredRuns = useMemo(() => {
+    const tierValue = allToZeroTierAdapter(selectedTier)
+    return filterHeatmapRuns(runs, { tier: tierValue, runType: selectedRunType })
+  }, [runs, selectedTier, selectedRunType])
+
+  // Get runs for the selected week, then build grid and summary
+  const weekRuns = useMemo(() => {
+    if (!weekNav.selectedWeek) return []
+    return getRunsForWeek(filteredRuns, weekNav.selectedWeek.weekStart)
+  }, [filteredRuns, weekNav.selectedWeek])
+
+  const grid = useMemo(() => {
+    if (!weekNav.selectedWeek) return null
+    return buildHeatmapGrid(weekRuns, weekNav.selectedWeek.weekStart)
+  }, [weekRuns, weekNav.selectedWeek])
+
+  const summary = useMemo(() => {
+    if (!grid) return null
+    return calculateHeatmapSummary(grid, activeHours)
+  }, [grid, activeHours])
+
+  // Persist active hours config when changed
+  const setActiveHours = useCallback((config: ActiveHoursConfig) => {
+    setActiveHoursState(config)
+    saveHeatmapConfig(config)
+  }, [])
+
+  return {
+    // Week navigation (spread from sub-hook)
+    ...weekNav,
+
+    // Grid data
+    grid,
+    summary,
+
+    // Filters
+    selectedTier,
+    setSelectedTier,
+    availableTiers,
+    selectedRunType,
+    setSelectedRunType,
+    activeHours,
+    setActiveHours,
+
+    // Tooltip
+    hoveredCell,
+    tooltipAnchorRect,
+    setHoveredCell,
+
+    // Data state
+    hasRuns: runs.length > 0,
+  }
+}

--- a/src/features/analysis/activity-heatmap/week-utils.test.ts
+++ b/src/features/analysis/activity-heatmap/week-utils.test.ts
@@ -1,0 +1,338 @@
+/**
+ * Week Utility Functions Tests
+ *
+ * Comprehensive tests for Sunday-based week date math.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  getWeekStart,
+  getWeekEnd,
+  getNextWeekStart,
+  getPrevWeekStart,
+  isSameWeek,
+  getDayIndex,
+} from './week-utils'
+
+describe('week-utils', () => {
+  describe('getWeekStart', () => {
+    it('should return same day at midnight when given a Sunday', () => {
+      // 2024-01-07 is a Sunday
+      const sunday = new Date(2024, 0, 7, 14, 30, 0)
+      const result = getWeekStart(sunday)
+
+      expect(result.getFullYear()).toBe(2024)
+      expect(result.getMonth()).toBe(0)
+      expect(result.getDate()).toBe(7)
+      expect(result.getHours()).toBe(0)
+      expect(result.getMinutes()).toBe(0)
+      expect(result.getSeconds()).toBe(0)
+      expect(result.getMilliseconds()).toBe(0)
+    })
+
+    it('should return previous Sunday for Monday', () => {
+      // 2024-01-08 is a Monday
+      const monday = new Date(2024, 0, 8, 10, 0, 0)
+      const result = getWeekStart(monday)
+
+      expect(result.getDate()).toBe(7) // Sunday Jan 7
+      expect(result.getDay()).toBe(0) // Sunday
+      expect(result.getHours()).toBe(0)
+    })
+
+    it('should return previous Sunday for Tuesday', () => {
+      // 2024-01-09 is a Tuesday
+      const tuesday = new Date(2024, 0, 9, 12, 0, 0)
+      const result = getWeekStart(tuesday)
+
+      expect(result.getDate()).toBe(7)
+      expect(result.getDay()).toBe(0)
+    })
+
+    it('should return previous Sunday for Wednesday', () => {
+      // 2024-01-10 is a Wednesday
+      const wednesday = new Date(2024, 0, 10, 12, 0, 0)
+      const result = getWeekStart(wednesday)
+
+      expect(result.getDate()).toBe(7)
+      expect(result.getDay()).toBe(0)
+    })
+
+    it('should return previous Sunday for Thursday', () => {
+      // 2024-01-11 is a Thursday
+      const thursday = new Date(2024, 0, 11, 12, 0, 0)
+      const result = getWeekStart(thursday)
+
+      expect(result.getDate()).toBe(7)
+      expect(result.getDay()).toBe(0)
+    })
+
+    it('should return previous Sunday for Friday', () => {
+      // 2024-01-12 is a Friday
+      const friday = new Date(2024, 0, 12, 12, 0, 0)
+      const result = getWeekStart(friday)
+
+      expect(result.getDate()).toBe(7)
+      expect(result.getDay()).toBe(0)
+    })
+
+    it('should return previous Sunday for Saturday', () => {
+      // 2024-01-13 is a Saturday
+      const saturday = new Date(2024, 0, 13, 23, 59, 59)
+      const result = getWeekStart(saturday)
+
+      expect(result.getDate()).toBe(7) // Sunday Jan 7
+      expect(result.getDay()).toBe(0)
+    })
+
+    it('should handle edge of year (Jan 1 on a Wednesday)', () => {
+      // 2025-01-01 is a Wednesday
+      const newYearsDay = new Date(2025, 0, 1, 12, 0, 0)
+      const result = getWeekStart(newYearsDay)
+
+      // Should go back to Sunday Dec 29, 2024
+      expect(result.getFullYear()).toBe(2024)
+      expect(result.getMonth()).toBe(11) // December
+      expect(result.getDate()).toBe(29)
+      expect(result.getDay()).toBe(0) // Sunday
+    })
+
+    it('should handle edge of month', () => {
+      // 2024-03-01 is a Friday
+      const marchFirst = new Date(2024, 2, 1, 12, 0, 0)
+      const result = getWeekStart(marchFirst)
+
+      // Should go back to Sunday Feb 25, 2024
+      expect(result.getFullYear()).toBe(2024)
+      expect(result.getMonth()).toBe(1) // February
+      expect(result.getDate()).toBe(25)
+      expect(result.getDay()).toBe(0)
+    })
+
+    it('should not mutate the input date', () => {
+      const original = new Date(2024, 0, 10, 15, 30, 0)
+      const originalTime = original.getTime()
+      getWeekStart(original)
+
+      expect(original.getTime()).toBe(originalTime)
+    })
+  })
+
+  describe('getWeekEnd', () => {
+    it('should return Saturday 23:59:59.999 for a given Sunday', () => {
+      const sunday = new Date(2024, 0, 7, 0, 0, 0, 0) // Sunday Jan 7
+      const result = getWeekEnd(sunday)
+
+      expect(result.getDate()).toBe(13) // Saturday Jan 13
+      expect(result.getDay()).toBe(6) // Saturday
+      expect(result.getHours()).toBe(23)
+      expect(result.getMinutes()).toBe(59)
+      expect(result.getSeconds()).toBe(59)
+      expect(result.getMilliseconds()).toBe(999)
+    })
+
+    it('should handle week crossing month boundary', () => {
+      // Sunday Jan 28, 2024 -> Saturday Feb 3, 2024
+      const sunday = new Date(2024, 0, 28, 0, 0, 0, 0)
+      const result = getWeekEnd(sunday)
+
+      expect(result.getMonth()).toBe(1) // February
+      expect(result.getDate()).toBe(3)
+      expect(result.getDay()).toBe(6)
+      expect(result.getHours()).toBe(23)
+      expect(result.getMinutes()).toBe(59)
+      expect(result.getSeconds()).toBe(59)
+      expect(result.getMilliseconds()).toBe(999)
+    })
+
+    it('should handle week crossing year boundary', () => {
+      // Sunday Dec 29, 2024 -> Saturday Jan 4, 2025
+      const sunday = new Date(2024, 11, 29, 0, 0, 0, 0)
+      const result = getWeekEnd(sunday)
+
+      expect(result.getFullYear()).toBe(2025)
+      expect(result.getMonth()).toBe(0) // January
+      expect(result.getDate()).toBe(4)
+      expect(result.getDay()).toBe(6)
+    })
+
+    it('should not mutate the input date', () => {
+      const original = new Date(2024, 0, 7, 0, 0, 0, 0)
+      const originalTime = original.getTime()
+      getWeekEnd(original)
+
+      expect(original.getTime()).toBe(originalTime)
+    })
+  })
+
+  describe('getNextWeekStart', () => {
+    it('should add 7 days to the given date', () => {
+      const sunday = new Date(2024, 0, 7, 0, 0, 0, 0) // Sunday Jan 7
+      const result = getNextWeekStart(sunday)
+
+      expect(result.getDate()).toBe(14) // Sunday Jan 14
+      expect(result.getDay()).toBe(0) // Sunday
+      expect(result.getHours()).toBe(0)
+    })
+
+    it('should handle month boundary', () => {
+      const sunday = new Date(2024, 0, 28, 0, 0, 0, 0) // Sunday Jan 28
+      const result = getNextWeekStart(sunday)
+
+      expect(result.getMonth()).toBe(1) // February
+      expect(result.getDate()).toBe(4) // Sunday Feb 4
+    })
+
+    it('should handle year boundary', () => {
+      const sunday = new Date(2024, 11, 29, 0, 0, 0, 0) // Sunday Dec 29
+      const result = getNextWeekStart(sunday)
+
+      expect(result.getFullYear()).toBe(2025)
+      expect(result.getMonth()).toBe(0) // January
+      expect(result.getDate()).toBe(5) // Sunday Jan 5
+    })
+
+    it('should not mutate the input date', () => {
+      const original = new Date(2024, 0, 7, 0, 0, 0, 0)
+      const originalTime = original.getTime()
+      getNextWeekStart(original)
+
+      expect(original.getTime()).toBe(originalTime)
+    })
+  })
+
+  describe('getPrevWeekStart', () => {
+    it('should subtract 7 days from the given date', () => {
+      const sunday = new Date(2024, 0, 14, 0, 0, 0, 0) // Sunday Jan 14
+      const result = getPrevWeekStart(sunday)
+
+      expect(result.getDate()).toBe(7) // Sunday Jan 7
+      expect(result.getDay()).toBe(0) // Sunday
+      expect(result.getHours()).toBe(0)
+    })
+
+    it('should handle month boundary', () => {
+      const sunday = new Date(2024, 1, 4, 0, 0, 0, 0) // Sunday Feb 4
+      const result = getPrevWeekStart(sunday)
+
+      expect(result.getMonth()).toBe(0) // January
+      expect(result.getDate()).toBe(28)
+    })
+
+    it('should handle year boundary', () => {
+      const sunday = new Date(2025, 0, 5, 0, 0, 0, 0) // Sunday Jan 5, 2025
+      const result = getPrevWeekStart(sunday)
+
+      expect(result.getFullYear()).toBe(2024)
+      expect(result.getMonth()).toBe(11) // December
+      expect(result.getDate()).toBe(29)
+    })
+
+    it('should not mutate the input date', () => {
+      const original = new Date(2024, 0, 14, 0, 0, 0, 0)
+      const originalTime = original.getTime()
+      getPrevWeekStart(original)
+
+      expect(original.getTime()).toBe(originalTime)
+    })
+  })
+
+  describe('isSameWeek', () => {
+    it('should return true for two dates in the same week', () => {
+      // Sunday Jan 7 and Tuesday Jan 9, 2024
+      const sunday = new Date(2024, 0, 7, 10, 0, 0)
+      const tuesday = new Date(2024, 0, 9, 15, 0, 0)
+
+      expect(isSameWeek(sunday, tuesday)).toBe(true)
+    })
+
+    it('should return true for Sunday and Saturday of the same week', () => {
+      // Sunday Jan 7 and Saturday Jan 13, 2024
+      const sunday = new Date(2024, 0, 7, 0, 0, 0)
+      const saturday = new Date(2024, 0, 13, 23, 59, 59)
+
+      expect(isSameWeek(sunday, saturday)).toBe(true)
+    })
+
+    it('should return false for adjacent weeks', () => {
+      // Saturday Jan 13 and Sunday Jan 14, 2024
+      const saturday = new Date(2024, 0, 13, 23, 59, 59)
+      const nextSunday = new Date(2024, 0, 14, 0, 0, 0)
+
+      expect(isSameWeek(saturday, nextSunday)).toBe(false)
+    })
+
+    it('should return false for dates in different weeks', () => {
+      const week1 = new Date(2024, 0, 8, 12, 0, 0)
+      const week3 = new Date(2024, 0, 22, 12, 0, 0)
+
+      expect(isSameWeek(week1, week3)).toBe(false)
+    })
+
+    it('should return true for the same date', () => {
+      const date = new Date(2024, 0, 10, 12, 0, 0)
+
+      expect(isSameWeek(date, date)).toBe(true)
+    })
+
+    it('should handle week spanning month boundary', () => {
+      // Sunday Jan 28 and Thursday Feb 1, 2024 (same week)
+      const sunday = new Date(2024, 0, 28, 12, 0, 0)
+      const thursday = new Date(2024, 1, 1, 12, 0, 0)
+
+      expect(isSameWeek(sunday, thursday)).toBe(true)
+    })
+
+    it('should handle week spanning year boundary', () => {
+      // Sunday Dec 29, 2024 and Wednesday Jan 1, 2025 (same week)
+      const sunday = new Date(2024, 11, 29, 12, 0, 0)
+      const wednesday = new Date(2025, 0, 1, 12, 0, 0)
+
+      expect(isSameWeek(sunday, wednesday)).toBe(true)
+    })
+  })
+
+  describe('getDayIndex', () => {
+    it('should return 0 for Sunday', () => {
+      // 2024-01-07 is a Sunday
+      const sunday = new Date(2024, 0, 7)
+      expect(getDayIndex(sunday)).toBe(0)
+    })
+
+    it('should return 1 for Monday', () => {
+      // 2024-01-08 is a Monday
+      const monday = new Date(2024, 0, 8)
+      expect(getDayIndex(monday)).toBe(1)
+    })
+
+    it('should return 2 for Tuesday', () => {
+      // 2024-01-09 is a Tuesday
+      const tuesday = new Date(2024, 0, 9)
+      expect(getDayIndex(tuesday)).toBe(2)
+    })
+
+    it('should return 3 for Wednesday', () => {
+      // 2024-01-10 is a Wednesday
+      const wednesday = new Date(2024, 0, 10)
+      expect(getDayIndex(wednesday)).toBe(3)
+    })
+
+    it('should return 4 for Thursday', () => {
+      // 2024-01-11 is a Thursday
+      const thursday = new Date(2024, 0, 11)
+      expect(getDayIndex(thursday)).toBe(4)
+    })
+
+    it('should return 5 for Friday', () => {
+      // 2024-01-12 is a Friday
+      const friday = new Date(2024, 0, 12)
+      expect(getDayIndex(friday)).toBe(5)
+    })
+
+    it('should return 6 for Saturday', () => {
+      // 2024-01-13 is a Saturday
+      const saturday = new Date(2024, 0, 13)
+      expect(getDayIndex(saturday)).toBe(6)
+    })
+  })
+})

--- a/src/features/analysis/activity-heatmap/week-utils.ts
+++ b/src/features/analysis/activity-heatmap/week-utils.ts
@@ -1,0 +1,70 @@
+/**
+ * Week Utility Functions
+ *
+ * Pure functions for Sunday-based week date math used by the activity heatmap.
+ * All functions operate in local time (not UTC).
+ *
+ * Week definition: Sunday (dayIndex 0) through Saturday (dayIndex 6).
+ */
+
+/**
+ * Returns Sunday 00:00:00.000 of the week containing the given date.
+ * Uses local time.
+ */
+export function getWeekStart(date: Date): Date {
+  const result = new Date(date)
+  const daysSinceSunday = result.getDay() // 0=Sun already means 0 days back
+  result.setDate(result.getDate() - daysSinceSunday)
+  result.setHours(0, 0, 0, 0)
+  return result
+}
+
+/**
+ * Returns Saturday 23:59:59.999 of the week starting at the given Sunday.
+ */
+export function getWeekEnd(weekStart: Date): Date {
+  const result = new Date(weekStart)
+  result.setDate(result.getDate() + 6)
+  result.setHours(23, 59, 59, 999)
+  return result
+}
+
+/**
+ * Returns the Sunday of the next week (weekStart + 7 days).
+ */
+export function getNextWeekStart(weekStart: Date): Date {
+  const result = new Date(weekStart)
+  result.setDate(result.getDate() + 7)
+  return result
+}
+
+/**
+ * Returns the Sunday of the previous week (weekStart - 7 days).
+ */
+export function getPrevWeekStart(weekStart: Date): Date {
+  const result = new Date(weekStart)
+  result.setDate(result.getDate() - 7)
+  return result
+}
+
+/**
+ * Returns whether two dates fall within the same Sunday-through-Saturday week.
+ */
+export function isSameWeek(a: Date, b: Date): boolean {
+  const weekA = getWeekStart(a)
+  const weekB = getWeekStart(b)
+  return (
+    weekA.getFullYear() === weekB.getFullYear() &&
+    weekA.getMonth() === weekB.getMonth() &&
+    weekA.getDate() === weekB.getDate()
+  )
+}
+
+/**
+ * Converts JS `getDay()` (0=Sun, ..., 6=Sat) to our heatmap index
+ * (0=Sun, 1=Mon, ..., 6=Sat).
+ * Since JS getDay() already uses Sunday=0, this is an identity mapping.
+ */
+export function getDayIndex(date: Date): number {
+  return date.getDay()
+}

--- a/src/features/analysis/coverage-report/calculations/coverage-calculations.test.ts
+++ b/src/features/analysis/coverage-report/calculations/coverage-calculations.test.ts
@@ -46,6 +46,7 @@ function createMockRun(
     coinsEarned: 100000,
     cellsEarned: 50,
     realTime: 3600,
+    gameSpeed: 2.0,
     runType: 'farm',
     ...overrides,
   }

--- a/src/features/analysis/coverage-report/calculations/period-grouping.test.ts
+++ b/src/features/analysis/coverage-report/calculations/period-grouping.test.ts
@@ -45,6 +45,7 @@ function createMockRun(
     coinsEarned: 100000,
     cellsEarned: 50,
     realTime: 3600,
+    gameSpeed: 2.0,
     runType: 'farm',
     ...overrides,
   }

--- a/src/features/analysis/coverage-report/use-coverage-report.test.tsx
+++ b/src/features/analysis/coverage-report/use-coverage-report.test.tsx
@@ -41,6 +41,7 @@ function createMockRun(
     coinsEarned: 100000,
     cellsEarned: 50,
     realTime: 3600,
+    gameSpeed: 2.0,
     runType: 'farm',
     ...overrides,
   }

--- a/src/features/analysis/field-analytics/use-field-selector.test.tsx
+++ b/src/features/analysis/field-analytics/use-field-selector.test.tsx
@@ -13,6 +13,7 @@ describe('useFieldSelector', () => {
       coinsEarned: 50000,
       cellsEarned: 1000,
       realTime: 3600,
+      gameSpeed: 2.0,
       runType: 'farm',
       fields: {}
     }]
@@ -31,6 +32,7 @@ describe('useFieldSelector', () => {
       coinsEarned: 50000,
       cellsEarned: 1000,
       realTime: 3600,
+      gameSpeed: 2.0,
       runType: 'farm',
       fields: {
         damageDealt: {
@@ -63,6 +65,7 @@ describe('useFieldSelector', () => {
       coinsEarned: 50000,
       cellsEarned: 1000,
       realTime: 3600,
+      gameSpeed: 2.0,
       runType: 'farm',
       fields: {}
     }]
@@ -88,6 +91,7 @@ describe('useFieldSelector', () => {
       coinsEarned: 50000,
       cellsEarned: 1000,
       realTime: 3600,
+      gameSpeed: 2.0,
       runType: 'farm',
       fields: {}
     }]
@@ -108,6 +112,7 @@ describe('useFieldSelector', () => {
       coinsEarned: 50000,
       cellsEarned: 1000,
       realTime: 3600,
+      gameSpeed: 2.0,
       runType: 'farm',
       fields: {}
     }]
@@ -138,6 +143,7 @@ describe('useFieldSelector', () => {
       coinsEarned: 50000,
       cellsEarned: 1000,
       realTime: 3600,
+      gameSpeed: 2.0,
       runType: 'farm',
       fields: {}
     }]
@@ -156,6 +162,7 @@ describe('useFieldSelector', () => {
       coinsEarned: 50000,
       cellsEarned: 1000,
       realTime: 3600,
+      gameSpeed: 2.0,
       runType: 'farm',
       fields: {
         waveDuration: {
@@ -186,6 +193,7 @@ describe('useFieldSelector', () => {
       coinsEarned: 50000,
       cellsEarned: 1000,
       realTime: 3600,
+      gameSpeed: 2.0,
       runType: 'farm',
       fields: {}
     }]
@@ -205,6 +213,7 @@ describe('useFieldSelector', () => {
       coinsEarned: 50000,
       cellsEarned: 1000,
       realTime: 3600,
+      gameSpeed: 2.0,
       runType: 'farm',
       fields: {
         damageDealt: {

--- a/src/features/analysis/shared/filtering/run-type-filter.test.ts
+++ b/src/features/analysis/shared/filtering/run-type-filter.test.ts
@@ -14,10 +14,11 @@ const mockRuns: ParsedGameRun[] = [
     coinsEarned: 1000000,
     cellsEarned: 500,
     realTime: 3600,
+    gameSpeed: 2.0,
     runType: RunType.FARM
   },
   {
-    id: '2', 
+    id: '2',
     timestamp: new Date('2023-01-02'),
     fields: {},
     tier: 10,
@@ -25,6 +26,7 @@ const mockRuns: ParsedGameRun[] = [
     coinsEarned: 5000000,
     cellsEarned: 1000,
     realTime: 5400,
+    gameSpeed: 2.0,
     runType: RunType.TOURNAMENT
   },
   {
@@ -36,6 +38,7 @@ const mockRuns: ParsedGameRun[] = [
     coinsEarned: 1500000,
     cellsEarned: 600,
     realTime: 4200,
+    gameSpeed: 2.0,
     runType: RunType.FARM
   },
   {
@@ -47,6 +50,7 @@ const mockRuns: ParsedGameRun[] = [
     coinsEarned: 2000000,
     cellsEarned: 800,
     realTime: 7200,
+    gameSpeed: 2.0,
     runType: RunType.MILESTONE
   }
 ]

--- a/src/features/analysis/shared/parsing/data-parser.ts
+++ b/src/features/analysis/shared/parsing/data-parser.ts
@@ -121,11 +121,12 @@ function extractKeyStatsFromFields(fields: Record<string, GameRunField>): {
   coinsEarned: number;
   cellsEarned: number;
   realTime: number;
+  gameSpeed: number | null;
   runType: RunTypeValue;
 } {
   const tierStr = (fields.tier?.rawValue) || '';
   const runType: RunTypeValue = determineRunType(tierStr);
-  
+
   // Extract numeric tier value from both numeric fields and tournament strings like "8+"
   let tier: number;
   if (fields.tier?.dataType === 'number') {
@@ -136,13 +137,18 @@ function extractKeyStatsFromFields(fields: Record<string, GameRunField>): {
     tier = match ? parseInt(match[1], 10) : 0;
   }
   tier = tier || 0;
-  
+
+  const realTime = (fields.realTime?.value as number) || 0;
+  const gameTime = (fields.gameTime?.value as number) || 0;
+  const gameSpeed = realTime === 0 ? null : Math.round((gameTime / realTime) * 1000) / 1000;
+
   return {
     tier,
     wave: (fields.wave?.value as number) || 0,
     coinsEarned: (fields.coinsEarned?.value as number) || 0,
     cellsEarned: (fields.cellsEarned?.value as number) || 0,
-    realTime: (fields.realTime?.value as number) || 0,
+    realTime,
+    gameSpeed,
     runType
   };
 }

--- a/src/features/analysis/shared/parsing/data-parser.ts
+++ b/src/features/analysis/shared/parsing/data-parser.ts
@@ -14,6 +14,7 @@ import {
   formatIsoDate,
   formatIsoTime
 } from '@/shared/formatting/date-formatters';
+import { calculateGameSpeed } from '@/shared/domain/game-speed-calculation';
 import {
   INTERNAL_FIELD_NAMES,
   isLegacyField,
@@ -140,7 +141,7 @@ function extractKeyStatsFromFields(fields: Record<string, GameRunField>): {
 
   const realTime = (fields.realTime?.value as number) || 0;
   const gameTime = (fields.gameTime?.value as number) || 0;
-  const gameSpeed = realTime === 0 ? null : Math.round((gameTime / realTime) * 1000) / 1000;
+  const gameSpeed = calculateGameSpeed(gameTime, realTime);
 
   return {
     tier,

--- a/src/features/analysis/source-analysis/calculations/period-grouping.test.ts
+++ b/src/features/analysis/source-analysis/calculations/period-grouping.test.ts
@@ -47,6 +47,7 @@ function createMockRun(
     coinsEarned: 100000,
     cellsEarned: 50,
     realTime: 3600,
+    gameSpeed: 2.0,
     runType
   };
 }

--- a/src/features/analysis/source-analysis/calculations/source-extraction.test.ts
+++ b/src/features/analysis/source-analysis/calculations/source-extraction.test.ts
@@ -40,6 +40,7 @@ function createMockRun(fields: Record<string, number>): ParsedGameRun {
     coinsEarned: 100000,
     cellsEarned: 50,
     realTime: 3600,
+    gameSpeed: 2.0,
     runType: 'farm'
   };
 }

--- a/src/features/analysis/source-analysis/use-source-analysis.test.tsx
+++ b/src/features/analysis/source-analysis/use-source-analysis.test.tsx
@@ -37,6 +37,7 @@ function createMockRun(
     coinsEarned: 100000,
     cellsEarned: 50,
     realTime: 3600,
+    gameSpeed: 2.0,
     runType
   };
 }

--- a/src/features/analysis/tier-stats/calculations/field-percentile-calculation.test.ts
+++ b/src/features/analysis/tier-stats/calculations/field-percentile-calculation.test.ts
@@ -13,6 +13,7 @@ describe('calculateFieldPercentiles', () => {
     tier: 1,
     wave: 100,
     realTime: duration,
+    gameSpeed: duration === 0 ? null : 2.0,
     coinsEarned: coins,
     cellsEarned: 0,
     runType: 'farm'
@@ -144,6 +145,7 @@ describe('calculateFieldPercentiles', () => {
       tier: 1,
       wave: 100,
       realTime: 5000,
+      gameSpeed: 2.0,
       coinsEarned: 0,
       cellsEarned: 0,
       runType: 'farm'

--- a/src/features/analysis/tier-stats/calculations/tier-stats-calculator.test.ts
+++ b/src/features/analysis/tier-stats/calculations/tier-stats-calculator.test.ts
@@ -35,6 +35,7 @@ describe('tier-stats-calculator', () => {
     coinsEarned: coins,
     cellsEarned: cells,
     realTime: duration,
+    gameSpeed: duration === 0 ? null : 2.0,
     runType: 'farm'
   })
 

--- a/src/features/analysis/tier-stats/config/tier-stats-config-utils.test.ts
+++ b/src/features/analysis/tier-stats/config/tier-stats-config-utils.test.ts
@@ -31,6 +31,7 @@ describe('tier-stats-config', () => {
     coinsEarned: 100000000,
     cellsEarned: 50000,
     realTime: 9000,
+    gameSpeed: 2.0,
     runType: 'farm',
     ...overrides
   })

--- a/src/features/analysis/tier-stats/config/use-tier-stats-config.test.tsx
+++ b/src/features/analysis/tier-stats/config/use-tier-stats-config.test.tsx
@@ -23,6 +23,7 @@ describe('useTierStatsConfig', () => {
     coinsEarned: 100000000,
     cellsEarned: 50000,
     realTime: 9000,
+    gameSpeed: 2.0,
     runType: 'farm'
   })
 
@@ -357,6 +358,7 @@ describe('useTierStatsConfig', () => {
         coinsEarned: 100000000,
         cellsEarned: 50000,
         realTime: 9000,
+        gameSpeed: 2.0,
         runType: 'farm'
       }]
 

--- a/src/features/analysis/tier-stats/tier-stats-sort.test.ts
+++ b/src/features/analysis/tier-stats/tier-stats-sort.test.ts
@@ -15,6 +15,7 @@ describe('tier-stats-sort', () => {
     tier,
     coinsEarned: coins,
     realTime: duration,
+    gameSpeed: duration === 0 ? null : 2.0,
     wave: 1000,
     cellsEarned: 0,
     runType: 'farm'

--- a/src/features/analysis/tier-trends/calculations/__tests__/test-helpers.ts
+++ b/src/features/analysis/tier-trends/calculations/__tests__/test-helpers.ts
@@ -43,6 +43,7 @@ export function createMockRun(
     coinsEarned: 1000,
     cellsEarned: 500,
     realTime: 1800,
+    gameSpeed: 2.0,
     runType: 'farm',
     ...overrides,
   };

--- a/src/features/analysis/tier-trends/calculations/aggregation-strategies.test.ts
+++ b/src/features/analysis/tier-trends/calculations/aggregation-strategies.test.ts
@@ -37,6 +37,7 @@ function createMockRun(realTimeSeconds: number): ParsedGameRun {
     coinsEarned: 1000,
     cellsEarned: 500,
     realTime: realTimeSeconds,
+    gameSpeed: realTimeSeconds === 0 ? null : 2.0,
     runType: 'farm',
   };
 }

--- a/src/features/analysis/tier-trends/calculations/hourly-rate-calculations.test.ts
+++ b/src/features/analysis/tier-trends/calculations/hourly-rate-calculations.test.ts
@@ -35,6 +35,7 @@ function createMockRun(realTimeSeconds: number): ParsedGameRun {
     coinsEarned: 1000,
     cellsEarned: 500,
     realTime: realTimeSeconds,
+    gameSpeed: realTimeSeconds === 0 ? null : 2.0,
     runType: 'farm',
   };
 }

--- a/src/features/analysis/tier-trends/calculations/run-header-formatting.test.ts
+++ b/src/features/analysis/tier-trends/calculations/run-header-formatting.test.ts
@@ -31,6 +31,7 @@ function createMockRun(overrides: Partial<ParsedGameRun> = {}): ParsedGameRun {
     coinsEarned: 1000,
     cellsEarned: 500,
     realTime: 31415, // 8hr 43min 35sec
+    gameSpeed: 2.0,
     runType: 'farm',
     fields: {
       tier: createMockField(10, 'number', 'Tier'),

--- a/src/features/analysis/tier-trends/use-tier-trends-view-state.test.tsx
+++ b/src/features/analysis/tier-trends/use-tier-trends-view-state.test.tsx
@@ -24,6 +24,7 @@ describe('useTierTrendsViewState', () => {
       coinsEarned: 1130000000000,
       cellsEarned: 45200,
       realTime: 27966,
+      gameSpeed: 2.0,
       runType: RunType.FARM,
       fields: {}
     },
@@ -35,6 +36,7 @@ describe('useTierTrendsViewState', () => {
       coinsEarned: 1100000000000,
       cellsEarned: 44000,
       realTime: 27000,
+      gameSpeed: 2.0,
       runType: RunType.FARM,
       fields: {}
     }

--- a/src/features/analysis/time-series/chart-data.test.ts
+++ b/src/features/analysis/time-series/chart-data.test.ts
@@ -14,6 +14,7 @@ describe('Chart Data Utils', () => {
           coinsEarned: 1000000,
           cellsEarned: 50000,
           realTime: 3600,
+          gameSpeed: 2.0,
           fields: {},
           runType: 'farm'
         },
@@ -25,6 +26,7 @@ describe('Chart Data Utils', () => {
           coinsEarned: 1200000,
           cellsEarned: 60000,
           realTime: 4000,
+          gameSpeed: 2.0,
           fields: {},
           runType: 'farm'
         }
@@ -51,6 +53,7 @@ describe('Chart Data Utils', () => {
           coinsEarned: 1000000,
           cellsEarned: 50000,
           realTime: 3600,
+          gameSpeed: 2.0,
           fields: {},
           runType: 'farm'
         },
@@ -62,6 +65,7 @@ describe('Chart Data Utils', () => {
           coinsEarned: 1200000,
           cellsEarned: 60000,
           realTime: 4000,
+          gameSpeed: 2.0,
           fields: {},
           runType: 'farm'
         }
@@ -95,6 +99,7 @@ describe('Chart Data Utils', () => {
           coinsEarned: 1000000,
           cellsEarned: 50000,
           realTime: 3600,
+          gameSpeed: 2.0,
           fields: {},
           runType: 'farm'
         }
@@ -119,6 +124,7 @@ describe('Chart Data Utils', () => {
           coinsEarned: 1000000,
           cellsEarned: 50000,
           realTime: 3600,
+          gameSpeed: 2.0,
           fields: {},
           runType: 'farm'
         }
@@ -143,6 +149,7 @@ describe('Chart Data Utils', () => {
           coinsEarned: 1000000,
           cellsEarned: 50000,
           realTime: 3600,
+          gameSpeed: 2.0,
           fields: {},
           runType: 'farm'
         }
@@ -165,6 +172,7 @@ describe('Chart Data Utils', () => {
           coinsEarned: 1000000,
           cellsEarned: 50000,
           realTime: 3600,
+          gameSpeed: 2.0,
           fields: {},
           runType: 'farm'
         },
@@ -176,6 +184,7 @@ describe('Chart Data Utils', () => {
           coinsEarned: 1200000,
           cellsEarned: 60000,
           realTime: 4000,
+          gameSpeed: 2.0,
           fields: {},
           runType: 'farm'
         }
@@ -198,6 +207,7 @@ describe('Chart Data Utils', () => {
           coinsEarned: 1000000,
           cellsEarned: 50000,
           realTime: 3600,
+          gameSpeed: 2.0,
           fields: {},
           runType: 'farm'
         }
@@ -220,6 +230,7 @@ describe('Chart Data Utils', () => {
           coinsEarned: 1000000,
           cellsEarned: 50000,
           realTime: 3600,
+          gameSpeed: 2.0,
           fields: {},
           runType: 'farm'
         },
@@ -232,6 +243,7 @@ describe('Chart Data Utils', () => {
           coinsEarned: 1200000,
           cellsEarned: 60000,
           realTime: 4000,
+          gameSpeed: 2.0,
           fields: {},
           runType: 'farm'
         }

--- a/src/features/analysis/time-series/date-aggregation.test.ts
+++ b/src/features/analysis/time-series/date-aggregation.test.ts
@@ -10,6 +10,7 @@ const mockRun1: ParsedGameRun = {
   coinsEarned: 1000000,
   cellsEarned: 50000,
   realTime: 3600,
+  gameSpeed: 2.0,
   fields: {},
   runType: 'farm'
 }
@@ -22,6 +23,7 @@ const mockRun2: ParsedGameRun = {
   coinsEarned: 1200000,
   cellsEarned: 60000,
   realTime: 4000,
+  gameSpeed: 2.0,
   fields: {},
   runType: 'farm'
 }
@@ -34,6 +36,7 @@ const mockRun3: ParsedGameRun = {
   coinsEarned: 1500000,
   cellsEarned: 75000,
   realTime: 4500,
+  gameSpeed: 2.0,
   fields: {},
   runType: 'tournament'
 }

--- a/src/features/analysis/time-series/field-extraction.test.ts
+++ b/src/features/analysis/time-series/field-extraction.test.ts
@@ -12,6 +12,7 @@ describe('extractFieldValue', () => {
       coinsEarned: 50000,
       cellsEarned: 1000,
       realTime: 3600,
+      gameSpeed: 2.0,
       runType: 'farm',
       fields: {}
     }
@@ -28,6 +29,7 @@ describe('extractFieldValue', () => {
       coinsEarned: 50000,
       cellsEarned: 1000,
       realTime: 3600,
+      gameSpeed: 2.0,
       runType: 'farm',
       fields: {}
     }
@@ -44,6 +46,7 @@ describe('extractFieldValue', () => {
       coinsEarned: 75000,
       cellsEarned: 1000,
       realTime: 3600,
+      gameSpeed: 2.0,
       runType: 'farm',
       fields: {}
     }
@@ -60,6 +63,7 @@ describe('extractFieldValue', () => {
       coinsEarned: 50000,
       cellsEarned: 1500,
       realTime: 3600,
+      gameSpeed: 2.0,
       runType: 'farm',
       fields: {}
     }
@@ -76,6 +80,7 @@ describe('extractFieldValue', () => {
       coinsEarned: 50000,
       cellsEarned: 1000,
       realTime: 7200,
+      gameSpeed: 2.0,
       runType: 'farm',
       fields: {}
     }
@@ -92,6 +97,7 @@ describe('extractFieldValue', () => {
       coinsEarned: 50000,
       cellsEarned: 1000,
       realTime: 3600,
+      gameSpeed: 2.0,
       runType: 'farm',
       fields: {
         damageDealt: {
@@ -116,6 +122,7 @@ describe('extractFieldValue', () => {
       coinsEarned: 50000,
       cellsEarned: 1000,
       realTime: 3600,
+      gameSpeed: 2.0,
       runType: 'farm',
       fields: {
         waveDuration: {
@@ -140,6 +147,7 @@ describe('extractFieldValue', () => {
       coinsEarned: 50000,
       cellsEarned: 1000,
       realTime: 3600,
+      gameSpeed: 2.0,
       runType: 'farm',
       fields: {}
     }
@@ -156,6 +164,7 @@ describe('extractFieldValue', () => {
       coinsEarned: 50000,
       cellsEarned: 1000,
       realTime: 3600,
+      gameSpeed: 2.0,
       runType: 'farm',
       fields: {
         notes: {
@@ -180,6 +189,7 @@ describe('extractFieldValue', () => {
       coinsEarned: 50000,
       cellsEarned: 1000,
       realTime: 3600,
+      gameSpeed: 2.0,
       runType: 'farm',
       fields: {
         battleDate: {
@@ -204,6 +214,7 @@ describe('extractFieldValue', () => {
       coinsEarned: 50000,
       cellsEarned: 1000,
       realTime: 3600,
+      gameSpeed: 2.0,
       runType: 'farm',
       fields: {
         customMetric: {
@@ -228,6 +239,7 @@ describe('extractFieldValue', () => {
       coinsEarned: 50000,
       cellsEarned: 1000,
       realTime: 3600,
+      gameSpeed: 2.0,
       runType: 'farm',
       fields: {
         tier: {
@@ -253,6 +265,7 @@ describe('extractFieldValue', () => {
       coinsEarned: 50000,
       cellsEarned: 1000,
       realTime: 3600,
+      gameSpeed: 2.0,
       runType: 'farm',
       fields: {
         invalidDuration: {

--- a/src/features/data-import/csv-import/csv-field-mapping.ts
+++ b/src/features/data-import/csv-import/csv-field-mapping.ts
@@ -109,6 +109,17 @@ export function createFieldMappingReport(
 }
 
 /**
+ * Calculate game speed (gameTime / realTime) rounded to 3 decimal places.
+ * Returns null if realTime is 0 (cannot calculate).
+ */
+function calculateGameSpeed(gameTime: number, realTime: number): number | null {
+  if (realTime === 0) {
+    return null;
+  }
+  return Math.round((gameTime / realTime) * 1000) / 1000;
+}
+
+/**
  * Extract key statistics from fields for cached properties
  */
 export function extractKeyStatsFromFields(fields: Record<string, GameRunField>): {
@@ -117,9 +128,14 @@ export function extractKeyStatsFromFields(fields: Record<string, GameRunField>):
   coinsEarned: number;
   cellsEarned: number;
   realTime: number;
+  gameSpeed: number | null;
   runType: 'farm' | 'tournament' | 'milestone';
 } {
   const numericStats = extractNumericStats(fields);
+
+  // Calculate gameSpeed from gameTime and realTime
+  const gameTime = (fields.gameTime?.value as number) || 0;
+  const gameSpeed = calculateGameSpeed(gameTime, numericStats.realTime);
 
   // Check if _runType field exists (from CSV), otherwise detect from tier
   let runType: 'farm' | 'tournament' | 'milestone';
@@ -132,6 +148,7 @@ export function extractKeyStatsFromFields(fields: Record<string, GameRunField>):
 
   return {
     ...numericStats,
+    gameSpeed,
     runType,
   };
 }

--- a/src/features/data-import/csv-import/csv-field-mapping.ts
+++ b/src/features/data-import/csv-import/csv-field-mapping.ts
@@ -12,6 +12,7 @@ import { isLegacyField, getMigratedFieldName } from '@/shared/domain/fields/inte
 import { extractFieldNamesFromStorage } from '@/shared/domain/fields/field-discovery';
 import { classifyFields } from '@/shared/domain/fields/field-similarity';
 import { detectRunTypeFromFields, extractNumericStats } from '@/shared/domain/run-types/run-type-detection';
+import { calculateGameSpeed } from '@/shared/domain/game-speed-calculation';
 
 /**
  * Create enhanced field mapping report with similarity detection
@@ -106,17 +107,6 @@ export function createFieldMappingReport(
     unsupportedFields,
     skippedFields: [] // No fields are skipped anymore
   };
-}
-
-/**
- * Calculate game speed (gameTime / realTime) rounded to 3 decimal places.
- * Returns null if realTime is 0 (cannot calculate).
- */
-function calculateGameSpeed(gameTime: number, realTime: number): number | null {
-  if (realTime === 0) {
-    return null;
-  }
-  return Math.round((gameTime / realTime) * 1000) / 1000;
 }
 
 /**

--- a/src/features/data-import/csv-import/csv-import-executor.test.ts
+++ b/src/features/data-import/csv-import/csv-import-executor.test.ts
@@ -14,6 +14,7 @@ describe('csv-import-executor', () => {
     coinsEarned: 0,
     cellsEarned: 0,
     realTime: 0,
+    gameSpeed: null,
     runType: 'farm'
   });
 

--- a/src/features/data-import/csv-import/csv-persistence.test.ts
+++ b/src/features/data-import/csv-import/csv-persistence.test.ts
@@ -113,6 +113,7 @@ function createTestRun(id: string, notes?: string, runType: 'farm' | 'tournament
     coinsEarned: 1130000000000,
     cellsEarned: 45200,
     realTime: 27966,
+    gameSpeed: 2.0,
     runType
   };
 }

--- a/src/features/data-import/csv-import/date-warning/date-derivation-fixer.test.ts
+++ b/src/features/data-import/csv-import/date-warning/date-derivation-fixer.test.ts
@@ -37,6 +37,7 @@ function createRun(id: string, timestamp: Date): ParsedGameRun {
     coinsEarned: 0,
     cellsEarned: 0,
     realTime: 3600,
+    gameSpeed: 2.0,
     runType: 'farm',
   };
 }
@@ -193,6 +194,7 @@ describe('applyDateDerivationFixes', () => {
       coinsEarned: 0,
       cellsEarned: 0,
       realTime: 3600,
+      gameSpeed: 2.0,
       runType: 'farm',
     };
     const warnings = [createWarning(1, true, derivedTimestamp)];

--- a/src/features/data-import/csv-import/format-warning/extract-raw-field-data.test.ts
+++ b/src/features/data-import/csv-import/format-warning/extract-raw-field-data.test.ts
@@ -35,6 +35,7 @@ describe('extractRawFieldData', () => {
       coinsEarned: 43.91e12,
       cellsEarned: 1000,
       realTime: 3600,
+      gameSpeed: 2.0,
       runType: 'farm',
     };
 
@@ -55,6 +56,7 @@ describe('extractRawFieldData', () => {
       coinsEarned: 0,
       cellsEarned: 0,
       realTime: 0,
+      gameSpeed: null,
       runType: 'farm',
     };
 
@@ -81,6 +83,7 @@ describe('extractRawFieldData', () => {
       coinsEarned: 0,
       cellsEarned: 0,
       realTime: 0,
+      gameSpeed: null,
       runType: 'farm',
     };
 

--- a/src/features/data-import/csv-import/page/import-button-text.test.ts
+++ b/src/features/data-import/csv-import/page/import-button-text.test.ts
@@ -14,6 +14,7 @@ describe('import-button-text', () => {
     coinsEarned: 0,
     cellsEarned: 0,
     realTime: 0,
+    gameSpeed: null,
     runType: 'farm'
   });
 

--- a/src/features/data-import/manual-entry/data-input-form-logic.test.ts
+++ b/src/features/data-import/manual-entry/data-input-form-logic.test.ts
@@ -15,6 +15,7 @@ function createTestRun(overrides: Partial<ParsedGameRun> = {}): ParsedGameRun {
     coinsEarned: 1000000,
     cellsEarned: 500,
     realTime: 3600,
+    gameSpeed: 2.0,
     runType: 'farm',
     ...overrides,
   };

--- a/src/features/data-import/manual-entry/data-input-preview.test.tsx
+++ b/src/features/data-import/manual-entry/data-input-preview.test.tsx
@@ -10,6 +10,7 @@ const mockPreviewData: ParsedGameRun = {
   tier: 10,
   wave: 5881,
   realTime: 28566, // 7h 46m 6s in seconds
+  gameSpeed: 2.0,
   coinsEarned: 1130000000000, // 1.13T
   cellsEarned: 45200, // 45.2K
   fields: {

--- a/src/features/game-runs/card-view/run-details/breakdown/breakdown-calculations.test.ts
+++ b/src/features/game-runs/card-view/run-details/breakdown/breakdown-calculations.test.ts
@@ -15,6 +15,7 @@ import {
   calculateBreakdownGroup,
   extractPlainFields,
   findUncategorizedFields,
+  calculateGameSpeed,
 } from './breakdown-calculations'
 
 // =============================================================================
@@ -501,3 +502,33 @@ describe('findUncategorizedFields', () => {
     expect(result.items.some(i => i.fieldName === 'newGameFeatureField')).toBe(true)
   })
 })
+
+// =============================================================================
+// calculateGameSpeed
+// =============================================================================
+
+describe('calculateGameSpeed', () => {
+  it('returns ratio of gameTime to realTime', () => {
+    expect(calculateGameSpeed(7200, 3600)).toBe(2)
+  })
+
+  it('returns null when realTime is 0', () => {
+    expect(calculateGameSpeed(7200, 0)).toBeNull()
+  })
+
+  it('handles fractional results', () => {
+    expect(calculateGameSpeed(5400, 3600)).toBe(1.5)
+  })
+
+  it('returns 0 when gameTime is 0', () => {
+    expect(calculateGameSpeed(0, 3600)).toBe(0)
+  })
+
+  it('handles typical 2x speed scenario', () => {
+    // 2 hours game time, 1 hour real time = 2x multiplier
+    const gameTime = 2 * 60 * 60 // 2 hours in seconds
+    const realTime = 1 * 60 * 60 // 1 hour in seconds
+    expect(calculateGameSpeed(gameTime, realTime)).toBe(2)
+  })
+})
+

--- a/src/features/game-runs/card-view/run-details/breakdown/breakdown-calculations.test.ts
+++ b/src/features/game-runs/card-view/run-details/breakdown/breakdown-calculations.test.ts
@@ -15,7 +15,6 @@ import {
   calculateBreakdownGroup,
   extractPlainFields,
   findUncategorizedFields,
-  calculateGameSpeed,
 } from './breakdown-calculations'
 
 // =============================================================================
@@ -503,32 +502,4 @@ describe('findUncategorizedFields', () => {
   })
 })
 
-// =============================================================================
-// calculateGameSpeed
-// =============================================================================
-
-describe('calculateGameSpeed', () => {
-  it('returns ratio of gameTime to realTime', () => {
-    expect(calculateGameSpeed(7200, 3600)).toBe(2)
-  })
-
-  it('returns null when realTime is 0', () => {
-    expect(calculateGameSpeed(7200, 0)).toBeNull()
-  })
-
-  it('handles fractional results', () => {
-    expect(calculateGameSpeed(5400, 3600)).toBe(1.5)
-  })
-
-  it('returns 0 when gameTime is 0', () => {
-    expect(calculateGameSpeed(0, 3600)).toBe(0)
-  })
-
-  it('handles typical 2x speed scenario', () => {
-    // 2 hours game time, 1 hour real time = 2x multiplier
-    const gameTime = 2 * 60 * 60 // 2 hours in seconds
-    const realTime = 1 * 60 * 60 // 1 hour in seconds
-    expect(calculateGameSpeed(gameTime, realTime)).toBe(2)
-  })
-})
 

--- a/src/features/game-runs/card-view/run-details/breakdown/breakdown-calculations.ts
+++ b/src/features/game-runs/card-view/run-details/breakdown/breakdown-calculations.ts
@@ -77,20 +77,6 @@ export function calculatePerHourRate(value: number, durationSeconds: number): nu
 }
 
 /**
- * Calculate game speed multiplier (gameTime / realTime).
- * Returns null if realTime is 0 (cannot calculate).
- */
-export function calculateGameSpeed(
-  gameTimeSeconds: number,
-  realTimeSeconds: number
-): number | null {
-  if (realTimeSeconds === 0) {
-    return null
-  }
-  return gameTimeSeconds / realTimeSeconds
-}
-
-/**
  * Sort breakdown items by percentage descending.
  * Uses value as tiebreaker for equal percentages.
  */

--- a/src/features/game-runs/card-view/run-details/breakdown/breakdown-calculations.ts
+++ b/src/features/game-runs/card-view/run-details/breakdown/breakdown-calculations.ts
@@ -77,6 +77,20 @@ export function calculatePerHourRate(value: number, durationSeconds: number): nu
 }
 
 /**
+ * Calculate game speed multiplier (gameTime / realTime).
+ * Returns null if realTime is 0 (cannot calculate).
+ */
+export function calculateGameSpeed(
+  gameTimeSeconds: number,
+  realTimeSeconds: number
+): number | null {
+  if (realTimeSeconds === 0) {
+    return null
+  }
+  return gameTimeSeconds / realTimeSeconds
+}
+
+/**
  * Sort breakdown items by percentage descending.
  * Uses value as tiebreaker for equal percentages.
  */

--- a/src/features/game-runs/card-view/run-details/test-helpers.ts
+++ b/src/features/game-runs/card-view/run-details/test-helpers.ts
@@ -45,6 +45,7 @@ export function createMockRun(
     coinsEarned: 100000,
     cellsEarned: 50,
     realTime: 3600,
+    gameSpeed: 2.0,
     runType: 'farm',
     ...overrides,
   }

--- a/src/features/game-runs/card-view/run-details/use-run-details-data.test.tsx
+++ b/src/features/game-runs/card-view/run-details/use-run-details-data.test.tsx
@@ -35,7 +35,8 @@ describe('useRunDetailsData', () => {
 
       const { result } = renderHook(() => useRunDetailsData(run))
 
-      expect(result.current.battleReport.essential.items).toHaveLength(5)
+      // 5 essential fields + 1 computed gameSpeed
+      expect(result.current.battleReport.essential.items).toHaveLength(6)
       expect(result.current.battleReport.essential.items.some(i => i.fieldName === 'tier')).toBe(true)
     })
 
@@ -69,8 +70,38 @@ describe('useRunDetailsData', () => {
       const { result } = renderHook(() => useRunDetailsData(run))
       const essential = result.current.battleReport.essential
 
-      expect(essential.items).toHaveLength(5)
+      // 5 essential fields + 1 computed gameSpeed
+      expect(essential.items).toHaveLength(6)
       expect(essential.items.find(i => i.fieldName === 'tier')?.displayValue).toBe('11')
+    })
+
+    it('calculates game speed from gameTime and realTime', () => {
+      const run = createMockRun({
+        gameTime: 7200, // 2 hours in seconds
+        realTime: 3600, // 1 hour in seconds
+      })
+
+      const { result } = renderHook(() => useRunDetailsData(run))
+      const essential = result.current.battleReport.essential
+
+      const gameSpeed = essential.items.find(i => i.fieldName === 'gameSpeed')
+      expect(gameSpeed).toBeDefined()
+      expect(gameSpeed!.displayName).toBe('Game Speed')
+      expect(gameSpeed!.displayValue).toBe('2.000x')
+    })
+
+    it('omits game speed when realTime is 0', () => {
+      const run = createMockRun({
+        gameTime: 7200,
+      }, {
+        realTime: 0, // Override the cached property
+      })
+
+      const { result } = renderHook(() => useRunDetailsData(run))
+      const essential = result.current.battleReport.essential
+
+      const gameSpeed = essential.items.find(i => i.fieldName === 'gameSpeed')
+      expect(gameSpeed).toBeUndefined()
     })
 
     it('extracts miscellaneous fields when present', () => {

--- a/src/features/game-runs/card-view/run-details/use-run-details-data.test.tsx
+++ b/src/features/game-runs/card-view/run-details/use-run-details-data.test.tsx
@@ -87,7 +87,7 @@ describe('useRunDetailsData', () => {
       const gameSpeed = essential.items.find(i => i.fieldName === 'gameSpeed')
       expect(gameSpeed).toBeDefined()
       expect(gameSpeed!.displayName).toBe('Game Speed')
-      expect(gameSpeed!.displayValue).toBe('2.000x')
+      expect(gameSpeed!.displayValue).toBe('2x')
     })
 
     it('omits game speed when realTime is 0', () => {

--- a/src/features/game-runs/card-view/run-details/use-run-details-data.test.tsx
+++ b/src/features/game-runs/card-view/run-details/use-run-details-data.test.tsx
@@ -95,6 +95,7 @@ describe('useRunDetailsData', () => {
         gameTime: 7200,
       }, {
         realTime: 0, // Override the cached property
+        gameSpeed: null, // gameSpeed is null when realTime is 0
       })
 
       const { result } = renderHook(() => useRunDetailsData(run))

--- a/src/features/game-runs/card-view/run-details/use-run-details-data.ts
+++ b/src/features/game-runs/card-view/run-details/use-run-details-data.ts
@@ -13,7 +13,10 @@ import {
   extractPlainFields,
   findUncategorizedFields,
   calculatePerHourRate,
+  extractFieldValue,
+  calculateGameSpeed,
 } from './breakdown/breakdown-calculations'
+import { formatGameSpeed } from '@/shared/formatting/run-display-formatters'
 import { formatLargeNumber } from '@/shared/formatting/number-scale'
 import {
   BATTLE_REPORT_ESSENTIAL,
@@ -43,6 +46,17 @@ export function useRunDetailsData(run: ParsedGameRun): RunDetailsData {
     const battleReport = {
       essential: extractPlainFields(run, BATTLE_REPORT_ESSENTIAL),
       miscellaneous: extractPlainFields(run, BATTLE_REPORT_MISCELLANEOUS),
+    }
+
+    // Add game speed as a computed field (gameTime / realTime)
+    const gameTimeSeconds = extractFieldValue(run, 'gameTime')
+    const gameSpeed = calculateGameSpeed(gameTimeSeconds, run.realTime)
+    if (gameSpeed !== null) {
+      battleReport.essential.items.push({
+        fieldName: 'gameSpeed',
+        displayName: 'Game Speed',
+        displayValue: formatGameSpeed(gameSpeed),
+      })
     }
 
     // Combat section

--- a/src/features/game-runs/card-view/run-details/use-run-details-data.ts
+++ b/src/features/game-runs/card-view/run-details/use-run-details-data.ts
@@ -13,8 +13,6 @@ import {
   extractPlainFields,
   findUncategorizedFields,
   calculatePerHourRate,
-  extractFieldValue,
-  calculateGameSpeed,
 } from './breakdown/breakdown-calculations'
 import { formatGameSpeed } from '@/shared/formatting/run-display-formatters'
 import { formatLargeNumber } from '@/shared/formatting/number-scale'
@@ -48,14 +46,12 @@ export function useRunDetailsData(run: ParsedGameRun): RunDetailsData {
       miscellaneous: extractPlainFields(run, BATTLE_REPORT_MISCELLANEOUS),
     }
 
-    // Add game speed as a computed field (gameTime / realTime)
-    const gameTimeSeconds = extractFieldValue(run, 'gameTime')
-    const gameSpeed = calculateGameSpeed(gameTimeSeconds, run.realTime)
-    if (gameSpeed !== null) {
+    // Add game speed from cached property
+    if (run.gameSpeed !== null) {
       battleReport.essential.items.push({
         fieldName: 'gameSpeed',
         displayName: 'Game Speed',
-        displayValue: formatGameSpeed(gameSpeed),
+        displayValue: formatGameSpeed(run.gameSpeed),
       })
     }
 

--- a/src/features/game-runs/card-view/run-details/use-run-details-data.ts
+++ b/src/features/game-runs/card-view/run-details/use-run-details-data.ts
@@ -14,7 +14,7 @@ import {
   findUncategorizedFields,
   calculatePerHourRate,
 } from './breakdown/breakdown-calculations'
-import { formatGameSpeed } from '@/shared/formatting/run-display-formatters'
+import { formatMultiplier } from '@/shared/formatting/run-display-formatters'
 import { formatLargeNumber } from '@/shared/formatting/number-scale'
 import {
   BATTLE_REPORT_ESSENTIAL,
@@ -51,7 +51,7 @@ export function useRunDetailsData(run: ParsedGameRun): RunDetailsData {
       battleReport.essential.items.push({
         fieldName: 'gameSpeed',
         displayName: 'Game Speed',
-        displayValue: formatGameSpeed(run.gameSpeed),
+        displayValue: formatMultiplier(run.gameSpeed),
       })
     }
 

--- a/src/features/game-runs/editing/field-update-logic.test.ts
+++ b/src/features/game-runs/editing/field-update-logic.test.ts
@@ -197,7 +197,7 @@ describe('field-update-logic', () => {
 
   describe('extractRunTypeValue', () => {
     it('should extract run type from fields when available', () => {
-      const run = {
+      const run: ParsedGameRun = {
         id: '1',
         timestamp: new Date(),
         fields: {
@@ -214,8 +214,9 @@ describe('field-update-logic', () => {
         coinsEarned: 1000,
         cellsEarned: 100,
         realTime: 3600,
+        gameSpeed: 2.0,
         runType: 'farm' as const,
-      } as ParsedGameRun;
+      };
 
       const result = extractRunTypeValue(run);
 
@@ -223,7 +224,7 @@ describe('field-update-logic', () => {
     });
 
     it('should fallback to runType property when field not available', () => {
-      const run = {
+      const run: ParsedGameRun = {
         id: '1',
         timestamp: new Date(),
         fields: {},
@@ -232,8 +233,9 @@ describe('field-update-logic', () => {
         coinsEarned: 1000,
         cellsEarned: 100,
         realTime: 3600,
+        gameSpeed: 2.0,
         runType: 'farm' as const,
-      } as ParsedGameRun;
+      };
 
       const result = extractRunTypeValue(run);
 
@@ -250,15 +252,16 @@ describe('field-update-logic', () => {
         coinsEarned: 1000,
         cellsEarned: 100,
         realTime: 3600,
+        gameSpeed: 2.0,
       };
 
-      const farmRun = { ...baseRun, runType: 'farm' as const } as ParsedGameRun;
+      const farmRun: ParsedGameRun = { ...baseRun, runType: 'farm' as const };
       expect(extractRunTypeValue(farmRun)).toBe('farm');
 
-      const tournamentRun = { ...baseRun, runType: 'tournament' as const } as ParsedGameRun;
+      const tournamentRun: ParsedGameRun = { ...baseRun, runType: 'tournament' as const };
       expect(extractRunTypeValue(tournamentRun)).toBe('tournament');
 
-      const milestoneRun = { ...baseRun, runType: 'milestone' as const } as ParsedGameRun;
+      const milestoneRun: ParsedGameRun = { ...baseRun, runType: 'milestone' as const };
       expect(extractRunTypeValue(milestoneRun)).toBe('milestone');
     });
   });

--- a/src/features/game-runs/filters/filter-runs-by-type.test.ts
+++ b/src/features/game-runs/filters/filter-runs-by-type.test.ts
@@ -14,6 +14,7 @@ function createMockRun(overrides: Partial<ParsedGameRun> = {}): ParsedGameRun {
     coinsEarned: 1000000,
     cellsEarned: 500,
     realTime: 3600,
+    gameSpeed: 2.0,
     runType: RunType.FARM,
     ...overrides,
   }

--- a/src/features/game-runs/filters/tier-filter-logic.test.ts
+++ b/src/features/game-runs/filters/tier-filter-logic.test.ts
@@ -11,6 +11,7 @@ const mockRun = (id: string, tier: number): ParsedGameRun => ({
   coinsEarned: 100,
   cellsEarned: 10,
   realTime: 60,
+  gameSpeed: 2.0,
   runType: 'farm'
 });
 

--- a/src/features/game-runs/filters/use-filtered-runs.test.tsx
+++ b/src/features/game-runs/filters/use-filtered-runs.test.tsx
@@ -26,6 +26,7 @@ function createMockRun(overrides: Partial<ParsedGameRun> = {}): ParsedGameRun {
     coinsEarned: 1000000,
     cellsEarned: 500,
     realTime: 3600,
+    gameSpeed: 2.0,
     runType: RunType.FARM,
     ...overrides,
   }

--- a/src/features/game-runs/filters/use-tier-filter.test.ts
+++ b/src/features/game-runs/filters/use-tier-filter.test.ts
@@ -11,6 +11,7 @@ const mockRun = (id: string, tier: number): ParsedGameRun => ({
   coinsEarned: 100,
   cellsEarned: 10,
   realTime: 60,
+  gameSpeed: 2.0,
   runType: 'farm'
 });
 

--- a/src/features/navigation/chart-navigation/chart-tabs-config.test.ts
+++ b/src/features/navigation/chart-navigation/chart-tabs-config.test.ts
@@ -3,8 +3,8 @@ import { CHART_TABS, getValidChartRoutes } from './chart-tabs-config'
 
 describe('chart-tabs-config', () => {
   describe('CHART_TABS', () => {
-    it('should have 8 chart tabs', () => {
-      expect(CHART_TABS).toHaveLength(8)
+    it('should have 9 chart tabs', () => {
+      expect(CHART_TABS).toHaveLength(9)
     })
 
     it('should have all required properties for each tab', () => {
@@ -39,7 +39,7 @@ describe('chart-tabs-config', () => {
   describe('getValidChartRoutes', () => {
     it('should return all chart routes', () => {
       const routes = getValidChartRoutes()
-      expect(routes).toHaveLength(8)
+      expect(routes).toHaveLength(9)
     })
 
     it('should return routes matching CHART_TABS', () => {
@@ -66,6 +66,11 @@ describe('chart-tabs-config', () => {
     it('should include coverage route', () => {
       const routes = getValidChartRoutes()
       expect(routes).toContain('/charts/coverage')
+    })
+
+    it('should include activity route', () => {
+      const routes = getValidChartRoutes()
+      expect(routes).toContain('/charts/activity')
     })
   })
 })

--- a/src/features/navigation/chart-navigation/chart-tabs-config.ts
+++ b/src/features/navigation/chart-navigation/chart-tabs-config.ts
@@ -61,6 +61,13 @@ export const CHART_TABS: TabConfig[] = [
     shortLabel: 'Coverage',
     activeClassName: 'data-[active=true]:bg-cyan-500/15 data-[active=true]:text-cyan-100 hover:bg-cyan-500/10',
   },
+  {
+    value: 'activity',
+    route: '/charts/activity',
+    label: 'Activity',
+    shortLabel: 'Activity',
+    activeClassName: 'data-[active=true]:bg-amber-500/15 data-[active=true]:text-amber-100 hover:bg-amber-500/10',
+  },
 ]
 
 /**

--- a/src/features/navigation/chart-navigation/chart-tabs-navigation.tsx
+++ b/src/features/navigation/chart-navigation/chart-tabs-navigation.tsx
@@ -11,7 +11,7 @@ export function ChartTabsNavigation() {
       tabs={CHART_TABS}
       ariaLabel="Chart analytics navigation"
       maxWidth="max-w-6xl"
-      columns={8}
+      columns={9}
     />
   )
 }

--- a/src/features/navigation/config/navigation-config.ts
+++ b/src/features/navigation/config/navigation-config.ts
@@ -76,6 +76,12 @@ export const NAVIGATION_SECTIONS: NavigationSection[] = [
         label: 'Coverage Report',
         href: '/charts/coverage',
         icon: 'field-analytics'
+      },
+      {
+        id: 'activity-heatmap',
+        label: 'Activity',
+        href: '/charts/activity',
+        icon: 'field-analytics'
       }
     ]
   },

--- a/src/features/navigation/runs-navigation/run-counts-logic.test.ts
+++ b/src/features/navigation/runs-navigation/run-counts-logic.test.ts
@@ -14,6 +14,7 @@ function createMockRun(overrides: Partial<ParsedGameRun> = {}): ParsedGameRun {
     coinsEarned: 1000000,
     cellsEarned: 500,
     realTime: 3600,
+    gameSpeed: 2.0,
     runType: RunType.FARM,
     ...overrides,
   }

--- a/src/features/navigation/tabs-navigation/tabs-navigation.tsx
+++ b/src/features/navigation/tabs-navigation/tabs-navigation.tsx
@@ -42,6 +42,8 @@ export function TabsNavigation({
         return 'grid-cols-2 sm:grid-cols-4 lg:grid-cols-7'
       case 8:
         return 'grid-cols-2 sm:grid-cols-4 lg:grid-cols-8'
+      case 9:
+        return 'grid-cols-3 sm:grid-cols-3 lg:grid-cols-9'
       default:
         return 'grid-cols-2 sm:grid-cols-4 lg:grid-cols-8'
     }

--- a/src/features/spending-planner/income/derived-income-calculation.test.ts
+++ b/src/features/spending-planner/income/derived-income-calculation.test.ts
@@ -45,6 +45,7 @@ function createMockRun(
     coinsEarned,
     cellsEarned: 0,
     realTime: 3600,
+    gameSpeed: 2.0,
     runType: 'farm',
     fields: {
       rerollShardsEarned: createField(rerollShardsEarned),

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -34,6 +34,7 @@ import { Route as ChartsDeathsRouteImport } from './routes/charts/deaths'
 import { Route as ChartsCoverageRouteImport } from './routes/charts/coverage'
 import { Route as ChartsCoinsRouteImport } from './routes/charts/coins'
 import { Route as ChartsCellsRouteImport } from './routes/charts/cells'
+import { Route as ChartsActivityRouteImport } from './routes/charts/activity'
 
 const ToolsRoute = ToolsRouteImport.update({
   id: '/tools',
@@ -160,6 +161,11 @@ const ChartsCellsRoute = ChartsCellsRouteImport.update({
   path: '/cells',
   getParentRoute: () => ChartsRoute,
 } as any)
+const ChartsActivityRoute = ChartsActivityRouteImport.update({
+  id: '/activity',
+  path: '/activity',
+  getParentRoute: () => ChartsRoute,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -167,6 +173,7 @@ export interface FileRoutesByFullPath {
   '/runs': typeof RunsRouteWithChildren
   '/settings': typeof SettingsRouteWithChildren
   '/tools': typeof ToolsRouteWithChildren
+  '/charts/activity': typeof ChartsActivityRoute
   '/charts/cells': typeof ChartsCellsRoute
   '/charts/coins': typeof ChartsCoinsRoute
   '/charts/coverage': typeof ChartsCoverageRoute
@@ -191,6 +198,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/tools': typeof ToolsRouteWithChildren
+  '/charts/activity': typeof ChartsActivityRoute
   '/charts/cells': typeof ChartsCellsRoute
   '/charts/coins': typeof ChartsCoinsRoute
   '/charts/coverage': typeof ChartsCoverageRoute
@@ -219,6 +227,7 @@ export interface FileRoutesById {
   '/runs': typeof RunsRouteWithChildren
   '/settings': typeof SettingsRouteWithChildren
   '/tools': typeof ToolsRouteWithChildren
+  '/charts/activity': typeof ChartsActivityRoute
   '/charts/cells': typeof ChartsCellsRoute
   '/charts/coins': typeof ChartsCoinsRoute
   '/charts/coverage': typeof ChartsCoverageRoute
@@ -248,6 +257,7 @@ export interface FileRouteTypes {
     | '/runs'
     | '/settings'
     | '/tools'
+    | '/charts/activity'
     | '/charts/cells'
     | '/charts/coins'
     | '/charts/coverage'
@@ -272,6 +282,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/tools'
+    | '/charts/activity'
     | '/charts/cells'
     | '/charts/coins'
     | '/charts/coverage'
@@ -299,6 +310,7 @@ export interface FileRouteTypes {
     | '/runs'
     | '/settings'
     | '/tools'
+    | '/charts/activity'
     | '/charts/cells'
     | '/charts/coins'
     | '/charts/coverage'
@@ -506,10 +518,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ChartsCellsRouteImport
       parentRoute: typeof ChartsRoute
     }
+    '/charts/activity': {
+      id: '/charts/activity'
+      path: '/activity'
+      fullPath: '/charts/activity'
+      preLoaderRoute: typeof ChartsActivityRouteImport
+      parentRoute: typeof ChartsRoute
+    }
   }
 }
 
 interface ChartsRouteChildren {
+  ChartsActivityRoute: typeof ChartsActivityRoute
   ChartsCellsRoute: typeof ChartsCellsRoute
   ChartsCoinsRoute: typeof ChartsCoinsRoute
   ChartsCoverageRoute: typeof ChartsCoverageRoute
@@ -522,6 +542,7 @@ interface ChartsRouteChildren {
 }
 
 const ChartsRouteChildren: ChartsRouteChildren = {
+  ChartsActivityRoute: ChartsActivityRoute,
   ChartsCellsRoute: ChartsCellsRoute,
   ChartsCoinsRoute: ChartsCoinsRoute,
   ChartsCoverageRoute: ChartsCoverageRoute,

--- a/src/routes/charts/activity.tsx
+++ b/src/routes/charts/activity.tsx
@@ -1,0 +1,19 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { ChartPageLayout } from '@/shared/layouts'
+import { ActivityHeatmap } from '@/features/analysis/activity-heatmap/activity-heatmap'
+
+export const Route = createFileRoute('/charts/activity')({
+  component: ActivityHeatmapRoute,
+})
+
+function ActivityHeatmapRoute() {
+  return (
+    <ChartPageLayout
+      accentColor="amber"
+      title="Activity Heatmap"
+      description="Visualize your play sessions across a weekly calendar to identify patterns and optimize your gaming schedule."
+    >
+      <ActivityHeatmap />
+    </ChartPageLayout>
+  )
+}

--- a/src/shared/domain/data-migrations.test.ts
+++ b/src/shared/domain/data-migrations.test.ts
@@ -298,6 +298,7 @@ Test\tfarm\t14:30:00\t2024-01-15\t10`;
         coinsEarned: 1500000000000,
         cellsEarned: 45200,
         realTime: 27966,
+        gameSpeed: 2.0,
         runType: 'farm',
         fields: {
           date: { value: '2024-01-15', rawValue: '2024-01-15', displayValue: '2024-01-15', originalKey: 'Date', dataType: 'string' },
@@ -334,6 +335,7 @@ Test\tfarm\t14:30:00\t2024-01-15\t10`;
         coinsEarned: 1500000000000,
         cellsEarned: 45200,
         realTime: 27966,
+        gameSpeed: 2.0,
         runType: 'farm',
         fields: {
           tier: { value: 10, rawValue: '10', displayValue: '10', originalKey: 'Tier', dataType: 'number' },
@@ -363,6 +365,7 @@ Test\tfarm\t14:30:00\t2024-01-15\t10`;
         coinsEarned: 1500000000000,
         cellsEarned: 45200,
         realTime: 27966,
+        gameSpeed: 2.0,
         runType: 'farm',
         fields: {
           date: { value: '2024-01-15', rawValue: '2024-01-15', displayValue: '2024-01-15', originalKey: 'Date', dataType: 'string' }

--- a/src/shared/domain/duplicate-detection/duplicate-detection.test.ts
+++ b/src/shared/domain/duplicate-detection/duplicate-detection.test.ts
@@ -19,6 +19,7 @@ function createMockRun(overrides: Partial<ParsedGameRun> = {}): ParsedGameRun {
     coinsEarned: 1000000,
     cellsEarned: 50000,
     realTime: 7200, // 2 hours
+    gameSpeed: 2.0,
     runType: 'farm',
     ...overrides
   };

--- a/src/shared/domain/fields/field-discovery.ts
+++ b/src/shared/domain/fields/field-discovery.ts
@@ -88,7 +88,7 @@ export function extractNumericFieldNames(runs: ParsedGameRun[]): string[] {
   const numericFields = new Set<string>()
 
   // Add cached numeric properties
-  const cachedNumericProps = ['tier', 'wave', 'coinsEarned', 'cellsEarned', 'realTime']
+  const cachedNumericProps = ['tier', 'wave', 'coinsEarned', 'cellsEarned', 'realTime', 'gameSpeed']
   cachedNumericProps.forEach(prop => numericFields.add(prop))
 
   // Scan all runs for dynamic numeric fields
@@ -112,7 +112,7 @@ export function extractNumericFieldNames(runs: ParsedGameRun[]): string[] {
  */
 export function getFieldDataType(runs: ParsedGameRun[], fieldKey: string): string {
   // Check if it's a cached property
-  const cachedNumericProps = ['tier', 'wave', 'coinsEarned', 'cellsEarned', 'realTime']
+  const cachedNumericProps = ['tier', 'wave', 'coinsEarned', 'cellsEarned', 'realTime', 'gameSpeed']
   if (cachedNumericProps.includes(fieldKey)) {
     return 'number'
   }

--- a/src/shared/domain/fields/field-extraction.test.ts
+++ b/src/shared/domain/fields/field-extraction.test.ts
@@ -110,6 +110,7 @@ describe('extractFieldNamesFromRuns', () => {
       coinsEarned: 50000,
       cellsEarned: 1000,
       realTime: 3600,
+      gameSpeed: 2.0,
       runType: 'farm',
       fields: {
         damageDealt: {
@@ -153,6 +154,7 @@ describe('extractFieldNamesFromRuns', () => {
       coinsEarned: 50000,
       cellsEarned: 1000,
       realTime: 3600,
+      gameSpeed: 2.0,
       runType: 'farm',
       fields: {
         damageDealt: {
@@ -180,6 +182,7 @@ describe('extractFieldNamesFromRuns', () => {
       coinsEarned: 60000,
       cellsEarned: 1100,
       realTime: 3700,
+      gameSpeed: 2.0,
       runType: 'farm',
       fields: {
         damageDealt: {

--- a/src/shared/domain/fields/field-formatters.ts
+++ b/src/shared/domain/fields/field-formatters.ts
@@ -1,5 +1,6 @@
 import { formatLargeNumber } from '@/features/analysis/shared/formatting/chart-formatters'
 import { formatDuration } from '@/features/analysis/shared/parsing/data-parser'
+import { formatGameSpeed } from '@/shared/formatting/run-display-formatters'
 
 /**
  * Convert field key to human-readable display name
@@ -30,6 +31,11 @@ export function getFieldFormatter(fieldKey: string, dataType: string): (value: n
   // Duration fields show as "HH:MM:SS" or "Xh Ym Zs"
   if (dataType === 'duration' || fieldKey === 'realTime') {
     return formatDuration
+  }
+
+  // Game speed shows as "Y.YYYx" (3 decimal places)
+  if (fieldKey === 'gameSpeed') {
+    return formatGameSpeed
   }
 
   // Default: use large number formatting (K, M, B, T, Q, etc.) for all numeric fields

--- a/src/shared/domain/fields/field-formatters.ts
+++ b/src/shared/domain/fields/field-formatters.ts
@@ -1,6 +1,6 @@
 import { formatLargeNumber } from '@/features/analysis/shared/formatting/chart-formatters'
 import { formatDuration } from '@/features/analysis/shared/parsing/data-parser'
-import { formatGameSpeed } from '@/shared/formatting/run-display-formatters'
+import { formatMultiplier } from '@/shared/formatting/run-display-formatters'
 
 /**
  * Convert field key to human-readable display name
@@ -35,7 +35,7 @@ export function getFieldFormatter(fieldKey: string, dataType: string): (value: n
 
   // Game speed shows as "Y.YYYx" (3 decimal places)
   if (fieldKey === 'gameSpeed') {
-    return formatGameSpeed
+    return formatMultiplier
   }
 
   // Default: use large number formatting (K, M, B, T, Q, etc.) for all numeric fields

--- a/src/shared/domain/fields/numeric-fields.test.ts
+++ b/src/shared/domain/fields/numeric-fields.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { describe, it, expect } from 'vitest';
 import {
   extractNumericFieldNames,
@@ -20,6 +21,7 @@ describe('extractNumericFieldNames', () => {
       coinsEarned: 50000,
       cellsEarned: 1000,
       realTime: 3600,
+      gameSpeed: 2.0,
       runType: 'farm',
       fields: {}
     };
@@ -42,6 +44,7 @@ describe('extractNumericFieldNames', () => {
       coinsEarned: 50000,
       cellsEarned: 1000,
       realTime: 3600,
+      gameSpeed: 2.0,
       runType: 'farm',
       fields: {
         damageDealt: {
@@ -76,6 +79,7 @@ describe('extractNumericFieldNames', () => {
       coinsEarned: 50000,
       cellsEarned: 1000,
       realTime: 3600,
+      gameSpeed: 2.0,
       runType: 'farm',
       fields: {
         waveDuration: {
@@ -102,6 +106,7 @@ describe('extractNumericFieldNames', () => {
       coinsEarned: 50000,
       cellsEarned: 1000,
       realTime: 3600,
+      gameSpeed: 2.0,
       runType: 'farm',
       fields: {
         notes: {
@@ -136,6 +141,7 @@ describe('extractNumericFieldNames', () => {
       coinsEarned: 50000,
       cellsEarned: 1000,
       realTime: 3600,
+      gameSpeed: 2.0,
       runType: 'farm',
       fields: {
         damageDealt: {
@@ -156,6 +162,7 @@ describe('extractNumericFieldNames', () => {
       coinsEarned: 60000,
       cellsEarned: 1100,
       realTime: 3700,
+      gameSpeed: 2.0,
       runType: 'farm',
       fields: {
         damageDealt: {
@@ -193,6 +200,7 @@ describe('extractNumericFieldNames', () => {
       coinsEarned: 50000,
       cellsEarned: 1000,
       realTime: 3600,
+      gameSpeed: 2.0,
       runType: 'farm',
       fields: {
         zebra: {
@@ -230,6 +238,7 @@ describe('getFieldDataType', () => {
       coinsEarned: 50000,
       cellsEarned: 1000,
       realTime: 3600,
+      gameSpeed: 2.0,
       runType: 'farm',
       fields: {}
     }];
@@ -250,6 +259,7 @@ describe('getFieldDataType', () => {
       coinsEarned: 50000,
       cellsEarned: 1000,
       realTime: 3600,
+      gameSpeed: 2.0,
       runType: 'farm',
       fields: {
         damageDealt: {
@@ -282,6 +292,7 @@ describe('getFieldDataType', () => {
       coinsEarned: 50000,
       cellsEarned: 1000,
       realTime: 3600,
+      gameSpeed: 2.0,
       runType: 'farm',
       fields: {}
     }];
@@ -299,6 +310,7 @@ describe('getFieldDataType', () => {
         coinsEarned: 50000,
         cellsEarned: 1000,
         realTime: 3600,
+        gameSpeed: 2.0,
         runType: 'farm',
         fields: {}
       },
@@ -310,6 +322,7 @@ describe('getFieldDataType', () => {
         coinsEarned: 60000,
         cellsEarned: 1100,
         realTime: 3700,
+        gameSpeed: 2.0,
         runType: 'farm',
         fields: {
           damageDealt: {

--- a/src/shared/domain/filters/duration/duration-filter-logic.test.ts
+++ b/src/shared/domain/filters/duration/duration-filter-logic.test.ts
@@ -19,9 +19,10 @@ function createMockRunWithDate(date: Date): ParsedGameRun {
     coinsEarned: 1000,
     cellsEarned: 100,
     realTime: 3600,
+    gameSpeed: 2.0,
     runType: 'farm',
     fields: {}
-  } as ParsedGameRun
+  }
 }
 
 describe('getAvailableDurations', () => {

--- a/src/shared/domain/filters/tier/tier-filter-logic.test.ts
+++ b/src/shared/domain/filters/tier/tier-filter-logic.test.ts
@@ -20,9 +20,10 @@ function createMockRun(tier: number, runType: 'farm' | 'tournament' | 'milestone
     coinsEarned: 1000,
     cellsEarned: 100,
     realTime: 3600,
+    gameSpeed: 2.0,
     runType,
     fields: {}
-  } as ParsedGameRun
+  }
 }
 
 describe('extractAvailableTiers', () => {

--- a/src/shared/domain/game-speed-calculation.test.ts
+++ b/src/shared/domain/game-speed-calculation.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { calculateGameSpeed } from './game-speed-calculation'
+
+describe('calculateGameSpeed', () => {
+  it('should calculate gameTime / realTime ratio', () => {
+    expect(calculateGameSpeed(1000, 500)).toBe(2)
+    expect(calculateGameSpeed(1500, 1000)).toBe(1.5)
+    expect(calculateGameSpeed(4787, 1000)).toBe(4.787)
+  })
+
+  it('should return null when realTime is 0', () => {
+    expect(calculateGameSpeed(1000, 0)).toBeNull()
+    expect(calculateGameSpeed(0, 0)).toBeNull()
+  })
+
+  it('should round to 3 decimal places', () => {
+    expect(calculateGameSpeed(1000, 3)).toBe(333.333)
+    expect(calculateGameSpeed(10, 3)).toBe(3.333)
+  })
+})

--- a/src/shared/domain/game-speed-calculation.ts
+++ b/src/shared/domain/game-speed-calculation.ts
@@ -1,0 +1,18 @@
+/**
+ * Game Speed Calculation
+ *
+ * Derives the game speed multiplier from game time and real time.
+ * Game speed is a cached property on ParsedGameRun, computed during
+ * data import (clipboard paste and CSV import).
+ */
+
+/**
+ * Calculate game speed (gameTime / realTime) rounded to 3 decimal places.
+ * Returns null if realTime is 0 (cannot divide by zero).
+ */
+export function calculateGameSpeed(gameTime: number, realTime: number): number | null {
+  if (realTime === 0) {
+    return null
+  }
+  return Math.round((gameTime / realTime) * 1000) / 1000
+}

--- a/src/shared/formatting/date-issue-detection.test.ts
+++ b/src/shared/formatting/date-issue-detection.test.ts
@@ -14,6 +14,7 @@ function createTestRun(overrides: Partial<ParsedGameRun> = {}): ParsedGameRun {
     coinsEarned: 1000000,
     cellsEarned: 500,
     realTime: 3600,
+    gameSpeed: 2.0,
     runType: 'farm',
     ...overrides,
   };

--- a/src/shared/formatting/run-display-formatters.test.ts
+++ b/src/shared/formatting/run-display-formatters.test.ts
@@ -76,23 +76,31 @@ describe('run-display-formatters', () => {
   })
 
   describe('formatGameSpeed', () => {
-    it('should format with 3 decimal places and x suffix', () => {
-      expect(formatGameSpeed(1.5)).toBe('1.500x')
+    it('should trim trailing zeros for cleaner display', () => {
+      expect(formatGameSpeed(1.5)).toBe('1.5x')
+      expect(formatGameSpeed(2.25)).toBe('2.25x')
     })
 
-    it('should format whole numbers with 3 decimal places', () => {
-      expect(formatGameSpeed(2)).toBe('2.000x')
-      expect(formatGameSpeed(1)).toBe('1.000x')
+    it('should format whole numbers without decimal places', () => {
+      expect(formatGameSpeed(2)).toBe('2x')
+      expect(formatGameSpeed(1)).toBe('1x')
     })
 
-    it('should round to 3 decimal places', () => {
+    it('should round to 3 decimal places when needed', () => {
       expect(formatGameSpeed(2.12345)).toBe('2.123x')
-      expect(formatGameSpeed(1.9999)).toBe('2.000x')
+      expect(formatGameSpeed(1.9999)).toBe('2x') // rounds to 2.000, then trims to 2
+      expect(formatGameSpeed(4.787)).toBe('4.787x') // typical game speed value
     })
 
     it('should handle values less than 1', () => {
-      expect(formatGameSpeed(0.5)).toBe('0.500x')
+      expect(formatGameSpeed(0.5)).toBe('0.5x')
       expect(formatGameSpeed(0.125)).toBe('0.125x')
+    })
+
+    it('should preserve precision when meaningful', () => {
+      expect(formatGameSpeed(2.001)).toBe('2.001x')
+      expect(formatGameSpeed(3.14)).toBe('3.14x')
+      expect(formatGameSpeed(1.100)).toBe('1.1x') // trims trailing zero
     })
   })
 })

--- a/src/shared/formatting/run-display-formatters.test.ts
+++ b/src/shared/formatting/run-display-formatters.test.ts
@@ -4,6 +4,7 @@ import {
   formatWaveNumber,
   formatTierWaveHeader,
   formatTimestampDisplay,
+  formatGameSpeed,
 } from './run-display-formatters'
 
 describe('run-display-formatters', () => {
@@ -71,6 +72,27 @@ describe('run-display-formatters', () => {
     it('should handle edge cases', () => {
       expect(formatTierWaveHeader(0, 0)).toBe('T0 0')
       expect(formatTierWaveHeader(1, 1000)).toBe('T1 1,000')
+    })
+  })
+
+  describe('formatGameSpeed', () => {
+    it('should format with 3 decimal places and x suffix', () => {
+      expect(formatGameSpeed(1.5)).toBe('1.500x')
+    })
+
+    it('should format whole numbers with 3 decimal places', () => {
+      expect(formatGameSpeed(2)).toBe('2.000x')
+      expect(formatGameSpeed(1)).toBe('1.000x')
+    })
+
+    it('should round to 3 decimal places', () => {
+      expect(formatGameSpeed(2.12345)).toBe('2.123x')
+      expect(formatGameSpeed(1.9999)).toBe('2.000x')
+    })
+
+    it('should handle values less than 1', () => {
+      expect(formatGameSpeed(0.5)).toBe('0.500x')
+      expect(formatGameSpeed(0.125)).toBe('0.125x')
     })
   })
 })

--- a/src/shared/formatting/run-display-formatters.test.ts
+++ b/src/shared/formatting/run-display-formatters.test.ts
@@ -4,7 +4,7 @@ import {
   formatWaveNumber,
   formatTierWaveHeader,
   formatTimestampDisplay,
-  formatGameSpeed,
+  formatMultiplier,
 } from './run-display-formatters'
 
 describe('run-display-formatters', () => {
@@ -75,32 +75,32 @@ describe('run-display-formatters', () => {
     })
   })
 
-  describe('formatGameSpeed', () => {
+  describe('formatMultiplier', () => {
     it('should trim trailing zeros for cleaner display', () => {
-      expect(formatGameSpeed(1.5)).toBe('1.5x')
-      expect(formatGameSpeed(2.25)).toBe('2.25x')
+      expect(formatMultiplier(1.5)).toBe('1.5x')
+      expect(formatMultiplier(2.25)).toBe('2.25x')
     })
 
     it('should format whole numbers without decimal places', () => {
-      expect(formatGameSpeed(2)).toBe('2x')
-      expect(formatGameSpeed(1)).toBe('1x')
+      expect(formatMultiplier(2)).toBe('2x')
+      expect(formatMultiplier(1)).toBe('1x')
     })
 
     it('should round to 3 decimal places when needed', () => {
-      expect(formatGameSpeed(2.12345)).toBe('2.123x')
-      expect(formatGameSpeed(1.9999)).toBe('2x') // rounds to 2.000, then trims to 2
-      expect(formatGameSpeed(4.787)).toBe('4.787x') // typical game speed value
+      expect(formatMultiplier(2.12345)).toBe('2.123x')
+      expect(formatMultiplier(1.9999)).toBe('2x') // rounds to 2.000, then trims to 2
+      expect(formatMultiplier(4.787)).toBe('4.787x') // typical game speed value
     })
 
     it('should handle values less than 1', () => {
-      expect(formatGameSpeed(0.5)).toBe('0.5x')
-      expect(formatGameSpeed(0.125)).toBe('0.125x')
+      expect(formatMultiplier(0.5)).toBe('0.5x')
+      expect(formatMultiplier(0.125)).toBe('0.125x')
     })
 
     it('should preserve precision when meaningful', () => {
-      expect(formatGameSpeed(2.001)).toBe('2.001x')
-      expect(formatGameSpeed(3.14)).toBe('3.14x')
-      expect(formatGameSpeed(1.100)).toBe('1.1x') // trims trailing zero
+      expect(formatMultiplier(2.001)).toBe('2.001x')
+      expect(formatMultiplier(3.14)).toBe('3.14x')
+      expect(formatMultiplier(1.100)).toBe('1.1x') // trims trailing zero
     })
   })
 })

--- a/src/shared/formatting/run-display-formatters.ts
+++ b/src/shared/formatting/run-display-formatters.ts
@@ -70,9 +70,13 @@ export function formatTimestampDisplay(timestamp: Date): string {
 // ============================================================================
 
 /**
- * Format game speed as "Y.YYYx" (3 decimal places + 'x').
+ * Format game speed with 'x' suffix.
+ * Removes unnecessary trailing zeros for cleaner display.
+ * Examples: 2.0 -> "2x", 2.5 -> "2.5x", 2.123 -> "2.123x"
  * Game speed is the ratio of gameTime to realTime.
  */
 export function formatGameSpeed(value: number): string {
-  return value.toFixed(3) + 'x'
+  // Use up to 3 decimal places, trimming trailing zeros and decimal point
+  const formatted = value.toFixed(3).replace(/\.?0+$/, '')
+  return formatted + 'x'
 }

--- a/src/shared/formatting/run-display-formatters.ts
+++ b/src/shared/formatting/run-display-formatters.ts
@@ -64,3 +64,15 @@ export function formatDurationHoursMinutes(durationSeconds: number): string {
 export function formatTimestampDisplay(timestamp: Date): string {
   return formatDisplayShortDateTime(timestamp)
 }
+
+// ============================================================================
+// Game Speed Formatting
+// ============================================================================
+
+/**
+ * Format game speed as "Y.YYYx" (3 decimal places + 'x').
+ * Game speed is the ratio of gameTime to realTime.
+ */
+export function formatGameSpeed(value: number): string {
+  return value.toFixed(3) + 'x'
+}

--- a/src/shared/formatting/run-display-formatters.ts
+++ b/src/shared/formatting/run-display-formatters.ts
@@ -9,6 +9,7 @@
  * - Duration (hours/minutes)
  * - Timestamps
  * - Wave numbers with locale formatting
+ * - Multiplier values (e.g., game speed)
  */
 
 import { formatDisplayShortDateTime } from './date-formatters'
@@ -66,16 +67,15 @@ export function formatTimestampDisplay(timestamp: Date): string {
 }
 
 // ============================================================================
-// Game Speed Formatting
+// Multiplier Formatting
 // ============================================================================
 
 /**
- * Format game speed with 'x' suffix.
+ * Format a multiplier value with 'x' suffix.
  * Removes unnecessary trailing zeros for cleaner display.
  * Examples: 2.0 -> "2x", 2.5 -> "2.5x", 2.123 -> "2.123x"
- * Game speed is the ratio of gameTime to realTime.
  */
-export function formatGameSpeed(value: number): string {
+export function formatMultiplier(value: number): string {
   // Use up to 3 decimal places, trimming trailing zeros and decimal point
   const formatted = value.toFixed(3).replace(/\.?0+$/, '')
   return formatted + 'x'

--- a/src/shared/layouts/accent-colors.ts
+++ b/src/shared/layouts/accent-colors.ts
@@ -11,6 +11,7 @@ export type AccentColor =
   | 'red'
   | 'purple'
   | 'cyan'
+  | 'amber'
 
 /**
  * Pre-computed Tailwind classes for each accent color.
@@ -75,6 +76,12 @@ const ACCENT_COLOR_MAP: Record<AccentColor, AccentColorClasses> = {
     headerGradient: 'bg-gradient-to-r from-cyan-500/10 via-transparent to-cyan-500/10',
     accentBar: 'bg-gradient-to-b from-cyan-400 to-cyan-600',
     accentBarShadow: 'shadow-cyan-500/30',
+  },
+  amber: {
+    hoverShadow: 'hover:shadow-amber-500/10',
+    headerGradient: 'bg-gradient-to-r from-amber-500/10 via-transparent to-amber-500/10',
+    accentBar: 'bg-gradient-to-b from-amber-400 to-amber-600',
+    accentBarShadow: 'shadow-amber-500/30',
   },
 }
 

--- a/src/shared/types/game-run.types.ts
+++ b/src/shared/types/game-run.types.ts
@@ -25,6 +25,7 @@ export interface ParsedGameRun {
   readonly coinsEarned: number;
   readonly cellsEarned: number;
   readonly realTime: number;
+  readonly gameSpeed: number | null;  // gameTime / realTime, null when realTime is 0
   readonly runType: RunTypeValue;
 
   // Optional validation error when battleDate parsing fails


### PR DESCRIPTION
This adds "Game Speed" to the Run reports

<img width="500" height="164" alt="image" src="https://github.com/user-attachments/assets/97a40820-2627-4a30-ac2a-9c6070b3131b" />

It's force calculated as 3 digits of significance (1.234) , displayed with a trailing x (1.234x) 

It's added as a field, so it also graphs.

<img width="551" height="240" alt="image" src="https://github.com/user-attachments/assets/42f976f4-92d0-4824-82d6-14ca7efb647b" />

The graphs don't QUITE make sense once you move out of the "per run", but neither do the game time / run time graphs so seems fine.

---

code-organization-naming: 

*No changes required - organization and naming are well-structured.*

---

frontend-design-reviewer:

As per discord, it changed it to remove trailing zeros.