### PR TITLE
BUG: Fix duplicate effects in same round and stale target sync

### DIFF
--- a/src/features/tools/module-calculator/manual-mode/manual-mode-logic.test.ts
+++ b/src/features/tools/module-calculator/manual-mode/manual-mode-logic.test.ts
@@ -20,6 +20,9 @@ import {
   countLockedSlots,
   getPoolSize,
   buildMinRarityMap,
+  getLockedEffectIds,
+  areTargetsEqual,
+  syncRemainingTargetsWithConfig,
 } from './manual-mode-logic';
 
 describe('manual-mode-logic', () => {
@@ -950,6 +953,210 @@ describe('manual-mode-logic', () => {
       // With a nonexistent effect, we shouldn't hit any target
       expect(result.hasTargetHit).toBe(false);
       expect(result.hasCurrentPriorityHit).toBe(false);
+    });
+  });
+
+  describe('getLockedEffectIds', () => {
+    it('returns empty set when no slots are locked', () => {
+      const config = createTestConfig({ slotCount: 4 });
+      const state = initializeManualMode(config, 'accumulator', 0);
+
+      const lockedIds = getLockedEffectIds(state);
+
+      expect(lockedIds.size).toBe(0);
+    });
+
+    it('returns locked effect IDs', () => {
+      const targets: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['attackSpeed'], minRarity: 'common' },
+      ];
+      const config = createTestConfig({ slotCount: 4, slotTargets: targets });
+      let state = initializeManualMode(config, 'accumulator', 0);
+      const modeConfig = createModeConfig(targets);
+
+      // Roll until we get an effect and lock it
+      let attempts = 0;
+      while (attempts < 100) {
+        const { newState } = executeRoll(state, modeConfig);
+        state = newState;
+        if (state.slots[0]?.effect) {
+          state = lockSlot(state, 1);
+          break;
+        }
+        attempts++;
+      }
+
+      const lockedIds = getLockedEffectIds(state);
+
+      expect(lockedIds.size).toBe(1);
+      expect(lockedIds.has(state.slots[0].effect!.id)).toBe(true);
+    });
+
+    it('ignores unlocked slots with effects', () => {
+      const config = createTestConfig({ slotCount: 4 });
+      let state = initializeManualMode(config, 'accumulator', 0);
+      const modeConfig = createModeConfig([]);
+
+      // Roll to fill slots but don't lock
+      const { newState } = executeRoll(state, modeConfig);
+      state = newState;
+
+      const lockedIds = getLockedEffectIds(state);
+
+      expect(lockedIds.size).toBe(0);
+    });
+  });
+
+  describe('areTargetsEqual', () => {
+    it('returns true for identical targets', () => {
+      const targets: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['attackSpeed', 'critChance'], minRarity: 'legendary' },
+        { slotNumber: 2, acceptableEffects: ['damage'], minRarity: 'epic' },
+      ];
+
+      expect(areTargetsEqual(targets, targets)).toBe(true);
+    });
+
+    it('returns true for equal but different arrays', () => {
+      const targets1: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['attackSpeed'], minRarity: 'legendary' },
+      ];
+      const targets2: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['attackSpeed'], minRarity: 'legendary' },
+      ];
+
+      expect(areTargetsEqual(targets1, targets2)).toBe(true);
+    });
+
+    it('returns false for different lengths', () => {
+      const targets1: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['attackSpeed'], minRarity: 'legendary' },
+      ];
+      const targets2: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['attackSpeed'], minRarity: 'legendary' },
+        { slotNumber: 2, acceptableEffects: ['damage'], minRarity: 'epic' },
+      ];
+
+      expect(areTargetsEqual(targets1, targets2)).toBe(false);
+    });
+
+    it('returns false for different slot numbers', () => {
+      const targets1: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['attackSpeed'], minRarity: 'legendary' },
+      ];
+      const targets2: SlotTarget[] = [
+        { slotNumber: 2, acceptableEffects: ['attackSpeed'], minRarity: 'legendary' },
+      ];
+
+      expect(areTargetsEqual(targets1, targets2)).toBe(false);
+    });
+
+    it('returns false for different minRarity', () => {
+      const targets1: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['attackSpeed'], minRarity: 'legendary' },
+      ];
+      const targets2: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['attackSpeed'], minRarity: 'ancestral' },
+      ];
+
+      expect(areTargetsEqual(targets1, targets2)).toBe(false);
+    });
+
+    it('returns false for different acceptableEffects', () => {
+      const targets1: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['attackSpeed'], minRarity: 'legendary' },
+      ];
+      const targets2: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['critChance'], minRarity: 'legendary' },
+      ];
+
+      expect(areTargetsEqual(targets1, targets2)).toBe(false);
+    });
+
+    it('returns true for empty arrays', () => {
+      expect(areTargetsEqual([], [])).toBe(true);
+    });
+  });
+
+  describe('syncRemainingTargetsWithConfig', () => {
+    it('returns fresh targets when no effects are locked', () => {
+      const newTargets: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['attackSpeed', 'critChance'], minRarity: 'legendary' },
+        { slotNumber: 2, acceptableEffects: ['attackSpeed', 'critChance'], minRarity: 'legendary' },
+      ];
+
+      const synced = syncRemainingTargetsWithConfig(newTargets, new Set(), []);
+
+      expect(synced).toHaveLength(2);
+      expect(synced[0].acceptableEffects).toEqual(['attackSpeed', 'critChance']);
+      expect(synced[1].acceptableEffects).toEqual(['attackSpeed', 'critChance']);
+    });
+
+    it('removes locked effects from targets', () => {
+      const newTargets: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['attackSpeed', 'critChance'], minRarity: 'legendary' },
+        { slotNumber: 2, acceptableEffects: ['attackSpeed', 'critChance'], minRarity: 'legendary' },
+      ];
+      const lockedEffects = new Set(['attackSpeed']);
+
+      const synced = syncRemainingTargetsWithConfig(newTargets, lockedEffects, []);
+
+      // Both targets should now only have critChance
+      expect(synced).toHaveLength(2);
+      expect(synced[0].acceptableEffects).toEqual(['critChance']);
+      expect(synced[1].acceptableEffects).toEqual(['critChance']);
+    });
+
+    it('removes pre-locked effects from targets', () => {
+      const newTargets: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['attackSpeed', 'critChance'], minRarity: 'legendary' },
+      ];
+      const preLockedEffects = ['critChance'];
+
+      const synced = syncRemainingTargetsWithConfig(newTargets, new Set(), preLockedEffects);
+
+      expect(synced).toHaveLength(1);
+      expect(synced[0].acceptableEffects).toEqual(['attackSpeed']);
+    });
+
+    it('removes targets with no remaining acceptable effects', () => {
+      const newTargets: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['attackSpeed'], minRarity: 'legendary' },
+        { slotNumber: 2, acceptableEffects: ['critChance'], minRarity: 'legendary' },
+      ];
+      const lockedEffects = new Set(['attackSpeed']);
+
+      const synced = syncRemainingTargetsWithConfig(newTargets, lockedEffects, []);
+
+      // Slot 1 should be removed (no acceptable effects left)
+      expect(synced).toHaveLength(1);
+      expect(synced[0].slotNumber).toBe(2);
+      expect(synced[0].acceptableEffects).toEqual(['critChance']);
+    });
+
+    it('reflects minRarity changes from new config', () => {
+      // This is the key test - verifying that changed rarity is reflected
+      const newTargets: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['attackSpeed'], minRarity: 'mythic' }, // Changed from ancestral
+      ];
+
+      const synced = syncRemainingTargetsWithConfig(newTargets, new Set(), []);
+
+      expect(synced).toHaveLength(1);
+      expect(synced[0].minRarity).toBe('mythic');
+    });
+
+    it('handles both locked and pre-locked effects together', () => {
+      const newTargets: SlotTarget[] = [
+        { slotNumber: 1, acceptableEffects: ['a', 'b', 'c'], minRarity: 'legendary' },
+      ];
+      const lockedEffects = new Set(['a']);
+      const preLockedEffects = ['b'];
+
+      const synced = syncRemainingTargetsWithConfig(newTargets, lockedEffects, preLockedEffects);
+
+      expect(synced).toHaveLength(1);
+      expect(synced[0].acceptableEffects).toEqual(['c']);
     });
   });
 });

