### PR TITLE
IMPROVE: Enhance Module Calculator UX with 11 usability refinements

### DIFF
--- a/.ruler/03-architecture-overview.md
+++ b/.ruler/03-architecture-overview.md
@@ -21,9 +21,9 @@
 - Handles shorthand number formats (100K, 15.2M, 1.5B, up to 1e63) and duration strings (7H 45M 35S)
 - See `src/shared/formatting/number-scale.ts` for number parsing/formatting
 
-## Localization (CRITICAL)
+## Number & Date Formatting (CRITICAL)
 
-**The app supports multiple locales.** All date and number handling MUST use the shared utilities:
+**NEVER format numbers or dates manually.** All formatting MUST use shared utilities - this ensures locale support and consistency. Before writing any number/date formatting code, use these:
 
 **Dates** (`src/shared/formatting/date-formatters.ts`):
 - `parseBattleDate()` - Parse dates from game export (handles multiple locale formats)
@@ -55,6 +55,12 @@ The app includes multiple analysis views in `src/features/analysis/`:
 ## Reusing Existing Utilities
 
 **CRITICAL**: Before implementing any data transformation, check if it already exists:
+
+**Number/Date Formatting** (`src/shared/formatting/`):
+- `formatLargeNumber()` - Display any number with K/M/B/T suffixes
+- `parseShorthandNumber()` - Parse user input like "100K", "1.5M"
+- `formatDisplayDate()` - Display dates to users
+- Never write custom number formatting - use these utilities
 
 **Data Grouping/Aggregation** (`src/features/analysis/`):
 - Period grouping (daily, weekly, monthly, yearly)

--- a/src/features/tools/module-calculator/calculator-sidebar.tsx
+++ b/src/features/tools/module-calculator/calculator-sidebar.tsx
@@ -65,10 +65,12 @@ export function CalculatorSidebar({
 
       {/* Manual Practice Mode */}
       <ManualModePanel
+        moduleType={config.config.moduleType}
         moduleRarity={config.config.moduleRarity}
         moduleLevel={config.config.moduleLevel}
         slotCount={config.config.slotCount}
         bannedEffects={calculatorConfig.bannedEffects}
+        preLockedEffects={calculatorConfig.preLockedEffects}
         manualMode={manualMode}
         isExpanded={isExpanded.practiceMode}
         onToggle={toggle.practiceMode}
@@ -79,7 +81,9 @@ export function CalculatorSidebar({
         <RollLog
           minimumLogRarity={manualMode.minimumLogRarity}
           logEntries={manualMode.logEntries}
+          showTargetMatches={manualMode.showTargetMatches}
           onMinimumRarityChange={manualMode.setMinimumLogRarity}
+          onShowTargetMatchesChange={manualMode.setShowTargetMatches}
           onClearLog={manualMode.clearLog}
           isExpanded={isExpanded.rollLog}
           onToggle={toggle.rollLog}

--- a/src/features/tools/module-calculator/manual-mode/manual-mode-logic.ts
+++ b/src/features/tools/module-calculator/manual-mode/manual-mode-logic.ts
@@ -9,6 +9,7 @@
  */
 
 import type { Rarity, SubEffectConfig } from '@/shared/domain/module-data';
+import { getSubEffectById } from '@/shared/domain/module-data';
 import { getLockCost } from '@/shared/domain/module-data/modules/lock-costs';
 import type { CalculatorConfig, PreLockedEffect } from '../types';
 import { buildInitialPool, preparePool } from '../simulation/pool-dynamics';
@@ -32,13 +33,15 @@ export { buildMinRarityMap } from '../simulation/simulation-engine';
 
 /**
  * Create a stub effect for pre-locked effects display.
+ * Looks up the actual effect to get proper displayName.
  */
 function createStubEffect(effectId: string): SubEffectConfig {
+  const actualEffect = getSubEffectById(effectId);
   return {
     id: effectId,
-    displayName: effectId,
-    moduleType: 'cannon',
-    values: {},
+    displayName: actualEffect?.displayName ?? effectId,
+    moduleType: actualEffect?.moduleType ?? 'cannon',
+    values: actualEffect?.values ?? {},
   } as SubEffectConfig;
 }
 

--- a/src/features/tools/module-calculator/manual-mode/manual-mode-panel.tsx
+++ b/src/features/tools/module-calculator/manual-mode/manual-mode-panel.tsx
@@ -5,35 +5,41 @@
  * Note: RollLog is rendered separately as its own collapsible card.
  */
 
-import type { Rarity } from '@/shared/domain/module-data';
+import type { ModuleType, Rarity } from '@/shared/domain/module-data';
 import type { UseManualModeResult } from './use-manual-mode';
 import type { ShardMode } from './types';
+import type { PreLockedEffect } from '../types';
 import { generatePracticeModeSummary } from './manual-mode-summary';
-import { BannedEffectsDisplay } from '../banned-effects-display';
+import { BannedEffectsDisplay, PoolInfoDisplay } from '../pool-status';
 import { ModuleHeader } from './module-header';
 import { EffectSlotsTable } from './effect-slots';
 import { ShardCounter } from './shard-counter';
 import { Button, CollapsibleCard } from '@/components/ui';
 
 interface ManualModePanelProps {
+  moduleType: ModuleType;
   moduleRarity: Rarity;
   moduleLevel: number;
   slotCount: number;
   bannedEffects: string[];
+  preLockedEffects: PreLockedEffect[];
   manualMode: UseManualModeResult;
   isExpanded: boolean;
   onToggle: () => void;
 }
 
 export function ManualModePanel({
+  moduleType,
   moduleRarity,
   moduleLevel,
   slotCount,
   bannedEffects,
+  preLockedEffects,
   manualMode,
   isExpanded,
   onToggle,
 }: ManualModePanelProps) {
+  const lockedEffectIds = preLockedEffects.map((e) => e.effectId);
   const maxLocks = Math.max(0, slotCount - 1);
 
   const summary = generatePracticeModeSummary(
@@ -98,8 +104,16 @@ export function ManualModePanel({
           />
         </div>
 
-        {/* Banned Effects */}
-        <BannedEffectsDisplay bannedEffectIds={bannedEffects} />
+        {/* Banned Effects & Pool Info */}
+        <div className="pt-3 border-t border-slate-700/30 space-y-3">
+          <BannedEffectsDisplay bannedEffectIds={bannedEffects} />
+          <PoolInfoDisplay
+            moduleType={moduleType}
+            moduleRarity={moduleRarity}
+            bannedEffectIds={bannedEffects}
+            lockedEffectIds={lockedEffectIds}
+          />
+        </div>
 
         {/* Actions Section */}
         <div className="border-t border-slate-700/30 pt-3">
@@ -153,7 +167,7 @@ function InactiveContent({ onActivate }: InactiveContentProps) {
     <div className="text-center space-y-4">
       <div className="space-y-2">
         <div className="flex items-center justify-center w-12 h-12 mx-auto rounded-full bg-orange-500/10 border border-orange-500/20">
-          <DiceIcon />
+          <RollIcon />
         </div>
         <p className="text-sm text-slate-400">
           Practice rolling manually to build intuition for module costs
@@ -184,7 +198,7 @@ function InactiveContent({ onActivate }: InactiveContentProps) {
   );
 }
 
-function DiceIcon() {
+function RollIcon() {
   return (
     <svg className="w-6 h-6 text-orange-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
       <rect x="3" y="3" width="18" height="18" rx="2" />

--- a/src/features/tools/module-calculator/manual-mode/roll-log/roll-log-logic.test.ts
+++ b/src/features/tools/module-calculator/manual-mode/roll-log/roll-log-logic.test.ts
@@ -95,6 +95,7 @@ describe('roll-log-logic', () => {
         name: 'Effect testEffect',
         rarity: 'ancestral',
         shortName: 'A',
+        isTargetMatch: false,
       });
     });
 
@@ -159,7 +160,7 @@ describe('roll-log-logic', () => {
   describe('createLogEntry', () => {
     it('creates entry with correct properties', () => {
       const effects: RollLogEffect[] = [
-        { effectId: 'effect1', name: 'Effect 1', rarity: 'mythic', shortName: 'M' },
+        { effectId: 'effect1', name: 'Effect 1', rarity: 'mythic', shortName: 'M', isTargetMatch: false },
       ];
 
       const entry = createLogEntry(42, 4200, 100, effects);
@@ -180,8 +181,8 @@ describe('roll-log-logic', () => {
 
     it('handles multiple effects', () => {
       const effects: RollLogEffect[] = [
-        { effectId: 'effect1', name: 'Effect 1', rarity: 'mythic', shortName: 'M' },
-        { effectId: 'effect2', name: 'Effect 2', rarity: 'ancestral', shortName: 'A' },
+        { effectId: 'effect1', name: 'Effect 1', rarity: 'mythic', shortName: 'M', isTargetMatch: false },
+        { effectId: 'effect2', name: 'Effect 2', rarity: 'ancestral', shortName: 'A', isTargetMatch: true },
       ];
 
       const entry = createLogEntry(1, 100, 100, effects);
@@ -429,7 +430,7 @@ describe('roll-log-logic', () => {
     it('returns singular "entry" for one entry', () => {
       const entries = [
         createMockEntry(1, [
-          { effectId: 'e1', name: 'Effect 1', rarity: 'legendary', shortName: 'L' },
+          { effectId: 'e1', name: 'Effect 1', rarity: 'legendary', shortName: 'L', isTargetMatch: false },
         ]),
       ];
       expect(generateRollLogSummary(entries)).toBe('1 entry | Latest: Legendary');
@@ -438,10 +439,10 @@ describe('roll-log-logic', () => {
     it('returns plural "entries" for multiple entries', () => {
       const entries = [
         createMockEntry(2, [
-          { effectId: 'e1', name: 'Effect 1', rarity: 'mythic', shortName: 'M' },
+          { effectId: 'e1', name: 'Effect 1', rarity: 'mythic', shortName: 'M', isTargetMatch: false },
         ]),
         createMockEntry(1, [
-          { effectId: 'e2', name: 'Effect 2', rarity: 'epic', shortName: 'E' },
+          { effectId: 'e2', name: 'Effect 2', rarity: 'epic', shortName: 'E', isTargetMatch: false },
         ]),
       ];
       expect(generateRollLogSummary(entries)).toBe('2 entries | Latest: Mythic');
@@ -450,9 +451,9 @@ describe('roll-log-logic', () => {
     it('shows highest rarity from latest entry', () => {
       const entries = [
         createMockEntry(1, [
-          { effectId: 'e1', name: 'Effect 1', rarity: 'rare', shortName: 'R' },
-          { effectId: 'e2', name: 'Effect 2', rarity: 'ancestral', shortName: 'A' },
-          { effectId: 'e3', name: 'Effect 3', rarity: 'epic', shortName: 'E' },
+          { effectId: 'e1', name: 'Effect 1', rarity: 'rare', shortName: 'R', isTargetMatch: false },
+          { effectId: 'e2', name: 'Effect 2', rarity: 'ancestral', shortName: 'A', isTargetMatch: true },
+          { effectId: 'e3', name: 'Effect 3', rarity: 'epic', shortName: 'E', isTargetMatch: false },
         ]),
       ];
       expect(generateRollLogSummary(entries)).toBe('1 entry | Latest: Ancestral');
@@ -466,7 +467,7 @@ describe('roll-log-logic', () => {
     it('handles large entry counts', () => {
       const entries = Array.from({ length: 100 }, (_, i) =>
         createMockEntry(i + 1, [
-          { effectId: 'e1', name: 'Effect 1', rarity: 'common', shortName: 'C' },
+          { effectId: 'e1', name: 'Effect 1', rarity: 'common', shortName: 'C', isTargetMatch: false },
         ])
       );
       expect(generateRollLogSummary(entries)).toBe('100 entries | Latest: Common');

--- a/src/features/tools/module-calculator/manual-mode/roll-log/roll-log-logic.ts
+++ b/src/features/tools/module-calculator/manual-mode/roll-log/roll-log-logic.ts
@@ -36,6 +36,7 @@ export function filterQualifyingEffects(
         name: slot.effect.displayName,
         rarity: slot.rarity,
         shortName: RARITY_CONFIG_MAP[slot.rarity].shortName,
+        isTargetMatch: slot.isTargetMatch,
       });
     }
   }

--- a/src/features/tools/module-calculator/manual-mode/roll-log/roll-log-settings-persistence.test.ts
+++ b/src/features/tools/module-calculator/manual-mode/roll-log/roll-log-settings-persistence.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  getDefaultRollLogSettings,
+  loadRollLogSettings,
+  saveRollLogSettings,
+} from './roll-log-settings-persistence';
+
+describe('roll-log-settings-persistence', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  describe('getDefaultRollLogSettings', () => {
+    it('returns default settings with showTargetMatches true', () => {
+      const defaults = getDefaultRollLogSettings();
+      expect(defaults).toEqual({
+        showTargetMatches: true,
+      });
+    });
+  });
+
+  describe('loadRollLogSettings', () => {
+    it('returns default settings when nothing is stored', () => {
+      const settings = loadRollLogSettings();
+      expect(settings).toEqual(getDefaultRollLogSettings());
+    });
+
+    it('returns stored settings when valid', () => {
+      const stored = { showTargetMatches: true };
+      localStorage.setItem(
+        'tower-tracking-module-calc-roll-log-settings',
+        JSON.stringify(stored)
+      );
+
+      const settings = loadRollLogSettings();
+      expect(settings).toEqual({ showTargetMatches: true });
+    });
+
+    it('returns defaults when stored data is invalid', () => {
+      localStorage.setItem(
+        'tower-tracking-module-calc-roll-log-settings',
+        JSON.stringify({ invalid: 'data' })
+      );
+
+      const settings = loadRollLogSettings();
+      expect(settings).toEqual(getDefaultRollLogSettings());
+    });
+
+    it('returns defaults when stored data is not JSON', () => {
+      localStorage.setItem(
+        'tower-tracking-module-calc-roll-log-settings',
+        'not json'
+      );
+
+      const settings = loadRollLogSettings();
+      expect(settings).toEqual(getDefaultRollLogSettings());
+    });
+
+    it('returns defaults when showTargetMatches is not a boolean', () => {
+      localStorage.setItem(
+        'tower-tracking-module-calc-roll-log-settings',
+        JSON.stringify({ showTargetMatches: 'yes' })
+      );
+
+      const settings = loadRollLogSettings();
+      expect(settings).toEqual(getDefaultRollLogSettings());
+    });
+  });
+
+  describe('saveRollLogSettings', () => {
+    it('saves settings to localStorage', () => {
+      const settings = { showTargetMatches: true };
+      saveRollLogSettings(settings);
+
+      const stored = localStorage.getItem('tower-tracking-module-calc-roll-log-settings');
+      expect(JSON.parse(stored!)).toEqual(settings);
+    });
+
+    it('handles localStorage errors gracefully', () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new Error('Storage full');
+      });
+
+      // Should not throw
+      expect(() => saveRollLogSettings({ showTargetMatches: true })).not.toThrow();
+      expect(consoleSpy).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/features/tools/module-calculator/manual-mode/roll-log/roll-log-settings-persistence.ts
+++ b/src/features/tools/module-calculator/manual-mode/roll-log/roll-log-settings-persistence.ts
@@ -1,0 +1,75 @@
+/**
+ * Roll Log Settings Persistence
+ *
+ * Handles localStorage persistence for roll log settings,
+ * specifically the "show target matches" preference.
+ */
+
+const STORAGE_KEY = 'tower-tracking-module-calc-roll-log-settings';
+
+/**
+ * Roll log settings that persist across sessions
+ */
+interface RollLogSettings {
+  /** Whether to show target match indicators (default: true) */
+  showTargetMatches: boolean;
+}
+
+/**
+ * Default settings - target matches shown by default
+ */
+export function getDefaultRollLogSettings(): RollLogSettings {
+  return {
+    showTargetMatches: true,
+  };
+}
+
+/**
+ * Validate that the stored settings have all required fields
+ */
+function isValidRollLogSettings(data: unknown): data is RollLogSettings {
+  if (!data || typeof data !== 'object') return false;
+
+  const settings = data as Record<string, unknown>;
+  return typeof settings.showTargetMatches === 'boolean';
+}
+
+/**
+ * Load roll log settings from localStorage
+ * Returns default settings if none exists or validation fails
+ */
+export function loadRollLogSettings(): RollLogSettings {
+  if (typeof window === 'undefined') {
+    return getDefaultRollLogSettings();
+  }
+
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) {
+      return getDefaultRollLogSettings();
+    }
+
+    const parsed = JSON.parse(stored);
+    if (isValidRollLogSettings(parsed)) {
+      return parsed;
+    }
+
+    return getDefaultRollLogSettings();
+  } catch (error) {
+    console.warn('Failed to load roll log settings from localStorage:', error);
+    return getDefaultRollLogSettings();
+  }
+}
+
+/**
+ * Save roll log settings to localStorage
+ */
+export function saveRollLogSettings(settings: RollLogSettings): void {
+  if (typeof window === 'undefined') return;
+
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+  } catch (error) {
+    console.error('Failed to save roll log settings to localStorage:', error);
+  }
+}

--- a/src/features/tools/module-calculator/manual-mode/types.ts
+++ b/src/features/tools/module-calculator/manual-mode/types.ts
@@ -128,6 +128,8 @@ export interface RollLogEffect {
   name: string;
   rarity: Rarity;
   shortName: string;
+  /** Whether this effect matched a target criteria when rolled */
+  isTargetMatch: boolean;
 }
 
 /**

--- a/src/features/tools/module-calculator/pool-status/banned-effects-display.tsx
+++ b/src/features/tools/module-calculator/pool-status/banned-effects-display.tsx
@@ -6,32 +6,33 @@
  * Uses flat styling (no card wrapper) per PRD constraints.
  */
 
-import { getSubEffectById } from '@/shared/domain/module-data';
+import { useMemo } from 'react';
+import { getBannedEffectsInfo, type BannedEffectsInfo } from './banned-effects-logic';
 
 interface BannedEffectsDisplayProps {
   bannedEffectIds: string[];
 }
 
 export function BannedEffectsDisplay({ bannedEffectIds }: BannedEffectsDisplayProps) {
+  const info: BannedEffectsInfo = useMemo(
+    () => getBannedEffectsInfo(bannedEffectIds),
+    [bannedEffectIds]
+  );
+
   if (bannedEffectIds.length === 0) {
     return null;
   }
-
-  const effectNames = bannedEffectIds.map((id) => {
-    const effect = getSubEffectById(id);
-    return effect?.displayName ?? id;
-  });
 
   return (
     <div className="space-y-1">
       <div className="flex items-center gap-2">
         <BanIcon />
         <span className="text-xs text-slate-400 font-medium">
-          Effects banned from pool ({bannedEffectIds.length}):
+          Effects banned from pool: {info.effectCount} ({info.combinationsRemoved} combinations)
         </span>
       </div>
       <div className="ml-6 text-xs text-slate-500">
-        {effectNames.join(', ')}
+        {info.effectNames.join(', ')}
       </div>
     </div>
   );

--- a/src/features/tools/module-calculator/pool-status/banned-effects-logic.test.ts
+++ b/src/features/tools/module-calculator/pool-status/banned-effects-logic.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Banned Effects Logic Tests
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getBannedEffectsInfo } from './banned-effects-logic';
+import * as moduleData from '@/shared/domain/module-data';
+
+vi.mock('@/shared/domain/module-data', () => ({
+  getSubEffectById: vi.fn(),
+  getAvailableRarities: vi.fn(),
+}));
+
+describe('getBannedEffectsInfo', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns empty info for no banned effects', () => {
+    const result = getBannedEffectsInfo([]);
+
+    expect(result).toEqual({
+      effectNames: [],
+      effectCount: 0,
+      combinationsRemoved: 0,
+    });
+  });
+
+  it('calculates combinations from available rarities', () => {
+    const mockEffect = { id: 'effect-1', displayName: 'Poison Swamp' };
+    vi.mocked(moduleData.getSubEffectById).mockReturnValue(mockEffect as never);
+    vi.mocked(moduleData.getAvailableRarities).mockReturnValue([
+      'common',
+      'uncommon',
+      'rare',
+      'epic',
+      'legendary',
+      'ancestral',
+    ] as never);
+
+    const result = getBannedEffectsInfo(['effect-1']);
+
+    expect(result).toEqual({
+      effectNames: ['Poison Swamp'],
+      effectCount: 1,
+      combinationsRemoved: 6,
+    });
+  });
+
+  it('sums combinations across multiple banned effects', () => {
+    const mockEffect1 = { id: 'effect-1', displayName: 'Effect One' };
+    const mockEffect2 = { id: 'effect-2', displayName: 'Effect Two' };
+
+    vi.mocked(moduleData.getSubEffectById)
+      .mockReturnValueOnce(mockEffect1 as never)
+      .mockReturnValueOnce(mockEffect2 as never);
+    vi.mocked(moduleData.getAvailableRarities)
+      .mockReturnValueOnce(['common', 'uncommon', 'rare'] as never)
+      .mockReturnValueOnce(['epic', 'legendary', 'ancestral'] as never);
+
+    const result = getBannedEffectsInfo(['effect-1', 'effect-2']);
+
+    expect(result).toEqual({
+      effectNames: ['Effect One', 'Effect Two'],
+      effectCount: 2,
+      combinationsRemoved: 6,
+    });
+  });
+
+  it('uses id as fallback for unknown effects', () => {
+    vi.mocked(moduleData.getSubEffectById).mockReturnValue(undefined);
+
+    const result = getBannedEffectsInfo(['unknown-effect']);
+
+    expect(result).toEqual({
+      effectNames: ['unknown-effect'],
+      effectCount: 1,
+      combinationsRemoved: 0,
+    });
+  });
+});

--- a/src/features/tools/module-calculator/pool-status/banned-effects-logic.ts
+++ b/src/features/tools/module-calculator/pool-status/banned-effects-logic.ts
@@ -1,0 +1,38 @@
+/**
+ * Banned Effects Logic
+ *
+ * Pure functions for calculating banned effects information.
+ */
+
+import { getSubEffectById, getAvailableRarities } from '@/shared/domain/module-data';
+
+export interface BannedEffectsInfo {
+  effectNames: string[];
+  effectCount: number;
+  combinationsRemoved: number;
+}
+
+/**
+ * Get display information about banned effects including
+ * effect names and the total number of pool combinations removed.
+ */
+export function getBannedEffectsInfo(bannedEffectIds: string[]): BannedEffectsInfo {
+  const effectNames: string[] = [];
+  let combinationsRemoved = 0;
+
+  for (const id of bannedEffectIds) {
+    const effect = getSubEffectById(id);
+    if (effect) {
+      effectNames.push(effect.displayName);
+      combinationsRemoved += getAvailableRarities(effect).length;
+    } else {
+      effectNames.push(id);
+    }
+  }
+
+  return {
+    effectNames,
+    effectCount: bannedEffectIds.length,
+    combinationsRemoved,
+  };
+}

--- a/src/features/tools/module-calculator/pool-status/index.ts
+++ b/src/features/tools/module-calculator/pool-status/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Pool Status
+ *
+ * Components and logic for displaying pool state information including:
+ * - Banned effects (removed from pool)
+ * - Pool info (available effects and combinations)
+ *
+ * Used by both Target Summary and Manual Practice Mode panels.
+ */
+
+export { BannedEffectsDisplay } from './banned-effects-display';
+export { PoolInfoDisplay } from './pool-info-display';
+export { getPoolInfo } from './pool-info-logic';

--- a/src/features/tools/module-calculator/pool-status/pool-info-display.tsx
+++ b/src/features/tools/module-calculator/pool-status/pool-info-display.tsx
@@ -1,0 +1,59 @@
+/**
+ * Pool Info Display
+ *
+ * Shared component for displaying pool size information in both
+ * Target Summary and Manual Practice Mode panels.
+ * Uses flat styling (no card wrapper) to match BannedEffectsDisplay.
+ */
+
+import { useMemo } from 'react';
+import type { ModuleType, Rarity } from '@/shared/domain/module-data';
+import { getPoolInfo, type PoolInfo } from './pool-info-logic';
+
+interface PoolInfoDisplayProps {
+  moduleType: ModuleType;
+  moduleRarity: Rarity;
+  bannedEffectIds: string[];
+  lockedEffectIds: string[];
+  /** Optional pre-computed pool info to avoid duplicate calculations */
+  poolInfo?: PoolInfo;
+}
+
+export function PoolInfoDisplay({
+  moduleType,
+  moduleRarity,
+  bannedEffectIds,
+  lockedEffectIds,
+  poolInfo: preComputedInfo,
+}: PoolInfoDisplayProps) {
+  const computedInfo: PoolInfo = useMemo(
+    () =>
+      getPoolInfo({
+        moduleType,
+        moduleRarity,
+        bannedEffectIds,
+        lockedEffectIds,
+      }),
+    [moduleType, moduleRarity, bannedEffectIds, lockedEffectIds]
+  );
+
+  // Use pre-computed info if provided, otherwise use the computed value
+  const info = preComputedInfo ?? computedInfo;
+
+  return (
+    <div className="flex items-center gap-2">
+      <PoolIcon />
+      <span className="text-xs text-slate-400 font-medium">
+        Pool size: {info.effectCount} effects ({info.combinationCount.toLocaleString()} combinations)
+      </span>
+    </div>
+  );
+}
+
+function PoolIcon() {
+  return (
+    <svg className="w-4 h-4 text-blue-400/70" viewBox="0 0 24 24" fill="currentColor">
+      <path d="M3 3h8v8H3V3zm2 2v4h4V5H5zm8-2h8v8h-8V3zm2 2v4h4V5h-4zM3 13h8v8H3v-8zm2 2v4h4v-4H5zm8-2h8v8h-8v-8zm2 2v4h4v-4h-4z" />
+    </svg>
+  );
+}

--- a/src/features/tools/module-calculator/pool-status/pool-info-logic.test.ts
+++ b/src/features/tools/module-calculator/pool-status/pool-info-logic.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Pool Info Logic Tests
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getPoolInfo, getAvailablePoolEffects } from './pool-info-logic';
+import * as moduleData from '@/shared/domain/module-data';
+
+vi.mock('@/shared/domain/module-data', () => ({
+  getSubEffectsForModule: vi.fn(),
+  filterByModuleRarity: vi.fn(),
+  countPoolCombinations: vi.fn(),
+}));
+
+describe('getAvailablePoolEffects', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('filters out banned and locked effects', () => {
+    const mockEffects = [
+      { id: 'effect-1' },
+      { id: 'effect-2' },
+      { id: 'effect-3' },
+      { id: 'effect-4' },
+    ];
+
+    vi.mocked(moduleData.getSubEffectsForModule).mockReturnValue(mockEffects as never);
+    vi.mocked(moduleData.filterByModuleRarity).mockImplementation((effects) => effects as never);
+
+    const result = getAvailablePoolEffects({
+      moduleType: 'cannon',
+      moduleRarity: 'legendary',
+      bannedEffectIds: ['effect-1'],
+      lockedEffectIds: ['effect-3'],
+    });
+
+    expect(result).toEqual([{ id: 'effect-2' }, { id: 'effect-4' }]);
+  });
+
+  it('applies module rarity filter', () => {
+    const mockEffects = [{ id: 'effect-1' }, { id: 'effect-2' }];
+    const filteredEffects = [{ id: 'effect-1' }];
+
+    vi.mocked(moduleData.getSubEffectsForModule).mockReturnValue(mockEffects as never);
+    vi.mocked(moduleData.filterByModuleRarity).mockReturnValue(filteredEffects as never);
+
+    const result = getAvailablePoolEffects({
+      moduleType: 'cannon',
+      moduleRarity: 'epic',
+      bannedEffectIds: [],
+      lockedEffectIds: [],
+    });
+
+    expect(moduleData.filterByModuleRarity).toHaveBeenCalledWith(mockEffects, 'epic');
+    expect(result).toEqual(filteredEffects);
+  });
+});
+
+describe('getPoolInfo', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns effect count and combination count', () => {
+    const mockEffects = [{ id: 'effect-1' }, { id: 'effect-2' }, { id: 'effect-3' }];
+
+    vi.mocked(moduleData.getSubEffectsForModule).mockReturnValue(mockEffects as never);
+    vi.mocked(moduleData.filterByModuleRarity).mockReturnValue(mockEffects as never);
+    vi.mocked(moduleData.countPoolCombinations).mockReturnValue(15);
+
+    const result = getPoolInfo({
+      moduleType: 'cannon',
+      moduleRarity: 'legendary',
+      bannedEffectIds: [],
+      lockedEffectIds: [],
+    });
+
+    expect(result).toEqual({
+      effectCount: 3,
+      combinationCount: 15,
+    });
+  });
+
+  it('excludes banned and locked effects from counts', () => {
+    const mockEffects = [
+      { id: 'effect-1' },
+      { id: 'effect-2' },
+      { id: 'effect-3' },
+      { id: 'effect-4' },
+    ];
+    const filteredEffects = [{ id: 'effect-2' }, { id: 'effect-4' }];
+
+    vi.mocked(moduleData.getSubEffectsForModule).mockReturnValue(mockEffects as never);
+    vi.mocked(moduleData.filterByModuleRarity).mockImplementation((effects) => effects as never);
+    vi.mocked(moduleData.countPoolCombinations).mockReturnValue(8);
+
+    const result = getPoolInfo({
+      moduleType: 'cannon',
+      moduleRarity: 'legendary',
+      bannedEffectIds: ['effect-1'],
+      lockedEffectIds: ['effect-3'],
+    });
+
+    expect(result).toEqual({
+      effectCount: 2,
+      combinationCount: 8,
+    });
+    expect(moduleData.countPoolCombinations).toHaveBeenCalledWith(filteredEffects, 'legendary');
+  });
+
+  it('returns zero counts for empty pool', () => {
+    vi.mocked(moduleData.getSubEffectsForModule).mockReturnValue([] as never);
+    vi.mocked(moduleData.filterByModuleRarity).mockReturnValue([] as never);
+    vi.mocked(moduleData.countPoolCombinations).mockReturnValue(0);
+
+    const result = getPoolInfo({
+      moduleType: 'cannon',
+      moduleRarity: 'common',
+      bannedEffectIds: [],
+      lockedEffectIds: [],
+    });
+
+    expect(result).toEqual({
+      effectCount: 0,
+      combinationCount: 0,
+    });
+  });
+});

--- a/src/features/tools/module-calculator/pool-status/pool-info-logic.ts
+++ b/src/features/tools/module-calculator/pool-status/pool-info-logic.ts
@@ -1,0 +1,54 @@
+/**
+ * Pool Info Logic
+ *
+ * Pure functions for calculating pool information including
+ * effect count and total combinations available.
+ */
+
+import type { ModuleType, Rarity, SubEffectConfig } from '@/shared/domain/module-data';
+import {
+  getSubEffectsForModule,
+  filterByModuleRarity,
+  countPoolCombinations,
+} from '@/shared/domain/module-data';
+
+export interface PoolInfo {
+  effectCount: number;
+  combinationCount: number;
+}
+
+interface PoolCalculationParams {
+  moduleType: ModuleType;
+  moduleRarity: Rarity;
+  bannedEffectIds: string[];
+  lockedEffectIds: string[];
+}
+
+/**
+ * Get the available effects in the pool after filtering out
+ * banned and locked effects.
+ */
+export function getAvailablePoolEffects(params: PoolCalculationParams): SubEffectConfig[] {
+  const { moduleType, moduleRarity, bannedEffectIds, lockedEffectIds } = params;
+
+  const allEffects = getSubEffectsForModule(moduleType);
+
+  const filteredEffects = allEffects.filter(
+    (e) => !bannedEffectIds.includes(e.id) && !lockedEffectIds.includes(e.id)
+  );
+
+  return filterByModuleRarity(filteredEffects, moduleRarity);
+}
+
+/**
+ * Calculate pool information including effect count and total combinations.
+ */
+export function getPoolInfo(params: PoolCalculationParams): PoolInfo {
+  const availableEffects = getAvailablePoolEffects(params);
+  const combinationCount = countPoolCombinations(availableEffects, params.moduleRarity);
+
+  return {
+    effectCount: availableEffects.length,
+    combinationCount,
+  };
+}

--- a/src/features/tools/module-calculator/results/results-formatters.test.ts
+++ b/src/features/tools/module-calculator/results/results-formatters.test.ts
@@ -4,7 +4,7 @@ import {
   formatCostRange,
   formatPercentage,
   formatProbability,
-  formatDiceCost,
+  formatShardCost,
   formatRollCount,
   formatExpectedRolls,
   getPercentileColor,
@@ -70,10 +70,10 @@ describe('results-formatters', () => {
     });
   });
 
-  describe('formatDiceCost', () => {
-    it('formats dice cost with unit', () => {
-      expect(formatDiceCost(10)).toBe('10 dice');
-      expect(formatDiceCost(1600)).toBe('1.6K dice');
+  describe('formatShardCost', () => {
+    it('formats shard cost with unit', () => {
+      expect(formatShardCost(10)).toBe('10 shards');
+      expect(formatShardCost(1600)).toBe('1.6K shards');
     });
   });
 
@@ -128,9 +128,20 @@ describe('results-formatters', () => {
   });
 
   describe('formatRunCount', () => {
-    it('formats with appropriate suffix', () => {
-      expect(formatRunCount(10000)).toBe('Based on 10.0K simulations');
-      expect(formatRunCount(1000000)).toBe('Based on 1.00M simulations');
+    it('formats round numbers without decimals', () => {
+      expect(formatRunCount(10000)).toBe('Based on 10K simulations');
+      expect(formatRunCount(100000)).toBe('Based on 100K simulations');
+      expect(formatRunCount(1000000)).toBe('Based on 1M simulations');
+    });
+
+    it('formats non-round numbers with one decimal', () => {
+      expect(formatRunCount(15000)).toBe('Based on 15K simulations');
+      expect(formatRunCount(12500)).toBe('Based on 12.5K simulations');
+      expect(formatRunCount(1500000)).toBe('Based on 1.5M simulations');
+    });
+
+    it('formats small numbers without suffix', () => {
+      expect(formatRunCount(500)).toBe('Based on 500 simulations');
     });
   });
 

--- a/src/features/tools/module-calculator/results/results-formatters.ts
+++ b/src/features/tools/module-calculator/results/results-formatters.ts
@@ -4,6 +4,8 @@
  * Pure functions for formatting simulation results for display.
  */
 
+import { formatLargeNumber } from '@/shared/formatting/number-scale';
+
 /**
  * Format a large number with appropriate suffix (K, M, B)
  *
@@ -51,10 +53,10 @@ export function formatProbability(probability: number): string {
 }
 
 /**
- * Format dice cost with unit
+ * Format shard cost with unit
  */
-export function formatDiceCost(dice: number): string {
-  return `${formatCost(dice)} dice`;
+export function formatShardCost(shards: number): string {
+  return `${formatCost(shards)} shards`;
 }
 
 /**
@@ -97,10 +99,10 @@ export function formatPercentileLabel(percentile: number): string {
 }
 
 /**
- * Format simulation run count
+ * Format simulation run count using locale-aware number formatting
  */
 export function formatRunCount(count: number): string {
-  return `Based on ${formatCost(count)} simulations`;
+  return `Based on ${formatLargeNumber(count)} simulations`;
 }
 
 /**

--- a/src/features/tools/module-calculator/results/results-panel.tsx
+++ b/src/features/tools/module-calculator/results/results-panel.tsx
@@ -143,7 +143,7 @@ function ProgressBar({ progress }: ProgressBarProps) {
       </div>
       <div className="h-2 bg-slate-700 rounded-full overflow-hidden">
         <div
-          className="h-full bg-orange-500 transition-all duration-300"
+          className="h-full bg-orange-500"
           style={{ width: `${progress}%` }}
         />
       </div>

--- a/src/features/tools/module-calculator/sub-effect-table/sub-effect-row.tsx
+++ b/src/features/tools/module-calculator/sub-effect-table/sub-effect-row.tsx
@@ -118,17 +118,16 @@ function BanToggle({ isBanned, isLocked, onToggle }: BanToggleProps) {
       title={isLocked ? 'Cannot ban a locked effect' : (isBanned ? 'Unban effect' : 'Ban effect (Lab Research)')}
       aria-pressed={isBanned}
     >
-      {isBanned ? (
-        <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="currentColor">
-          <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
-        </svg>
-      ) : (
-        <svg className="w-3.5 h-3.5 opacity-0 group-hover:opacity-100 transition-opacity" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-          <circle cx="12" cy="12" r="9" />
-          <line x1="5.5" y1="5.5" x2="18.5" y2="18.5" />
-        </svg>
-      )}
+      <BanIcon />
     </button>
+  );
+}
+
+function BanIcon() {
+  return (
+    <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="currentColor">
+      <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8 0-1.85.63-3.55 1.69-4.9L16.9 18.31C15.55 19.37 13.85 20 12 20zm6.31-3.1L7.1 5.69C8.45 4.63 10.15 4 12 4c4.42 0 8 3.58 8 8 0 1.85-.63 3.55-1.69 4.9z" />
+    </svg>
   );
 }
 

--- a/src/features/tools/module-calculator/sub-effect-table/table-state-logic.test.ts
+++ b/src/features/tools/module-calculator/sub-effect-table/table-state-logic.test.ts
@@ -36,11 +36,12 @@ describe('table-state-logic', () => {
   });
 
   describe('toggleMinRarity', () => {
-    it('sets rarity when not selected', () => {
+    it('sets rarity and auto-assigns slot 1 when no slots assigned', () => {
       const selection = createEmptySelection('attackSpeed');
       const updated = toggleMinRarity(selection, 'legendary');
 
       expect(updated.minRarity).toBe('legendary');
+      expect(updated.targetSlots).toEqual([1]);
     });
 
     it('clears rarity when clicking same rarity', () => {
@@ -53,14 +54,35 @@ describe('table-state-logic', () => {
       expect(updated.minRarity).toBeNull();
     });
 
-    it('changes to different rarity', () => {
+    it('changes to different rarity without modifying existing slots', () => {
       const selection: EffectSelection = {
         ...createEmptySelection('attackSpeed'),
         minRarity: 'legendary',
+        targetSlots: [2, 3],
       };
       const updated = toggleMinRarity(selection, 'mythic');
 
       expect(updated.minRarity).toBe('mythic');
+      expect(updated.targetSlots).toEqual([2, 3]);
+    });
+
+    it('uses custom default slot when provided', () => {
+      const selection = createEmptySelection('attackSpeed');
+      const updated = toggleMinRarity(selection, 'epic', 3);
+
+      expect(updated.minRarity).toBe('epic');
+      expect(updated.targetSlots).toEqual([3]);
+    });
+
+    it('does not add slot when targetSlots already has values', () => {
+      const selection: EffectSelection = {
+        ...createEmptySelection('attackSpeed'),
+        targetSlots: [2],
+      };
+      const updated = toggleMinRarity(selection, 'legendary');
+
+      expect(updated.minRarity).toBe('legendary');
+      expect(updated.targetSlots).toEqual([2]);
     });
   });
 

--- a/src/features/tools/module-calculator/sub-effect-table/table-state-logic.ts
+++ b/src/features/tools/module-calculator/sub-effect-table/table-state-logic.ts
@@ -26,14 +26,27 @@ export function createEmptySelection(effectId: string): EffectSelection {
  * Update the minimum rarity for an effect
  *
  * If clicking the same rarity that's already selected, clears it.
+ * When setting a rarity and no target slots exist, auto-assigns the default slot (priority 1).
+ *
+ * @param selection - Current effect selection
+ * @param rarity - The rarity to set as minimum
+ * @param defaultSlot - Optional slot to auto-assign when first selecting a rarity (defaults to 1)
  */
 export function toggleMinRarity(
   selection: EffectSelection,
-  rarity: Rarity
+  rarity: Rarity,
+  defaultSlot: number = 1
 ): EffectSelection {
+  // Clicking same rarity clears the selection
   if (selection.minRarity === rarity) {
     return { ...selection, minRarity: null };
   }
+
+  // Setting a new rarity - auto-assign first slot if none assigned
+  if (selection.targetSlots.length === 0) {
+    return { ...selection, minRarity: rarity, targetSlots: [defaultSlot] };
+  }
+
   return { ...selection, minRarity: rarity };
 }
 

--- a/src/shared/domain/module-data/modules/lock-costs.ts
+++ b/src/shared/domain/module-data/modules/lock-costs.ts
@@ -1,48 +1,48 @@
 /**
  * Lock Costs
  *
- * Dice cost required to lock effects based on how many are already locked.
+ * Shard cost required to lock effects based on how many are already locked.
  * Costs increase exponentially as more effects are locked.
  */
 
 import type { LockCost } from '../types';
 
 /**
- * Dice costs by number of already-locked effects
+ * Shard costs by number of already-locked effects
  *
  * Lock count is the number of effects already locked (0-7).
- * Dice cost is what it costs to lock the next effect.
+ * Shard cost is what it costs to lock the next effect.
  */
 const LOCK_COSTS: LockCost[] = [
-  { lockCount: 0, diceCost: 10 },
-  { lockCount: 1, diceCost: 40 },
-  { lockCount: 2, diceCost: 160 },
-  { lockCount: 3, diceCost: 500 },
-  { lockCount: 4, diceCost: 1000 },
-  { lockCount: 5, diceCost: 1600 },
-  { lockCount: 6, diceCost: 2250 },
-  { lockCount: 7, diceCost: 3000 },
+  { lockCount: 0, shardCost: 10 },
+  { lockCount: 1, shardCost: 40 },
+  { lockCount: 2, shardCost: 160 },
+  { lockCount: 3, shardCost: 500 },
+  { lockCount: 4, shardCost: 1000 },
+  { lockCount: 5, shardCost: 1600 },
+  { lockCount: 6, shardCost: 2250 },
+  { lockCount: 7, shardCost: 3000 },
 ];
 
 /**
  * Lookup map for quick access by lock count
  */
 const LOCK_COST_MAP: Record<number, number> = Object.fromEntries(
-  LOCK_COSTS.map((cost) => [cost.lockCount, cost.diceCost])
+  LOCK_COSTS.map((cost) => [cost.lockCount, cost.shardCost])
 );
 
 /**
- * Get the dice cost to lock the next effect
+ * Get the shard cost to lock the next effect
  *
  * @param lockedCount - Number of effects already locked (0-7)
- * @returns Dice cost for the next lock
+ * @returns Shard cost for the next lock
  */
 export function getLockCost(lockedCount: number): number {
   if (lockedCount < 0) {
-    return LOCK_COSTS[0].diceCost;
+    return LOCK_COSTS[0].shardCost;
   }
   if (lockedCount >= LOCK_COSTS.length) {
-    return LOCK_COSTS[LOCK_COSTS.length - 1].diceCost;
+    return LOCK_COSTS[LOCK_COSTS.length - 1].shardCost;
   }
   return LOCK_COST_MAP[lockedCount];
 }

--- a/src/shared/domain/module-data/types.ts
+++ b/src/shared/domain/module-data/types.ts
@@ -94,12 +94,12 @@ export interface SlotUnlockThreshold {
 }
 
 /**
- * Dice cost for locking effects
+ * Shard cost for locking effects
  */
 export interface LockCost {
   /** Number of already-locked effects (0-7) */
   lockCount: number;
 
-  /** Dice required for the next lock */
-  diceCost: number;
+  /** Shards required for the next lock */
+  shardCost: number;
 }


### PR DESCRIPTION
## Summary
Improves the Module Calculator experience through 11 targeted UX refinements addressing user feedback. Changes include better visual feedback for pool status, persistent user preferences, corrected game terminology, and several display bug fixes that improve clarity during both manual practice and simulation modes.

## Technical Details
- Roll Log: Optimized column widths (w-16/w-24 to w-14), added "Show Hits" toggle with localStorage persistence for target match indicators
- Pool Status: Created new `pool-status/` subdirectory with reusable `PoolInfoDisplay` and `BannedEffectsDisplay` components showing effect counts and combinations
- Fixed `createStubEffect()` to lookup actual effect displayName instead of using raw camelCase IDs
- Replaced custom `formatCountCompact` with shared `formatLargeNumber` utility for simulation counts
- Removed CSS transition from Monte Carlo progress bar to eliminate visual lag with parallel workers
- Renamed `diceCost` to `shardCost` and `formatDiceCost` to `formatShardCost` throughout codebase
- Modified `toggleMinRarity()` to auto-assign priority slot 1 when selecting rarity with no slots assigned
- Ban column icon now always visible (gray inactive, red active) matching lock column pattern
- Updated architecture docs to emphasize number formatting utilities under "Reusing Existing Utilities"

## Context
Users reported difficulty understanding pool impact when banning effects and confusion about why selecting a rarity didn't include effects in simulations. The "dice" terminology also didn't match the in-game "shards" currency name.