--- a/src/features/tools/module-calculator/manual-mode/manual-mode-logic.ts
+++ b/src/features/tools/module-calculator/manual-mode/manual-mode-logic.ts
@@ -404,4 +404,11 @@ export {
   countUnfulfilledTargetEffects,
 } from './state-queries';
 
+// Re-export target sync functions
+export {
+  getLockedEffectIds,
+  areTargetsEqual,
+  syncRemainingTargetsWithConfig,
+} from './target-sync';
+
 import { countUnfulfilledTargetEffects } from './state-queries';

--- a/src/features/tools/module-calculator/manual-mode/target-sync.ts
+++ b/src/features/tools/module-calculator/manual-mode/target-sync.ts
@@ -1,0 +1,78 @@
+/**
+ * Target Sync Logic
+ *
+ * Functions for syncing remainingTargets with config changes during
+ * an active manual mode session.
+ */
+
+import type { SlotTarget } from '../types';
+import { removeLockedEffectFromTargets } from '../simulation/simulation-engine';
+import type { ManualModeState } from './types';
+
+/**
+ * Extract locked effect IDs from current state.
+ *
+ * Used to preserve which effects should remain excluded when
+ * syncing remainingTargets with config changes.
+ */
+export function getLockedEffectIds(state: ManualModeState): Set<string> {
+  const lockedIds = new Set<string>();
+  for (const slot of state.slots) {
+    if (slot.isLocked && slot.effect) {
+      lockedIds.add(slot.effect.id);
+    }
+  }
+  return lockedIds;
+}
+
+/**
+ * Check if two target arrays are equal.
+ *
+ * Used to prevent infinite loops when syncing - only update state
+ * if there's an actual difference.
+ */
+export function areTargetsEqual(a: SlotTarget[], b: SlotTarget[]): boolean {
+  if (a.length !== b.length) return false;
+
+  for (let i = 0; i < a.length; i++) {
+    if (a[i].slotNumber !== b[i].slotNumber) return false;
+    if (a[i].minRarity !== b[i].minRarity) return false;
+    if (a[i].acceptableEffects.length !== b[i].acceptableEffects.length) return false;
+
+    for (let j = 0; j < a[i].acceptableEffects.length; j++) {
+      if (a[i].acceptableEffects[j] !== b[i].acceptableEffects[j]) return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Sync remainingTargets with current config.slotTargets.
+ *
+ * When the user changes target configuration mid-run (e.g., changing minRarity),
+ * this rebuilds remainingTargets from the fresh config while preserving
+ * which effects are already locked.
+ *
+ * Uses the same rebuild approach as unlockSlot() for consistency.
+ */
+export function syncRemainingTargetsWithConfig(
+  newSlotTargets: SlotTarget[],
+  lockedEffectIds: Set<string>,
+  preLockedEffectIds: string[]
+): SlotTarget[] {
+  // Start from fresh config targets
+  let synced = [...newSlotTargets];
+
+  // Remove pre-locked effects (they're always excluded from targets)
+  for (const effectId of preLockedEffectIds) {
+    synced = removeLockedEffectFromTargets(synced, effectId);
+  }
+
+  // Remove all user-locked effects
+  for (const effectId of lockedEffectIds) {
+    synced = removeLockedEffectFromTargets(synced, effectId);
+  }
+
+  return synced;
+}

--- a/src/features/tools/module-calculator/simulation/simulation-engine.test.ts
+++ b/src/features/tools/module-calculator/simulation/simulation-engine.test.ts
@@ -75,6 +75,25 @@ describe('simulation-engine', () => {
       expect(hitFound).toBe(true);
     });
 
+    it('never produces duplicate effects in the same round', () => {
+      const pool = createTestPool();
+      const targets: SlotTarget[] = [];
+      const minRarityMap = new Map();
+
+      // Roll many rounds with multiple slots to check for duplicates
+      // This is a critical invariant: a module cannot have duplicate effects
+      for (let i = 0; i < 200; i++) {
+        const result = rollRound(pool, 5, targets, minRarityMap);
+
+        // Extract effect IDs from this round
+        const effectIds = result.slotResults.map((sr) => sr.entry.effect.id);
+
+        // Check for duplicates using a Set
+        const uniqueIds = new Set(effectIds);
+        expect(uniqueIds.size).toBe(effectIds.length);
+      }
+    });
+
     it('distinguishes current priority from future priority targets', () => {
       const pool = createTestPool();
       // Two different priorities


### PR DESCRIPTION
## Summary
Fixes two critical bugs in the module calculator that caused incorrect simulation behavior. First, duplicate effects (like "Spotlight Bonus") could appear in the same roll round because all slots shared the same pool. Second, auto-roll would miss matched effects when users changed target configuration (like minRarity) mid-session because remainingTargets was a stale snapshot.

## Technical Details
- Modified `processSlotRoll` in simulation-engine.ts to return updated pool with rolled effect removed
- Added `currentPool` tracking in `rollRound` loop to prevent duplicate effects within a round
- Created target-sync.ts with `getLockedEffectIds`, `areTargetsEqual`, and `syncRemainingTargetsWithConfig` functions
- Added useEffect in use-manual-mode.ts to sync remainingTargets when config.slotTargets changes
- Added test verifying no duplicate effects across 200 rounds with 5 slots each
- Added comprehensive tests for all target sync functions

## Context
The pool fix affects both Monte Carlo simulation and Manual Mode since they share `rollRound`. The target sync fix only affects Manual Mode where users can modify targets during an active session.