### PR TITLE
MINOR: Add Spending Planner feature for currency-based upgrade planning

### DIFF
--- a/src/features/navigation/config/navigation-config.ts
+++ b/src/features/navigation/config/navigation-config.ts
@@ -88,6 +88,12 @@ export const NAVIGATION_SECTIONS: NavigationSection[] = [
         label: 'Module Calculator',
         href: '/tools/module-calculator',
         icon: 'calculator'
+      },
+      {
+        id: 'spending-planner',
+        label: 'Spending Planner',
+        href: '/tools/spending-planner',
+        icon: 'planner'
       }
     ]
   },

--- a/src/features/navigation/top-navbar/nav-icon.tsx
+++ b/src/features/navigation/top-navbar/nav-icon.tsx
@@ -1,5 +1,5 @@
 interface NavIconProps {
-  type: 'runs' | 'farming' | 'tournament' | 'milestone' | 'coins' | 'cells' | 'deaths' | 'tier-stats' | 'tier-trends' | 'field-analytics' | 'settings' | 'data-management' | 'locale' | 'discord' | 'github' | 'calculator'
+  type: 'runs' | 'farming' | 'tournament' | 'milestone' | 'coins' | 'cells' | 'deaths' | 'tier-stats' | 'tier-trends' | 'field-analytics' | 'settings' | 'data-management' | 'locale' | 'discord' | 'github' | 'calculator' | 'planner'
   className?: string
 }
 
@@ -100,6 +100,12 @@ export function NavIcon({ type, className = "w-4 h-4" }: NavIconProps) {
       return (
         <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 7h6m0 10v-3m-3 3h.01M9 17h.01M9 14h.01M12 14h.01M15 11h.01M12 11h.01M9 11h.01M7 21h10a2 2 0 002-2V5a2 2 0 00-2-2H7a2 2 0 00-2 2v14a2 2 0 002 2z" />
+        </svg>
+      )
+    case 'planner':
+      return (
+        <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
         </svg>
       )
     default:

--- a/src/features/navigation/types.ts
+++ b/src/features/navigation/types.ts
@@ -1,7 +1,7 @@
 interface NavigationItem {
   id: string
   label: string
-  icon?: 'runs' | 'farming' | 'tournament' | 'milestone' | 'coins' | 'cells' | 'deaths' | 'tier-stats' | 'tier-trends' | 'field-analytics' | 'settings' | 'data-management' | 'locale' | 'discord' | 'github' | 'calculator'
+  icon?: 'runs' | 'farming' | 'tournament' | 'milestone' | 'coins' | 'cells' | 'deaths' | 'tier-stats' | 'tier-trends' | 'field-analytics' | 'settings' | 'data-management' | 'locale' | 'discord' | 'github' | 'calculator' | 'planner'
   href?: string
   children?: NavigationItem[]
 }

--- a/src/features/spending-planner/calculations/income-projection.test.ts
+++ b/src/features/spending-planner/calculations/income-projection.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from 'vitest'
+import {
+  projectBalances,
+  projectIncomes,
+  projectAllBalances,
+  projectAllIncomes,
+  findAffordableWeek,
+} from './income-projection'
+import { CurrencyId } from '../types'
+import type { CurrencyIncome } from '../types'
+
+describe('income-projection', () => {
+  describe('projectBalances', () => {
+    it('should project balances without growth', () => {
+      const income: CurrencyIncome = {
+        currencyId: CurrencyId.Coins,
+        currentBalance: 100,
+        weeklyIncome: 50,
+        growthRatePercent: 0,
+      }
+
+      const balances = projectBalances(income, 4)
+
+      expect(balances).toEqual([100, 150, 200, 250, 300])
+    })
+
+    it('should project balances with growth', () => {
+      const income: CurrencyIncome = {
+        currencyId: CurrencyId.Coins,
+        currentBalance: 100,
+        weeklyIncome: 100,
+        growthRatePercent: 10,
+      }
+
+      const balances = projectBalances(income, 3)
+
+      // Week 0: 100 (starting)
+      // Week 1: 100 + 100 = 200
+      // Week 2: 200 + 110 = 310
+      // Week 3: 310 + 121 = 431
+      expect(balances[0]).toBe(100)
+      expect(balances[1]).toBe(200)
+      expect(balances[2]).toBeCloseTo(310, 5)
+      expect(balances[3]).toBeCloseTo(431, 5)
+    })
+
+    it('should handle zero starting balance', () => {
+      const income: CurrencyIncome = {
+        currencyId: CurrencyId.Coins,
+        currentBalance: 0,
+        weeklyIncome: 100,
+        growthRatePercent: 0,
+      }
+
+      const balances = projectBalances(income, 3)
+
+      expect(balances).toEqual([0, 100, 200, 300])
+    })
+
+    it('should handle zero income', () => {
+      const income: CurrencyIncome = {
+        currencyId: CurrencyId.Coins,
+        currentBalance: 500,
+        weeklyIncome: 0,
+        growthRatePercent: 0,
+      }
+
+      const balances = projectBalances(income, 3)
+
+      expect(balances).toEqual([500, 500, 500, 500])
+    })
+
+    it('should handle negative growth', () => {
+      const income: CurrencyIncome = {
+        currencyId: CurrencyId.Coins,
+        currentBalance: 100,
+        weeklyIncome: 100,
+        growthRatePercent: -50,
+      }
+
+      const balances = projectBalances(income, 3)
+
+      // Week 0: 100
+      // Week 1: 100 + 100 = 200
+      // Week 2: 200 + 50 = 250
+      // Week 3: 250 + 25 = 275
+      expect(balances[0]).toBe(100)
+      expect(balances[1]).toBe(200)
+      expect(balances[2]).toBe(250)
+      expect(balances[3]).toBe(275)
+    })
+  })
+
+  describe('projectIncomes', () => {
+    it('should project incomes without growth', () => {
+      const income: CurrencyIncome = {
+        currencyId: CurrencyId.Coins,
+        currentBalance: 100,
+        weeklyIncome: 50,
+        growthRatePercent: 0,
+      }
+
+      const incomes = projectIncomes(income, 4)
+
+      expect(incomes).toEqual([50, 50, 50, 50])
+    })
+
+    it('should project incomes with growth', () => {
+      const income: CurrencyIncome = {
+        currencyId: CurrencyId.Coins,
+        currentBalance: 100,
+        weeklyIncome: 100,
+        growthRatePercent: 10,
+      }
+
+      const incomes = projectIncomes(income, 4)
+
+      expect(incomes[0]).toBe(100)
+      expect(incomes[1]).toBeCloseTo(110, 5)
+      expect(incomes[2]).toBeCloseTo(121, 5)
+      expect(incomes[3]).toBeCloseTo(133.1, 5)
+    })
+  })
+
+  describe('projectAllBalances', () => {
+    it('should project balances for all currencies', () => {
+      const incomes: CurrencyIncome[] = [
+        { currencyId: CurrencyId.Coins, currentBalance: 100, weeklyIncome: 50, growthRatePercent: 0 },
+        { currencyId: CurrencyId.Stones, currentBalance: 200, weeklyIncome: 100, growthRatePercent: 0 },
+      ]
+
+      const result = projectAllBalances(incomes, 2)
+
+      expect(result.get(CurrencyId.Coins)).toEqual([100, 150, 200])
+      expect(result.get(CurrencyId.Stones)).toEqual([200, 300, 400])
+    })
+  })
+
+  describe('projectAllIncomes', () => {
+    it('should project incomes for all currencies', () => {
+      const incomes: CurrencyIncome[] = [
+        { currencyId: CurrencyId.Coins, currentBalance: 100, weeklyIncome: 50, growthRatePercent: 0 },
+        { currencyId: CurrencyId.Stones, currentBalance: 200, weeklyIncome: 100, growthRatePercent: 0 },
+      ]
+
+      const result = projectAllIncomes(incomes, 2)
+
+      expect(result.get(CurrencyId.Coins)).toEqual([50, 50])
+      expect(result.get(CurrencyId.Stones)).toEqual([100, 100])
+    })
+  })
+
+  describe('findAffordableWeek', () => {
+    it('should find week when affordable from start', () => {
+      const balances = [100, 150, 200, 250, 300]
+      expect(findAffordableWeek(balances, 100)).toBe(0)
+    })
+
+    it('should find week when affordable later', () => {
+      const balances = [100, 150, 200, 250, 300]
+      expect(findAffordableWeek(balances, 200)).toBe(2)
+    })
+
+    it('should return -1 if never affordable', () => {
+      const balances = [100, 150, 200, 250, 300]
+      expect(findAffordableWeek(balances, 500)).toBe(-1)
+    })
+
+    it('should handle exact match', () => {
+      const balances = [100, 150, 200, 250, 300]
+      expect(findAffordableWeek(balances, 150)).toBe(1)
+    })
+
+    it('should handle empty balances', () => {
+      expect(findAffordableWeek([], 100)).toBe(-1)
+    })
+  })
+})

--- a/src/features/spending-planner/calculations/income-projection.ts
+++ b/src/features/spending-planner/calculations/income-projection.ts
@@ -1,0 +1,107 @@
+/**
+ * Income Projection
+ *
+ * Functions for projecting currency balances over time with growth.
+ */
+
+import type { CurrencyIncome, CurrencyId } from '../types'
+
+/**
+ * Project balances for a currency over multiple weeks.
+ * Applies compound growth to weekly income.
+ *
+ * @param income - Income configuration for the currency
+ * @param weeks - Number of weeks to project
+ * @returns Array of balances, one per week (index 0 = week 0, current balance)
+ */
+export function projectBalances(income: CurrencyIncome, weeks: number): number[] {
+  const balances: number[] = [income.currentBalance]
+  let currentIncome = income.weeklyIncome
+  const growthMultiplier = 1 + income.growthRatePercent / 100
+
+  for (let week = 1; week <= weeks; week++) {
+    const previousBalance = balances[week - 1]
+    balances.push(previousBalance + currentIncome)
+    // Apply growth for next week's income
+    currentIncome *= growthMultiplier
+  }
+
+  return balances
+}
+
+/**
+ * Project weekly income amounts for a currency.
+ * Shows the income added each week (with growth applied).
+ *
+ * @param income - Income configuration for the currency
+ * @param weeks - Number of weeks to project
+ * @returns Array of income amounts, one per week (index 0 = week 1 income)
+ */
+export function projectIncomes(income: CurrencyIncome, weeks: number): number[] {
+  const incomes: number[] = []
+  let currentIncome = income.weeklyIncome
+  const growthMultiplier = 1 + income.growthRatePercent / 100
+
+  for (let week = 0; week < weeks; week++) {
+    incomes.push(currentIncome)
+    currentIncome *= growthMultiplier
+  }
+
+  return incomes
+}
+
+/**
+ * Project balances for all currencies.
+ *
+ * @param incomes - Income configurations for all currencies
+ * @param weeks - Number of weeks to project
+ * @returns Map of currency ID to balance arrays
+ */
+export function projectAllBalances(
+  incomes: CurrencyIncome[],
+  weeks: number
+): Map<CurrencyId, number[]> {
+  const result = new Map<CurrencyId, number[]>()
+
+  for (const income of incomes) {
+    result.set(income.currencyId, projectBalances(income, weeks))
+  }
+
+  return result
+}
+
+/**
+ * Project income amounts for all currencies.
+ *
+ * @param incomes - Income configurations for all currencies
+ * @param weeks - Number of weeks to project
+ * @returns Map of currency ID to income arrays
+ */
+export function projectAllIncomes(
+  incomes: CurrencyIncome[],
+  weeks: number
+): Map<CurrencyId, number[]> {
+  const result = new Map<CurrencyId, number[]>()
+
+  for (const income of incomes) {
+    result.set(income.currencyId, projectIncomes(income, weeks))
+  }
+
+  return result
+}
+
+/**
+ * Find the first week where balance exceeds a threshold.
+ *
+ * @param balances - Projected balances array
+ * @param amount - Amount needed
+ * @returns Week index where balance first exceeds amount, or -1 if never
+ */
+export function findAffordableWeek(balances: number[], amount: number): number {
+  for (let week = 0; week < balances.length; week++) {
+    if (balances[week] >= amount) {
+      return week
+    }
+  }
+  return -1
+}

--- a/src/features/spending-planner/calculations/timeline-calculator.test.ts
+++ b/src/features/spending-planner/calculations/timeline-calculator.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect } from 'vitest'
+import { calculateTimeline, getWeekNumber, getWeekStartDate } from './timeline-calculator'
+import { CurrencyId } from '../types'
+import type { CurrencyIncome, SpendingEvent } from '../types'
+
+describe('timeline-calculator', () => {
+  // Use explicit date parts to avoid UTC parsing issues
+  const startDate = new Date(2025, 0, 1) // Jan 1, 2025
+
+  describe('calculateTimeline', () => {
+    it('should schedule event in week 0 if affordable immediately', () => {
+      const incomes: CurrencyIncome[] = [
+        { currencyId: CurrencyId.Coins, currentBalance: 1000, weeklyIncome: 100, growthRatePercent: 0 },
+      ]
+      const events: SpendingEvent[] = [
+        { id: '1', name: 'Event 1', currencyId: CurrencyId.Coins, amount: 500, priority: 0 },
+      ]
+
+      const result = calculateTimeline(incomes, events, 12, startDate)
+
+      expect(result.events).toHaveLength(1)
+      expect(result.events[0].triggerWeek).toBe(0)
+      expect(result.events[0].balanceAtTrigger).toBe(1000)
+    })
+
+    it('should schedule event in later week if not affordable immediately', () => {
+      const incomes: CurrencyIncome[] = [
+        { currencyId: CurrencyId.Coins, currentBalance: 100, weeklyIncome: 100, growthRatePercent: 0 },
+      ]
+      const events: SpendingEvent[] = [
+        { id: '1', name: 'Event 1', currencyId: CurrencyId.Coins, amount: 500, priority: 0 },
+      ]
+
+      const result = calculateTimeline(incomes, events, 12, startDate)
+
+      expect(result.events).toHaveLength(1)
+      expect(result.events[0].triggerWeek).toBe(4) // 100 + 4*100 = 500
+    })
+
+    it('should process events in priority order', () => {
+      const incomes: CurrencyIncome[] = [
+        { currencyId: CurrencyId.Coins, currentBalance: 1000, weeklyIncome: 100, growthRatePercent: 0 },
+      ]
+      const events: SpendingEvent[] = [
+        { id: '2', name: 'Event 2', currencyId: CurrencyId.Coins, amount: 300, priority: 1 },
+        { id: '1', name: 'Event 1', currencyId: CurrencyId.Coins, amount: 700, priority: 0 },
+      ]
+
+      const result = calculateTimeline(incomes, events, 12, startDate)
+
+      expect(result.events).toHaveLength(2)
+      // Event 1 (priority 0) should trigger first at week 0 (1000 >= 700)
+      expect(result.events[0].event.id).toBe('1')
+      expect(result.events[0].triggerWeek).toBe(0)
+      // Event 2 (priority 1) should trigger at week 0 since 1000-700=300 >= 300
+      expect(result.events[1].event.id).toBe('2')
+      expect(result.events[1].triggerWeek).toBe(0)
+    })
+
+    it('should deduct cost from future balances', () => {
+      const incomes: CurrencyIncome[] = [
+        { currencyId: CurrencyId.Coins, currentBalance: 500, weeklyIncome: 100, growthRatePercent: 0 },
+      ]
+      const events: SpendingEvent[] = [
+        { id: '1', name: 'Event 1', currencyId: CurrencyId.Coins, amount: 400, priority: 0 },
+        { id: '2', name: 'Event 2', currencyId: CurrencyId.Coins, amount: 200, priority: 1 },
+      ]
+
+      const result = calculateTimeline(incomes, events, 12, startDate)
+
+      expect(result.events).toHaveLength(2)
+      // Event 1: triggers week 0 (500 >= 400)
+      expect(result.events[0].triggerWeek).toBe(0)
+      // Event 2: balance after event 1 is 100, needs 200, so triggers week 1 (100+100=200)
+      expect(result.events[1].triggerWeek).toBe(1)
+    })
+
+    it('should handle multiple currencies independently when sequence allows', () => {
+      const incomes: CurrencyIncome[] = [
+        { currencyId: CurrencyId.Coins, currentBalance: 500, weeklyIncome: 100, growthRatePercent: 0 },
+        { currencyId: CurrencyId.Stones, currentBalance: 200, weeklyIncome: 50, growthRatePercent: 0 },
+      ]
+      const events: SpendingEvent[] = [
+        { id: '1', name: 'Coin Event', currencyId: CurrencyId.Coins, amount: 400, priority: 0 },
+        { id: '2', name: 'Stone Event', currencyId: CurrencyId.Stones, amount: 150, priority: 1 },
+      ]
+
+      const result = calculateTimeline(incomes, events, 12, startDate)
+
+      expect(result.events).toHaveLength(2)
+      expect(result.events[0].event.currencyId).toBe(CurrencyId.Coins)
+      expect(result.events[0].triggerWeek).toBe(0)
+      // Stone event CAN trigger at week 0 since coin event also triggered at week 0
+      expect(result.events[1].event.currencyId).toBe(CurrencyId.Stones)
+      expect(result.events[1].triggerWeek).toBe(0)
+    })
+
+    it('should enforce queue sequence - later events cannot trigger before earlier ones', () => {
+      const incomes: CurrencyIncome[] = [
+        { currencyId: CurrencyId.Coins, currentBalance: 100, weeklyIncome: 100, growthRatePercent: 0 },
+        { currencyId: CurrencyId.Stones, currentBalance: 500, weeklyIncome: 50, growthRatePercent: 0 },
+      ]
+      // Event 1 (coins) can't afford until week 4
+      // Event 2 (stones) COULD afford immediately at week 0
+      // But Event 2 should wait for Event 1 due to queue sequence
+      const events: SpendingEvent[] = [
+        { id: '1', name: 'Coin Event', currencyId: CurrencyId.Coins, amount: 500, priority: 0 },
+        { id: '2', name: 'Stone Event', currencyId: CurrencyId.Stones, amount: 100, priority: 1 },
+      ]
+
+      const result = calculateTimeline(incomes, events, 12, startDate)
+
+      expect(result.events).toHaveLength(2)
+      // Coin event triggers at week 4 (100 + 4*100 = 500)
+      expect(result.events[0].triggerWeek).toBe(4)
+      // Stone event must wait until week 4 even though balance allows week 0
+      expect(result.events[1].triggerWeek).toBe(4)
+    })
+
+    it('should mark events as unaffordable if cannot be afforded within timeline', () => {
+      const incomes: CurrencyIncome[] = [
+        { currencyId: CurrencyId.Coins, currentBalance: 100, weeklyIncome: 10, growthRatePercent: 0 },
+      ]
+      const events: SpendingEvent[] = [
+        { id: '1', name: 'Expensive Event', currencyId: CurrencyId.Coins, amount: 10000, priority: 0 },
+      ]
+
+      const result = calculateTimeline(incomes, events, 12, startDate)
+
+      expect(result.events).toHaveLength(0)
+      expect(result.unaffordableEvents).toHaveLength(1)
+      expect(result.unaffordableEvents[0].id).toBe('1')
+    })
+
+    it('should calculate correct trigger dates', () => {
+      const incomes: CurrencyIncome[] = [
+        { currencyId: CurrencyId.Coins, currentBalance: 100, weeklyIncome: 100, growthRatePercent: 0 },
+      ]
+      const events: SpendingEvent[] = [
+        { id: '1', name: 'Event', currencyId: CurrencyId.Coins, amount: 300, priority: 0 },
+      ]
+
+      const result = calculateTimeline(incomes, events, 12, startDate)
+
+      expect(result.events).toHaveLength(1)
+      expect(result.events[0].triggerWeek).toBe(2) // Week 2: 100 + 2*100 = 300
+      // 2 weeks after Jan 1 = Jan 15
+      expect(result.events[0].triggerDate.getDate()).toBe(15)
+    })
+
+    it('should calculate end dates for events with duration', () => {
+      const incomes: CurrencyIncome[] = [
+        { currencyId: CurrencyId.Coins, currentBalance: 1000, weeklyIncome: 100, growthRatePercent: 0 },
+      ]
+      const events: SpendingEvent[] = [
+        { id: '1', name: 'Lab', currencyId: CurrencyId.Coins, amount: 500, priority: 0, durationDays: 40 },
+      ]
+
+      const result = calculateTimeline(incomes, events, 12, startDate)
+
+      expect(result.events).toHaveLength(1)
+      expect(result.events[0].endDate).toBeDefined()
+      // 40 days after Jan 1 = Feb 10
+      const expectedEnd = new Date(startDate)
+      expectedEnd.setDate(expectedEnd.getDate() + 40)
+      expect(result.events[0].endDate!.getDate()).toBe(expectedEnd.getDate())
+    })
+
+    it('should include balance projections in result', () => {
+      const incomes: CurrencyIncome[] = [
+        { currencyId: CurrencyId.Coins, currentBalance: 100, weeklyIncome: 50, growthRatePercent: 0 },
+      ]
+      const events: SpendingEvent[] = []
+
+      const result = calculateTimeline(incomes, events, 4, startDate)
+
+      const coinBalances = result.balancesByWeek.get(CurrencyId.Coins)
+      expect(coinBalances).toBeDefined()
+      expect(coinBalances).toEqual([100, 150, 200, 250, 300])
+    })
+
+    it('should include income projections in result', () => {
+      const incomes: CurrencyIncome[] = [
+        { currencyId: CurrencyId.Coins, currentBalance: 100, weeklyIncome: 50, growthRatePercent: 0 },
+      ]
+      const events: SpendingEvent[] = []
+
+      const result = calculateTimeline(incomes, events, 4, startDate)
+
+      const coinIncomes = result.incomeByWeek.get(CurrencyId.Coins)
+      expect(coinIncomes).toBeDefined()
+      expect(coinIncomes).toEqual([50, 50, 50, 50])
+    })
+  })
+
+  describe('getWeekNumber', () => {
+    it('should return 0 for same date', () => {
+      const date = new Date(2025, 0, 1)
+      expect(getWeekNumber(date, startDate)).toBe(0)
+    })
+
+    it('should return correct week for later date', () => {
+      const date = new Date(2025, 0, 15) // 14 days = 2 weeks
+      expect(getWeekNumber(date, startDate)).toBe(2)
+    })
+
+    it('should handle partial weeks', () => {
+      const date = new Date(2025, 0, 5) // 4 days = still week 0
+      expect(getWeekNumber(date, startDate)).toBe(0)
+    })
+  })
+
+  describe('getWeekStartDate', () => {
+    it('should return start date for week 0', () => {
+      const result = getWeekStartDate(0, startDate)
+      expect(result.getTime()).toBe(startDate.getTime())
+    })
+
+    it('should return correct date for later weeks', () => {
+      const result = getWeekStartDate(2, startDate)
+      expect(result.getDate()).toBe(15) // Jan 1 + 14 days = Jan 15
+    })
+  })
+})

--- a/src/features/spending-planner/calculations/timeline-calculator.ts
+++ b/src/features/spending-planner/calculations/timeline-calculator.ts
@@ -1,0 +1,173 @@
+/**
+ * Timeline Calculator
+ *
+ * Calculate when spending events can be triggered based on income projections.
+ */
+
+import type {
+  CurrencyIncome,
+  SpendingEvent,
+  TimelineEvent,
+  TimelineData,
+  CurrencyId,
+} from '../types'
+import { projectBalances, projectIncomes } from './income-projection'
+import { sortByPriority } from '../events/event-reorder'
+
+/**
+ * Initialize balance projections for all currencies.
+ */
+function initializeBalances(
+  incomes: CurrencyIncome[],
+  weeks: number
+): Map<CurrencyId, number[]> {
+  const balances = new Map<CurrencyId, number[]>()
+  for (const income of incomes) {
+    balances.set(income.currencyId, projectBalances(income, weeks))
+  }
+  return balances
+}
+
+/**
+ * Initialize income projections for all currencies.
+ */
+function initializeIncomes(
+  incomes: CurrencyIncome[],
+  weeks: number
+): Map<CurrencyId, number[]> {
+  const result = new Map<CurrencyId, number[]>()
+  for (const income of incomes) {
+    result.set(income.currencyId, projectIncomes(income, weeks))
+  }
+  return result
+}
+
+/**
+ * Process a single event and return the timeline event if affordable.
+ *
+ * @param minTriggerWeek - Earliest week this event can trigger (enforces queue sequence)
+ */
+function processEvent(
+  event: SpendingEvent,
+  balances: Map<CurrencyId, number[]>,
+  startDate: Date,
+  minTriggerWeek: number
+): TimelineEvent | null {
+  const currencyBalances = balances.get(event.currencyId)
+  if (!currencyBalances) return null
+
+  // Find trigger week, but no earlier than minTriggerWeek (respects queue order)
+  const triggerWeek = findTriggerWeek(currencyBalances, event.amount, minTriggerWeek)
+  if (triggerWeek === -1) return null
+
+  const triggerDate = addWeeks(startDate, triggerWeek)
+  const endDate = event.durationDays && event.durationDays > 0
+    ? addDays(triggerDate, event.durationDays)
+    : undefined
+
+  subtractFromBalances(currencyBalances, triggerWeek, event.amount)
+
+  return {
+    event,
+    triggerWeek,
+    triggerDate,
+    endDate,
+    balanceAtTrigger: currencyBalances[triggerWeek] + event.amount,
+  }
+}
+
+/**
+ * Calculate timeline for all spending events.
+ */
+export function calculateTimeline(
+  incomes: CurrencyIncome[],
+  events: SpendingEvent[],
+  weeks: number,
+  startDate: Date = new Date()
+): TimelineData {
+  const sortedEvents = sortByPriority(events)
+  const runningBalances = initializeBalances(incomes, weeks)
+  const incomeByWeek = initializeIncomes(incomes, weeks)
+
+  const timelineEvents: TimelineEvent[] = []
+  const unaffordableEvents: SpendingEvent[] = []
+
+  // Track the latest trigger week to enforce queue sequence
+  // Later events in queue cannot trigger before earlier events
+  let minTriggerWeek = 0
+
+  for (const event of sortedEvents) {
+    const result = processEvent(event, runningBalances, startDate, minTriggerWeek)
+    if (result) {
+      timelineEvents.push(result)
+      // Update minimum trigger week for subsequent events
+      minTriggerWeek = result.triggerWeek
+    } else {
+      unaffordableEvents.push(event)
+    }
+  }
+
+  return { events: timelineEvents, balancesByWeek: runningBalances, incomeByWeek, unaffordableEvents }
+}
+
+/**
+ * Find the first week where balance can cover the amount.
+ *
+ * @param startWeek - Earliest week to consider (for queue sequence enforcement)
+ */
+function findTriggerWeek(balances: number[], amount: number, startWeek: number = 0): number {
+  for (let week = startWeek; week < balances.length; week++) {
+    if (balances[week] >= amount) {
+      return week
+    }
+  }
+  return -1
+}
+
+/**
+ * Subtract an amount from balances starting at a specific week.
+ * Modifies the balances array in place.
+ */
+function subtractFromBalances(
+  balances: number[],
+  fromWeek: number,
+  amount: number
+): void {
+  for (let week = fromWeek; week < balances.length; week++) {
+    balances[week] -= amount
+  }
+}
+
+/**
+ * Add weeks to a date.
+ */
+function addWeeks(date: Date, weeks: number): Date {
+  const result = new Date(date)
+  result.setDate(result.getDate() + weeks * 7)
+  return result
+}
+
+/**
+ * Add days to a date.
+ */
+function addDays(date: Date, days: number): Date {
+  const result = new Date(date)
+  result.setDate(result.getDate() + days)
+  return result
+}
+
+/**
+ * Get the week number for a date relative to a start date.
+ */
+export function getWeekNumber(date: Date, startDate: Date): number {
+  const diffMs = date.getTime() - startDate.getTime()
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24))
+  return Math.floor(diffDays / 7)
+}
+
+/**
+ * Get the date for the start of a specific week.
+ */
+export function getWeekStartDate(weekNumber: number, startDate: Date): Date {
+  return addWeeks(startDate, weekNumber)
+}

--- a/src/features/spending-planner/currencies/currency-config.test.ts
+++ b/src/features/spending-planner/currencies/currency-config.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest'
+import {
+  CURRENCY_CONFIGS,
+  CURRENCY_ORDER,
+  getCurrencyConfig,
+  getAllCurrencyConfigs,
+  isValidCurrencyId,
+  createDefaultIncome,
+  createDefaultStoneBreakdown,
+  calculateStoneIncome,
+} from './currency-config'
+import { CurrencyId } from '../types'
+
+describe('currency-config', () => {
+  describe('CURRENCY_CONFIGS', () => {
+    it('should define coins currency', () => {
+      expect(CURRENCY_CONFIGS[CurrencyId.Coins]).toEqual({
+        id: CurrencyId.Coins,
+        displayName: 'Coins',
+        abbreviation: 'c',
+        color: 'text-yellow-400',
+        hasUnitSelector: true,
+      })
+    })
+
+    it('should define stones currency', () => {
+      expect(CURRENCY_CONFIGS[CurrencyId.Stones]).toEqual({
+        id: CurrencyId.Stones,
+        displayName: 'Stones',
+        abbreviation: 'st',
+        color: 'text-emerald-400',
+        hasUnitSelector: false,
+      })
+    })
+  })
+
+  describe('CURRENCY_ORDER', () => {
+    it('should have coins before stones', () => {
+      expect(CURRENCY_ORDER).toEqual([CurrencyId.Coins, CurrencyId.Stones])
+    })
+  })
+
+  describe('getCurrencyConfig', () => {
+    it('should return coins config', () => {
+      const config = getCurrencyConfig(CurrencyId.Coins)
+      expect(config.id).toBe(CurrencyId.Coins)
+      expect(config.hasUnitSelector).toBe(true)
+    })
+
+    it('should return stones config', () => {
+      const config = getCurrencyConfig(CurrencyId.Stones)
+      expect(config.id).toBe(CurrencyId.Stones)
+      expect(config.hasUnitSelector).toBe(false)
+    })
+  })
+
+  describe('getAllCurrencyConfigs', () => {
+    it('should return all configs in order', () => {
+      const configs = getAllCurrencyConfigs()
+      expect(configs).toHaveLength(2)
+      expect(configs[0].id).toBe(CurrencyId.Coins)
+      expect(configs[1].id).toBe(CurrencyId.Stones)
+    })
+  })
+
+  describe('isValidCurrencyId', () => {
+    it('should return true for coins', () => {
+      expect(isValidCurrencyId(CurrencyId.Coins)).toBe(true)
+    })
+
+    it('should return true for stones', () => {
+      expect(isValidCurrencyId(CurrencyId.Stones)).toBe(true)
+    })
+
+    it('should return false for invalid currency', () => {
+      expect(isValidCurrencyId('gems')).toBe(false)
+      expect(isValidCurrencyId('')).toBe(false)
+      expect(isValidCurrencyId('invalid')).toBe(false)
+    })
+  })
+
+  describe('createDefaultIncome', () => {
+    it('should create default coins income with 5% growth', () => {
+      const income = createDefaultIncome(CurrencyId.Coins)
+      expect(income).toEqual({
+        currencyId: CurrencyId.Coins,
+        currentBalance: 0,
+        weeklyIncome: 0,
+        growthRatePercent: 5,
+      })
+    })
+
+    it('should create default stones income with 0% growth', () => {
+      const income = createDefaultIncome(CurrencyId.Stones)
+      expect(income).toEqual({
+        currencyId: CurrencyId.Stones,
+        currentBalance: 0,
+        weeklyIncome: 0,
+        growthRatePercent: 0,
+      })
+    })
+  })
+
+  describe('createDefaultStoneBreakdown', () => {
+    it('should create breakdown with all zeros', () => {
+      const breakdown = createDefaultStoneBreakdown()
+      expect(breakdown).toEqual({
+        weeklyChallenges: 0,
+        eventStore: 0,
+        tournamentResults: 0,
+      })
+    })
+  })
+
+  describe('calculateStoneIncome', () => {
+    it('should sum all breakdown sources', () => {
+      const breakdown = {
+        weeklyChallenges: 60,
+        eventStore: 0,
+        tournamentResults: 200,
+      }
+      expect(calculateStoneIncome(breakdown)).toBe(260)
+    })
+
+    it('should return 0 for empty breakdown', () => {
+      const breakdown = createDefaultStoneBreakdown()
+      expect(calculateStoneIncome(breakdown)).toBe(0)
+    })
+
+    it('should handle all sources having values', () => {
+      const breakdown = {
+        weeklyChallenges: 100,
+        eventStore: 50,
+        tournamentResults: 150,
+      }
+      expect(calculateStoneIncome(breakdown)).toBe(300)
+    })
+  })
+})

--- a/src/features/spending-planner/currencies/currency-config.ts
+++ b/src/features/spending-planner/currencies/currency-config.ts
@@ -1,0 +1,86 @@
+/**
+ * Currency Configuration
+ *
+ * Defines the supported currencies in the spending planner.
+ * Designed to be extensible for future currency additions.
+ */
+
+import { CurrencyId } from '../types'
+import type { CurrencyConfig, CurrencyIncome, StoneIncomeBreakdown } from '../types'
+
+/**
+ * Configuration for all supported currencies.
+ * Add new currencies here when extending the system.
+ */
+export const CURRENCY_CONFIGS: Record<CurrencyId, CurrencyConfig> = {
+  [CurrencyId.Coins]: {
+    id: CurrencyId.Coins,
+    displayName: 'Coins',
+    abbreviation: 'c',
+    color: 'text-yellow-400',
+    hasUnitSelector: true,
+  },
+  [CurrencyId.Stones]: {
+    id: CurrencyId.Stones,
+    displayName: 'Stones',
+    abbreviation: 'st',
+    color: 'text-emerald-400',
+    hasUnitSelector: false,
+  },
+}
+
+/**
+ * Ordered list of currency IDs for consistent display.
+ */
+export const CURRENCY_ORDER: CurrencyId[] = [CurrencyId.Coins, CurrencyId.Stones]
+
+/**
+ * Get configuration for a specific currency.
+ */
+export function getCurrencyConfig(currencyId: CurrencyId): CurrencyConfig {
+  return CURRENCY_CONFIGS[currencyId]
+}
+
+/**
+ * Get all currency configurations in display order.
+ */
+export function getAllCurrencyConfigs(): CurrencyConfig[] {
+  return CURRENCY_ORDER.map((id) => CURRENCY_CONFIGS[id])
+}
+
+/**
+ * Check if a currency ID is valid.
+ */
+export function isValidCurrencyId(value: string): value is CurrencyId {
+  return Object.values(CurrencyId).includes(value as CurrencyId)
+}
+
+/**
+ * Create default income configuration for a currency.
+ */
+export function createDefaultIncome(currencyId: CurrencyId): CurrencyIncome {
+  return {
+    currencyId,
+    currentBalance: 0,
+    weeklyIncome: 0,
+    growthRatePercent: currencyId === CurrencyId.Coins ? 5 : 0,
+  }
+}
+
+/**
+ * Create default stone income breakdown.
+ */
+export function createDefaultStoneBreakdown(): StoneIncomeBreakdown {
+  return {
+    weeklyChallenges: 0,
+    eventStore: 0,
+    tournamentResults: 0,
+  }
+}
+
+/**
+ * Calculate total stone income from breakdown.
+ */
+export function calculateStoneIncome(breakdown: StoneIncomeBreakdown): number {
+  return breakdown.weeklyChallenges + breakdown.eventStore + breakdown.tournamentResults
+}

--- a/src/features/spending-planner/events/add-event-dialog.tsx
+++ b/src/features/spending-planner/events/add-event-dialog.tsx
@@ -1,0 +1,99 @@
+/**
+ * Add Event Dialog Component
+ *
+ * Dialog for adding new spending events to the queue.
+ */
+
+import { useState } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogDescription,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { CurrencyId } from '../types'
+import { getAllCurrencyConfigs } from '../currencies/currency-config'
+import { AddEventForm, SCALE_OPTIONS } from './add-event-form'
+
+interface AddEventDialogProps {
+  isOpen: boolean
+  onClose: () => void
+  onAdd: (name: string, currencyId: CurrencyId, amount: number, durationDays?: number) => void
+}
+
+export function AddEventDialog({ isOpen, onClose, onAdd }: AddEventDialogProps) {
+  const [name, setName] = useState('')
+  const [currencyId, setCurrencyId] = useState<CurrencyId>(CurrencyId.Coins)
+  const [amountValue, setAmountValue] = useState('')
+  const [amountScale, setAmountScale] = useState('T')
+  const [durationDays, setDurationDays] = useState('')
+
+  const currencies = getAllCurrencyConfigs()
+  const selectedCurrency = currencies.find((c) => c.id === currencyId)!
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    const baseAmount = parseFloat(amountValue) || 0
+    const multiplier = SCALE_OPTIONS.find((s) => s.value === amountScale)?.multiplier || 1
+    const finalAmount = selectedCurrency.hasUnitSelector ? baseAmount * multiplier : baseAmount
+
+    if (name.trim() && finalAmount > 0) {
+      const duration = durationDays ? parseInt(durationDays, 10) : undefined
+      onAdd(name.trim(), currencyId, finalAmount, duration && duration > 0 ? duration : undefined)
+      handleClose()
+    }
+  }
+
+  const handleClose = () => {
+    setName('')
+    setCurrencyId(CurrencyId.Coins)
+    setAmountValue('')
+    setAmountScale('T')
+    setDurationDays('')
+    onClose()
+  }
+
+  const isValid = name.trim() !== '' && (parseFloat(amountValue) || 0) > 0
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add Spending Event</DialogTitle>
+          <DialogDescription>
+            Add a new upgrade, unlock, or other spending event to your plan.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit}>
+          <AddEventForm
+            name={name}
+            currencyId={currencyId}
+            amountValue={amountValue}
+            amountScale={amountScale}
+            durationDays={durationDays}
+            currencies={currencies}
+            selectedCurrency={selectedCurrency}
+            onNameChange={setName}
+            onCurrencyChange={setCurrencyId}
+            onAmountValueChange={setAmountValue}
+            onAmountScaleChange={setAmountScale}
+            onDurationChange={setDurationDays}
+          />
+
+          <DialogFooter className="mt-4">
+            <Button type="button" variant="outline" onClick={handleClose}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!isValid}>
+              Add Event
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/features/spending-planner/events/add-event-form.tsx
+++ b/src/features/spending-planner/events/add-event-form.tsx
@@ -1,0 +1,117 @@
+/**
+ * Add Event Form Component
+ *
+ * Form fields for adding a new spending event.
+ */
+
+import { Input } from '@/components/ui/input'
+import { Select } from '@/components/ui/select'
+import { FormControl } from '@/components/ui/form-field'
+import { SCALE_DEFINITIONS } from '@/shared/formatting/number-scale'
+import type { CurrencyId, CurrencyConfig } from '../types'
+
+/**
+ * Scale options for the amount selector.
+ * Derived from the shared SCALE_DEFINITIONS with an empty option for "no scale".
+ */
+export const SCALE_OPTIONS = [
+  { value: '', label: '--', multiplier: 1 },
+  ...SCALE_DEFINITIONS.map(({ suffix, multiplier }) => ({
+    value: suffix,
+    label: suffix,
+    multiplier,
+  })),
+] as const
+
+interface AddEventFormProps {
+  name: string
+  currencyId: CurrencyId
+  amountValue: string
+  amountScale: string
+  durationDays: string
+  currencies: CurrencyConfig[]
+  selectedCurrency: CurrencyConfig
+  onNameChange: (value: string) => void
+  onCurrencyChange: (value: CurrencyId) => void
+  onAmountValueChange: (value: string) => void
+  onAmountScaleChange: (value: string) => void
+  onDurationChange: (value: string) => void
+}
+
+export function AddEventForm({
+  name,
+  currencyId,
+  amountValue,
+  amountScale,
+  durationDays,
+  currencies,
+  selectedCurrency,
+  onNameChange,
+  onCurrencyChange,
+  onAmountValueChange,
+  onAmountScaleChange,
+  onDurationChange,
+}: AddEventFormProps) {
+  return (
+    <div className="space-y-4">
+      <FormControl label="Name" required layout="vertical">
+        <Input
+          value={name}
+          onChange={(e) => onNameChange(e.target.value)}
+          placeholder="e.g., Unlock Damage Mastery"
+        />
+      </FormControl>
+
+      <FormControl label="Currency" required layout="vertical">
+        <Select
+          value={currencyId}
+          onChange={(e) => onCurrencyChange(e.target.value as CurrencyId)}
+          width="full"
+        >
+          {currencies.map((currency) => (
+            <option key={currency.id} value={currency.id}>
+              {currency.displayName}
+            </option>
+          ))}
+        </Select>
+      </FormControl>
+
+      <FormControl label="Amount" required layout="vertical">
+        <div className="flex gap-2">
+          <Input
+            type="number"
+            value={amountValue}
+            onChange={(e) => onAmountValueChange(e.target.value)}
+            placeholder="0"
+            min={0}
+            className="flex-1"
+          />
+          {selectedCurrency.hasUnitSelector && (
+            <Select
+              value={amountScale}
+              onChange={(e) => onAmountScaleChange(e.target.value)}
+              width="sm"
+            >
+              {SCALE_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </Select>
+          )}
+        </div>
+      </FormControl>
+
+      <FormControl label="Duration (days)" layout="vertical">
+        <Input
+          type="number"
+          value={durationDays}
+          onChange={(e) => onDurationChange(e.target.value)}
+          placeholder="Optional - for labs"
+          min={0}
+          className="w-32"
+        />
+      </FormControl>
+    </div>
+  )
+}

--- a/src/features/spending-planner/events/edit-event-dialog.tsx
+++ b/src/features/spending-planner/events/edit-event-dialog.tsx
@@ -1,0 +1,125 @@
+/**
+ * Edit Event Dialog Component
+ *
+ * Dialog for editing existing spending events.
+ */
+
+import { useState, useEffect, useMemo } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogDescription,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { CurrencyId } from '../types'
+import type { SpendingEvent } from '../types'
+import { getAllCurrencyConfigs } from '../currencies/currency-config'
+import { AddEventForm } from './add-event-form'
+import { getDisplayValueAndScale, calculateFinalAmount, parseDurationDays } from './event-form-utils'
+
+interface SaveEventData {
+  eventId: string
+  name: string
+  currencyId: CurrencyId
+  amount: number
+  durationDays?: number
+}
+
+interface EditEventDialogProps {
+  event: SpendingEvent | null
+  isOpen: boolean
+  onClose: () => void
+  onSave: (data: SaveEventData) => void
+}
+
+export function EditEventDialog({ event, isOpen, onClose, onSave }: EditEventDialogProps) {
+  const [name, setName] = useState('')
+  const [currencyId, setCurrencyId] = useState<CurrencyId>(CurrencyId.Coins)
+  const [amountValue, setAmountValue] = useState('')
+  const [amountScale, setAmountScale] = useState('T')
+  const [durationDays, setDurationDays] = useState('')
+
+  const currencies = useMemo(() => getAllCurrencyConfigs(), [])
+  const selectedCurrency = currencies.find((c) => c.id === currencyId)!
+
+  // Populate form when event changes
+  useEffect(() => {
+    if (event) {
+      setName(event.name)
+      setCurrencyId(event.currencyId)
+
+      const config = currencies.find((c) => c.id === event.currencyId)
+      if (config?.hasUnitSelector) {
+        const { value, scale } = getDisplayValueAndScale(event.amount)
+        setAmountValue(value)
+        setAmountScale(scale)
+      } else {
+        setAmountValue(event.amount.toString())
+        setAmountScale('')
+      }
+
+      setDurationDays(event.durationDays?.toString() || '')
+    }
+  }, [event, currencies])
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!event) return
+
+    const finalAmount = calculateFinalAmount(amountValue, amountScale, selectedCurrency.hasUnitSelector)
+    if (!name.trim() || finalAmount <= 0) return
+
+    onSave({
+      eventId: event.id,
+      name: name.trim(),
+      currencyId,
+      amount: finalAmount,
+      durationDays: parseDurationDays(durationDays),
+    })
+    onClose()
+  }
+
+  const isValid = name.trim() !== '' && (parseFloat(amountValue) || 0) > 0
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Edit Spending Event</DialogTitle>
+          <DialogDescription>
+            Modify the details of this spending event.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit}>
+          <AddEventForm
+            name={name}
+            currencyId={currencyId}
+            amountValue={amountValue}
+            amountScale={amountScale}
+            durationDays={durationDays}
+            currencies={currencies}
+            selectedCurrency={selectedCurrency}
+            onNameChange={setName}
+            onCurrencyChange={setCurrencyId}
+            onAmountValueChange={setAmountValue}
+            onAmountScaleChange={setAmountScale}
+            onDurationChange={setDurationDays}
+          />
+
+          <DialogFooter className="mt-4">
+            <Button type="button" variant="outline" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!isValid}>
+              Save Changes
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/features/spending-planner/events/event-form-utils.ts
+++ b/src/features/spending-planner/events/event-form-utils.ts
@@ -1,0 +1,68 @@
+/**
+ * Event Form Utilities
+ *
+ * Pure functions for event form value conversion.
+ */
+
+import { SCALE_OPTIONS } from './add-event-form'
+
+interface DisplayValueAndScale {
+  value: string
+  scale: string
+}
+
+/**
+ * Convert a raw amount to a display value and scale suffix.
+ * Finds the largest scale that produces a clean value (no decimals when possible).
+ */
+export function getDisplayValueAndScale(amount: number): DisplayValueAndScale {
+  if (amount === 0) {
+    return { value: '0', scale: '' }
+  }
+
+  // Sort scales from largest to smallest (excluding the empty scale)
+  const sortedScales = [...SCALE_OPTIONS]
+    .filter((s) => s.multiplier > 1)
+    .sort((a, b) => b.multiplier - a.multiplier)
+
+  for (const scale of sortedScales) {
+    const value = amount / scale.multiplier
+    // Use this scale if the result is >= 1 and reasonably clean
+    if (value >= 1 && value < 10000) {
+      // Check if it's a clean number (at most 2 decimal places)
+      const rounded = Math.round(value * 100) / 100
+      if (Math.abs(rounded - value) < 0.001) {
+        return {
+          value: rounded.toString(),
+          scale: scale.value,
+        }
+      }
+    }
+  }
+
+  // Fall back to raw value with no scale
+  return { value: amount.toString(), scale: '' }
+}
+
+/**
+ * Calculate the final amount from form values.
+ */
+export function calculateFinalAmount(
+  amountValue: string,
+  amountScale: string,
+  hasUnitSelector: boolean
+): number {
+  const baseAmount = parseFloat(amountValue) || 0
+  const multiplier = SCALE_OPTIONS.find((s) => s.value === amountScale)?.multiplier || 1
+  return hasUnitSelector ? baseAmount * multiplier : baseAmount
+}
+
+/**
+ * Parse duration days from form input.
+ * Returns undefined for empty, zero, or invalid values.
+ */
+export function parseDurationDays(value: string): number | undefined {
+  if (!value) return undefined
+  const parsed = parseInt(value, 10)
+  return parsed > 0 ? parsed : undefined
+}

--- a/src/features/spending-planner/events/event-pill-actions.tsx
+++ b/src/features/spending-planner/events/event-pill-actions.tsx
@@ -1,0 +1,57 @@
+/**
+ * Event Pill Action Buttons
+ *
+ * Edit, clone, and remove action buttons for event pills.
+ */
+
+interface EventPillActionsProps {
+  eventName: string
+  onEdit: (e: React.MouseEvent) => void
+  onClone: (e: React.MouseEvent) => void
+  onRemove: (e: React.MouseEvent) => void
+}
+
+export function EventPillActions({
+  eventName,
+  onEdit,
+  onClone,
+  onRemove,
+}: EventPillActionsProps) {
+  return (
+    <div className="flex flex-col justify-center gap-0.5 px-1 border-l border-slate-600/30">
+      <button
+        type="button"
+        onClick={onEdit}
+        className="p-1 text-slate-500 hover:text-blue-400 transition-colors"
+        aria-label={`Edit ${eventName}`}
+        title="Edit"
+      >
+        <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+        </svg>
+      </button>
+      <button
+        type="button"
+        onClick={onClone}
+        className="p-1 text-slate-500 hover:text-green-400 transition-colors"
+        aria-label={`Clone ${eventName}`}
+        title="Clone"
+      >
+        <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+        </svg>
+      </button>
+      <button
+        type="button"
+        onClick={onRemove}
+        className="p-1 text-slate-500 hover:text-red-400 transition-colors"
+        aria-label={`Remove ${eventName}`}
+        title="Remove"
+      >
+        <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+        </svg>
+      </button>
+    </div>
+  )
+}

--- a/src/features/spending-planner/events/event-pill-handlers.ts
+++ b/src/features/spending-planner/events/event-pill-handlers.ts
@@ -1,0 +1,65 @@
+/**
+ * Event Pill Handlers
+ *
+ * Pure functions for creating event pill handlers.
+ */
+
+import type { SpendingEvent } from '../types'
+
+interface DragHandlers {
+  onDragStart: (e: React.DragEvent) => void
+  onDragEnter: (e: React.DragEvent) => void
+  onDragOver: (e: React.DragEvent) => void
+  onDrop: (e: React.DragEvent) => void
+}
+
+interface ActionHandlers {
+  onEdit: (e: React.MouseEvent) => void
+  onClone: (e: React.MouseEvent) => void
+  onRemove: (e: React.MouseEvent) => void
+}
+
+export function createEventDragHandlers(
+  index: number,
+  onDragStart: (index: number) => void,
+  onDragEnter: (index: number) => void
+): DragHandlers {
+  return {
+    onDragStart: (e: React.DragEvent) => {
+      e.dataTransfer.effectAllowed = 'move'
+      onDragStart(index)
+    },
+    onDragEnter: (e: React.DragEvent) => {
+      e.preventDefault()
+      onDragEnter(index)
+    },
+    onDragOver: (e: React.DragEvent) => {
+      e.preventDefault()
+    },
+    onDrop: (e: React.DragEvent) => {
+      e.preventDefault()
+    },
+  }
+}
+
+export function createEventActionHandlers(
+  event: SpendingEvent,
+  onEdit: (event: SpendingEvent) => void,
+  onClone: (eventId: string) => void,
+  onRemove: (eventId: string) => void
+): ActionHandlers {
+  return {
+    onEdit: (e: React.MouseEvent) => {
+      e.stopPropagation()
+      onEdit(event)
+    },
+    onClone: (e: React.MouseEvent) => {
+      e.stopPropagation()
+      onClone(event.id)
+    },
+    onRemove: (e: React.MouseEvent) => {
+      e.stopPropagation()
+      onRemove(event.id)
+    },
+  }
+}

--- a/src/features/spending-planner/events/event-pill.tsx
+++ b/src/features/spending-planner/events/event-pill.tsx
@@ -1,0 +1,91 @@
+/**
+ * Event Pill Component
+ *
+ * Draggable pill displaying a spending event in the queue.
+ */
+
+import { cn } from '@/shared/lib/utils'
+import { formatLargeNumber } from '@/shared/formatting/number-scale'
+import type { SpendingEvent } from '../types'
+import { getCurrencyConfig } from '../currencies/currency-config'
+import { EventPillActions } from './event-pill-actions'
+import { createEventDragHandlers, createEventActionHandlers } from './event-pill-handlers'
+
+interface EventPillProps {
+  event: SpendingEvent
+  index: number
+  isDragging: boolean
+  isDraggedOver: boolean
+  onDragStart: (index: number) => void
+  onDragEnter: (index: number) => void
+  onDragEnd: () => void
+  onRemove: (eventId: string) => void
+  onEdit: (event: SpendingEvent) => void
+  onClone: (eventId: string) => void
+}
+
+export function EventPill({
+  event,
+  index,
+  isDragging,
+  isDraggedOver,
+  onDragStart,
+  onDragEnter,
+  onDragEnd,
+  onRemove,
+  onEdit,
+  onClone,
+}: EventPillProps) {
+  const config = getCurrencyConfig(event.currencyId)
+  const formattedAmount = formatLargeNumber(event.amount)
+
+  const dragHandlers = createEventDragHandlers(index, onDragStart, onDragEnter)
+  const actionHandlers = createEventActionHandlers(event, onEdit, onClone, onRemove)
+
+  return (
+    <div
+      draggable
+      onDragStart={dragHandlers.onDragStart}
+      onDragEnter={dragHandlers.onDragEnter}
+      onDragOver={dragHandlers.onDragOver}
+      onDrop={dragHandlers.onDrop}
+      onDragEnd={onDragEnd}
+      className={cn(
+        'relative flex rounded-lg border',
+        'bg-slate-800/50 border-slate-600/50',
+        'hover:bg-slate-700/50 hover:border-slate-500/50',
+        'transition-all duration-150',
+        'min-w-[160px] max-w-[200px]',
+        isDragging && 'opacity-50',
+        isDraggedOver && 'border-orange-500/70 bg-slate-700/70'
+      )}
+    >
+      {/* Drag handle on left */}
+      <div className="flex items-center justify-center px-1.5 border-r border-slate-600/30 cursor-grab active:cursor-grabbing text-slate-500 hover:text-slate-400">
+        <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+          <path d="M7 2a2 2 0 1 0 .001 4.001A2 2 0 0 0 7 2zm0 6a2 2 0 1 0 .001 4.001A2 2 0 0 0 7 8zm0 6a2 2 0 1 0 .001 4.001A2 2 0 0 0 7 14zm6-8a2 2 0 1 0-.001-4.001A2 2 0 0 0 13 6zm0 2a2 2 0 1 0 .001 4.001A2 2 0 0 0 13 8zm0 6a2 2 0 1 0 .001 4.001A2 2 0 0 0 13 14z" />
+        </svg>
+      </div>
+
+      {/* Content area */}
+      <div className="flex-1 flex flex-col py-2 px-2 min-w-0">
+        <span className="text-sm text-slate-200 font-medium truncate">{event.name}</span>
+        <span className={cn('text-xs mt-0.5', config.color)}>
+          -{formattedAmount} {config.abbreviation}
+        </span>
+        {event.durationDays && (
+          <span className="text-xs text-slate-400 mt-0.5">
+            {event.durationDays} day{event.durationDays !== 1 ? 's' : ''}
+          </span>
+        )}
+      </div>
+
+      <EventPillActions
+        eventName={event.name}
+        onEdit={actionHandlers.onEdit}
+        onClone={actionHandlers.onClone}
+        onRemove={actionHandlers.onRemove}
+      />
+    </div>
+  )
+}

--- a/src/features/spending-planner/events/event-queue-panel.tsx
+++ b/src/features/spending-planner/events/event-queue-panel.tsx
@@ -1,0 +1,131 @@
+/**
+ * Event Queue Panel Component
+ *
+ * Panel displaying the draggable queue of spending events.
+ */
+
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { EventPill } from './event-pill'
+import { AddEventDialog } from './add-event-dialog'
+import { EditEventDialog } from './edit-event-dialog'
+import type { SpendingEvent, CurrencyId } from '../types'
+
+export interface AddEventData {
+  name: string
+  currencyId: CurrencyId
+  amount: number
+  durationDays?: number
+}
+
+export interface EditEventData extends AddEventData {
+  eventId: string
+}
+
+interface EventQueuePanelProps {
+  events: SpendingEvent[]
+  draggedIndex: number | null
+  draggedOverIndex: number | null
+  onDragStart: (index: number) => void
+  onDragEnter: (index: number) => void
+  onDragEnd: () => void
+  onAddEvent: (data: AddEventData) => void
+  onRemoveEvent: (eventId: string) => void
+  onEditEvent: (data: EditEventData) => void
+  onCloneEvent: (eventId: string) => void
+}
+
+export function EventQueuePanel({
+  events,
+  draggedIndex,
+  draggedOverIndex,
+  onDragStart,
+  onDragEnter,
+  onDragEnd,
+  onAddEvent,
+  onRemoveEvent,
+  onEditEvent,
+  onCloneEvent,
+}: EventQueuePanelProps) {
+  const [isAddDialogOpen, setIsAddDialogOpen] = useState(false)
+  const [editingEvent, setEditingEvent] = useState<SpendingEvent | null>(null)
+
+  const handleEditClick = (event: SpendingEvent) => {
+    setEditingEvent(event)
+  }
+
+  const handleEditSave = (data: EditEventData) => {
+    onEditEvent(data)
+    setEditingEvent(null)
+  }
+
+  const handleAddEvent = (name: string, currencyId: CurrencyId, amount: number, durationDays?: number) => {
+    onAddEvent({ name, currencyId, amount, durationDays })
+  }
+
+  return (
+    <div className="bg-slate-800/30 rounded-lg border border-slate-700/50">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-slate-700/50">
+        <h2 className="text-sm font-semibold text-slate-200">Event Queue</h2>
+        <Button
+          size="compact"
+          variant="outline"
+          onClick={() => setIsAddDialogOpen(true)}
+        >
+          + Add Event
+        </Button>
+      </div>
+
+      {/* Events */}
+      <div className="p-4">
+        {events.length === 0 ? (
+          <div className="text-center py-8 text-slate-400">
+            <p className="text-sm">No events planned yet.</p>
+            <p className="text-xs mt-1">Click &ldquo;+ Add Event&rdquo; to start planning.</p>
+          </div>
+        ) : (
+          <div className="flex flex-wrap gap-3">
+            {events.map((event, index) => (
+              <EventPill
+                key={event.id}
+                event={event}
+                index={index}
+                isDragging={draggedIndex === index}
+                isDraggedOver={draggedOverIndex === index && draggedIndex !== index}
+                onDragStart={onDragStart}
+                onDragEnter={onDragEnter}
+                onDragEnd={onDragEnd}
+                onRemove={onRemoveEvent}
+                onEdit={handleEditClick}
+                onClone={onCloneEvent}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Hint */}
+      {events.length > 0 && (
+        <div className="px-4 pb-3 text-xs text-slate-500">
+          Drag to reorder priorities. Events trigger when balance is sufficient.
+        </div>
+      )}
+
+      {/* Add Event Dialog */}
+      <AddEventDialog
+        isOpen={isAddDialogOpen}
+        onClose={() => setIsAddDialogOpen(false)}
+        onAdd={handleAddEvent}
+      />
+
+      {/* Edit Event Dialog */}
+      <EditEventDialog
+        event={editingEvent}
+        isOpen={editingEvent !== null}
+        onClose={() => setEditingEvent(null)}
+        onSave={handleEditSave}
+      />
+    </div>
+  )
+}

--- a/src/features/spending-planner/events/event-reorder.test.ts
+++ b/src/features/spending-planner/events/event-reorder.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect } from 'vitest'
+import {
+  reorderEvents,
+  addEvent,
+  removeEvent,
+  updateEvent,
+  sortByPriority,
+  generateEventId,
+} from './event-reorder'
+import { CurrencyId } from '../types'
+import type { SpendingEvent } from '../types'
+
+describe('event-reorder', () => {
+  const createTestEvents = (): SpendingEvent[] => [
+    { id: '1', name: 'Event A', currencyId: CurrencyId.Coins, amount: 100, priority: 0 },
+    { id: '2', name: 'Event B', currencyId: CurrencyId.Stones, amount: 200, priority: 1 },
+    { id: '3', name: 'Event C', currencyId: CurrencyId.Coins, amount: 300, priority: 2 },
+  ]
+
+  describe('reorderEvents', () => {
+    it('should move event from front to back', () => {
+      const events = createTestEvents()
+      const result = reorderEvents(events, 0, 2)
+
+      expect(result[0].id).toBe('2')
+      expect(result[1].id).toBe('3')
+      expect(result[2].id).toBe('1')
+    })
+
+    it('should move event from back to front', () => {
+      const events = createTestEvents()
+      const result = reorderEvents(events, 2, 0)
+
+      expect(result[0].id).toBe('3')
+      expect(result[1].id).toBe('1')
+      expect(result[2].id).toBe('2')
+    })
+
+    it('should move event to middle', () => {
+      const events = createTestEvents()
+      const result = reorderEvents(events, 0, 1)
+
+      expect(result[0].id).toBe('2')
+      expect(result[1].id).toBe('1')
+      expect(result[2].id).toBe('3')
+    })
+
+    it('should update priorities after reorder', () => {
+      const events = createTestEvents()
+      const result = reorderEvents(events, 2, 0)
+
+      expect(result[0].priority).toBe(0)
+      expect(result[1].priority).toBe(1)
+      expect(result[2].priority).toBe(2)
+    })
+
+    it('should return same array if indices are equal', () => {
+      const events = createTestEvents()
+      const result = reorderEvents(events, 1, 1)
+
+      expect(result).toEqual(events)
+    })
+
+    it('should return same array if fromIndex is out of bounds', () => {
+      const events = createTestEvents()
+      const result = reorderEvents(events, -1, 1)
+
+      expect(result).toEqual(events)
+    })
+
+    it('should return same array if toIndex is out of bounds', () => {
+      const events = createTestEvents()
+      const result = reorderEvents(events, 0, 10)
+
+      expect(result).toEqual(events)
+    })
+
+    it('should not mutate original array', () => {
+      const events = createTestEvents()
+      const originalOrder = events.map((e) => e.id)
+      reorderEvents(events, 0, 2)
+
+      expect(events.map((e) => e.id)).toEqual(originalOrder)
+    })
+  })
+
+  describe('addEvent', () => {
+    it('should add event with correct priority', () => {
+      const events = createTestEvents()
+      const newEvent = { id: '4', name: 'Event D', currencyId: CurrencyId.Coins, amount: 400 }
+      const result = addEvent(events, newEvent)
+
+      expect(result).toHaveLength(4)
+      expect(result[3].id).toBe('4')
+      expect(result[3].priority).toBe(3)
+    })
+
+    it('should handle empty array', () => {
+      const events: SpendingEvent[] = []
+      const newEvent = { id: '1', name: 'Event A', currencyId: CurrencyId.Coins, amount: 100 }
+      const result = addEvent(events, newEvent)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].priority).toBe(0)
+    })
+
+    it('should not mutate original array', () => {
+      const events = createTestEvents()
+      const newEvent = { id: '4', name: 'Event D', currencyId: CurrencyId.Coins, amount: 400 }
+      addEvent(events, newEvent)
+
+      expect(events).toHaveLength(3)
+    })
+  })
+
+  describe('removeEvent', () => {
+    it('should remove event by ID', () => {
+      const events = createTestEvents()
+      const result = removeEvent(events, '2')
+
+      expect(result).toHaveLength(2)
+      expect(result.find((e) => e.id === '2')).toBeUndefined()
+    })
+
+    it('should update priorities after removal', () => {
+      const events = createTestEvents()
+      const result = removeEvent(events, '1')
+
+      expect(result[0].priority).toBe(0)
+      expect(result[1].priority).toBe(1)
+    })
+
+    it('should handle non-existent ID', () => {
+      const events = createTestEvents()
+      const result = removeEvent(events, 'non-existent')
+
+      expect(result).toHaveLength(3)
+    })
+
+    it('should not mutate original array', () => {
+      const events = createTestEvents()
+      removeEvent(events, '2')
+
+      expect(events).toHaveLength(3)
+    })
+  })
+
+  describe('updateEvent', () => {
+    it('should update event properties', () => {
+      const events = createTestEvents()
+      const result = updateEvent(events, '2', { name: 'Updated Name', amount: 999 })
+
+      expect(result[1].name).toBe('Updated Name')
+      expect(result[1].amount).toBe(999)
+    })
+
+    it('should preserve other properties', () => {
+      const events = createTestEvents()
+      const result = updateEvent(events, '2', { name: 'Updated Name' })
+
+      expect(result[1].amount).toBe(200)
+      expect(result[1].currencyId).toBe(CurrencyId.Stones)
+      expect(result[1].priority).toBe(1)
+    })
+
+    it('should not change other events', () => {
+      const events = createTestEvents()
+      const result = updateEvent(events, '2', { name: 'Updated Name' })
+
+      expect(result[0]).toEqual(events[0])
+      expect(result[2]).toEqual(events[2])
+    })
+
+    it('should handle non-existent ID', () => {
+      const events = createTestEvents()
+      const result = updateEvent(events, 'non-existent', { name: 'Test' })
+
+      expect(result).toEqual(events)
+    })
+  })
+
+  describe('sortByPriority', () => {
+    it('should sort events by priority', () => {
+      const events: SpendingEvent[] = [
+        { id: '3', name: 'Event C', currencyId: CurrencyId.Coins, amount: 300, priority: 2 },
+        { id: '1', name: 'Event A', currencyId: CurrencyId.Coins, amount: 100, priority: 0 },
+        { id: '2', name: 'Event B', currencyId: CurrencyId.Stones, amount: 200, priority: 1 },
+      ]
+      const result = sortByPriority(events)
+
+      expect(result[0].id).toBe('1')
+      expect(result[1].id).toBe('2')
+      expect(result[2].id).toBe('3')
+    })
+
+    it('should not mutate original array', () => {
+      const events: SpendingEvent[] = [
+        { id: '3', name: 'Event C', currencyId: CurrencyId.Coins, amount: 300, priority: 2 },
+        { id: '1', name: 'Event A', currencyId: CurrencyId.Coins, amount: 100, priority: 0 },
+      ]
+      sortByPriority(events)
+
+      expect(events[0].id).toBe('3')
+    })
+  })
+
+  describe('generateEventId', () => {
+    it('should generate unique IDs', () => {
+      const ids = new Set<string>()
+      for (let i = 0; i < 100; i++) {
+        ids.add(generateEventId())
+      }
+      expect(ids.size).toBe(100)
+    })
+
+    it('should start with event- prefix', () => {
+      const id = generateEventId()
+      expect(id.startsWith('event-')).toBe(true)
+    })
+  })
+})

--- a/src/features/spending-planner/events/event-reorder.ts
+++ b/src/features/spending-planner/events/event-reorder.ts
@@ -1,0 +1,132 @@
+/**
+ * Event Reorder Logic
+ *
+ * Pure functions for reordering spending events.
+ */
+
+import type { SpendingEvent } from '../types'
+
+/**
+ * Reorder events by moving an item from one index to another.
+ * Also updates priority values to match the new order.
+ */
+export function reorderEvents(
+  events: SpendingEvent[],
+  fromIndex: number,
+  toIndex: number
+): SpendingEvent[] {
+  // Validate indices
+  if (
+    fromIndex < 0 ||
+    fromIndex >= events.length ||
+    toIndex < 0 ||
+    toIndex >= events.length
+  ) {
+    return events
+  }
+
+  // No-op if indices are the same
+  if (fromIndex === toIndex) {
+    return events
+  }
+
+  // Create new array with reordered items
+  const result = [...events]
+  const [removed] = result.splice(fromIndex, 1)
+  result.splice(toIndex, 0, removed)
+
+  // Update priorities to match new order
+  return result.map((event, index) => ({
+    ...event,
+    priority: index,
+  }))
+}
+
+/**
+ * Add a new event to the queue at the end.
+ */
+export function addEvent(
+  events: SpendingEvent[],
+  newEvent: Omit<SpendingEvent, 'priority'>
+): SpendingEvent[] {
+  const eventWithPriority: SpendingEvent = {
+    ...newEvent,
+    priority: events.length,
+  }
+  return [...events, eventWithPriority]
+}
+
+/**
+ * Remove an event from the queue by ID.
+ * Updates priorities of remaining events.
+ */
+export function removeEvent(
+  events: SpendingEvent[],
+  eventId: string
+): SpendingEvent[] {
+  const filtered = events.filter((e) => e.id !== eventId)
+  // Re-index priorities
+  return filtered.map((event, index) => ({
+    ...event,
+    priority: index,
+  }))
+}
+
+/**
+ * Update an existing event.
+ */
+export function updateEvent(
+  events: SpendingEvent[],
+  eventId: string,
+  updates: Partial<Omit<SpendingEvent, 'id' | 'priority'>>
+): SpendingEvent[] {
+  return events.map((event) =>
+    event.id === eventId ? { ...event, ...updates } : event
+  )
+}
+
+/**
+ * Sort events by priority.
+ */
+export function sortByPriority(events: SpendingEvent[]): SpendingEvent[] {
+  return [...events].sort((a, b) => a.priority - b.priority)
+}
+
+/**
+ * Clone an existing event with a new ID.
+ * The cloned event is inserted right after the original.
+ */
+export function cloneEvent(
+  events: SpendingEvent[],
+  eventId: string
+): SpendingEvent[] {
+  const sourceIndex = events.findIndex((e) => e.id === eventId)
+  if (sourceIndex === -1) return events
+
+  const source = events[sourceIndex]
+  const cloned: SpendingEvent = {
+    ...source,
+    id: generateEventId(),
+    name: `${source.name} (copy)`,
+    priority: source.priority + 1,
+  }
+
+  // Insert after the source and re-index priorities
+  const result = [
+    ...events.slice(0, sourceIndex + 1),
+    cloned,
+    ...events.slice(sourceIndex + 1),
+  ]
+
+  return result.map((event, index) => ({
+    ...event,
+    priority: index,
+  }))
+}
+
+/**
+ * Generate a unique ID for a new event.
+ */
+export function generateEventId(): string {
+  return `event-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`
+}

--- a/src/features/spending-planner/events/use-event-queue.ts
+++ b/src/features/spending-planner/events/use-event-queue.ts
@@ -1,0 +1,136 @@
+/**
+ * Event Queue Hook
+ *
+ * Manages event queue state including drag-and-drop reordering.
+ */
+
+import { useState, useCallback } from 'react'
+import type { SpendingEvent, CurrencyId } from '../types'
+import {
+  reorderEvents,
+  addEvent as addEventFn,
+  removeEvent as removeEventFn,
+  updateEvent as updateEventFn,
+  cloneEvent as cloneEventFn,
+  generateEventId,
+} from './event-reorder'
+
+/** Input for adding a new event */
+interface AddEventInput {
+  name: string
+  currencyId: CurrencyId
+  amount: number
+  durationDays?: number
+}
+
+/** Input for updating an event */
+interface UpdateEventInput {
+  name: string
+  currencyId: CurrencyId
+  amount: number
+  durationDays?: number
+}
+
+interface UseEventQueueReturn {
+  /** Current drag state */
+  draggedIndex: number | null
+  draggedOverIndex: number | null
+  isDragging: boolean
+  /** Drag handlers */
+  handleDragStart: (index: number) => void
+  handleDragEnter: (index: number) => void
+  handleDragEnd: () => void
+  handleDrop: (events: SpendingEvent[]) => SpendingEvent[]
+  /** Event operations */
+  addEvent: (events: SpendingEvent[], input: AddEventInput) => SpendingEvent[]
+  removeEvent: (events: SpendingEvent[], eventId: string) => SpendingEvent[]
+  updateEvent: (events: SpendingEvent[], eventId: string, input: UpdateEventInput) => SpendingEvent[]
+  cloneEvent: (events: SpendingEvent[], eventId: string) => SpendingEvent[]
+}
+
+/**
+ * Hook for managing event queue with drag-and-drop reordering.
+ */
+export function useEventQueue(): UseEventQueueReturn {
+  const [draggedIndex, setDraggedIndex] = useState<number | null>(null)
+  const [draggedOverIndex, setDraggedOverIndex] = useState<number | null>(null)
+
+  const handleDragStart = useCallback((index: number) => {
+    setDraggedIndex(index)
+  }, [])
+
+  const handleDragEnter = useCallback((index: number) => {
+    setDraggedOverIndex(index)
+  }, [])
+
+  const handleDragEnd = useCallback(() => {
+    setDraggedIndex(null)
+    setDraggedOverIndex(null)
+  }, [])
+
+  const handleDrop = useCallback(
+    (events: SpendingEvent[]): SpendingEvent[] => {
+      if (draggedIndex === null || draggedOverIndex === null) {
+        return events
+      }
+      return reorderEvents(events, draggedIndex, draggedOverIndex)
+    },
+    [draggedIndex, draggedOverIndex]
+  )
+
+  const addEvent = useCallback(
+    (events: SpendingEvent[], input: AddEventInput): SpendingEvent[] => {
+      const newEvent = {
+        id: generateEventId(),
+        name: input.name,
+        currencyId: input.currencyId,
+        amount: input.amount,
+        durationDays: input.durationDays,
+      }
+      return addEventFn(events, newEvent)
+    },
+    []
+  )
+
+  const removeEvent = useCallback(
+    (events: SpendingEvent[], eventId: string): SpendingEvent[] => {
+      return removeEventFn(events, eventId)
+    },
+    []
+  )
+
+  const updateEvent = useCallback(
+    (events: SpendingEvent[], eventId: string, input: UpdateEventInput): SpendingEvent[] => {
+      return updateEventFn(events, eventId, {
+        name: input.name,
+        currencyId: input.currencyId,
+        amount: input.amount,
+        durationDays: input.durationDays,
+      })
+    },
+    []
+  )
+
+  const cloneEvent = useCallback(
+    (events: SpendingEvent[], eventId: string): SpendingEvent[] => {
+      return cloneEventFn(events, eventId)
+    },
+    []
+  )
+
+  const isDragging = draggedIndex !== null
+
+  return {
+    draggedIndex,
+    draggedOverIndex,
+    isDragging,
+    handleDragStart,
+    handleDragEnter,
+    handleDragEnd,
+    handleDrop,
+    addEvent,
+    removeEvent,
+    updateEvent,
+    cloneEvent,
+  }
+}

--- a/src/features/spending-planner/income/currency-income-row.tsx
+++ b/src/features/spending-planner/income/currency-income-row.tsx
@@ -1,0 +1,111 @@
+/**
+ * Currency Income Row Component
+ *
+ * Input fields for a single currency's income configuration.
+ * Uses a consistent vertical layout within each currency section.
+ */
+
+import { useEffect, useState } from 'react'
+import { Input } from '@/components/ui/input'
+import { CurrencyId } from '../types'
+import type { CurrencyIncome, StoneIncomeBreakdown } from '../types'
+import { getCurrencyConfig } from '../currencies/currency-config'
+import { StoneIncomeBreakdown as StoneBreakdownComponent } from './stone-income-breakdown'
+import { CurrencyInputField } from './currency-input-field'
+import { getBestScaleForValue } from './scale-detection'
+
+interface CurrencyIncomeRowProps {
+  income: CurrencyIncome
+  stoneBreakdown?: StoneIncomeBreakdown
+  onBalanceChange: (value: number) => void
+  onWeeklyIncomeChange: (value: number) => void
+  onGrowthRateChange: (value: number) => void
+  onStoneBreakdownChange?: (field: keyof StoneIncomeBreakdown, value: number) => void
+}
+
+export function CurrencyIncomeRow({
+  income,
+  stoneBreakdown,
+  onBalanceChange,
+  onWeeklyIncomeChange,
+  onGrowthRateChange,
+  onStoneBreakdownChange,
+}: CurrencyIncomeRowProps) {
+  const config = getCurrencyConfig(income.currencyId)
+  const isStones = income.currencyId === CurrencyId.Stones
+
+  const [balanceScale, setBalanceScale] = useState(() =>
+    getBestScaleForValue(income.currentBalance)
+  )
+  const [incomeScale, setIncomeScale] = useState(() =>
+    getBestScaleForValue(income.weeklyIncome)
+  )
+
+  // Sync scale when value changes externally (e.g., loading saved data)
+  useEffect(() => {
+    setBalanceScale(getBestScaleForValue(income.currentBalance))
+  }, [income.currentBalance])
+
+  useEffect(() => {
+    setIncomeScale(getBestScaleForValue(income.weeklyIncome))
+  }, [income.weeklyIncome])
+
+  const handleGrowthChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onGrowthRateChange(parseFloat(e.target.value) || 0)
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Main income fields in a consistent grid */}
+      <div className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-3 items-center">
+        {/* Balance row */}
+        <span className="text-xs text-slate-400">Balance</span>
+        <CurrencyInputField
+          value={income.currentBalance}
+          scale={balanceScale}
+          hasUnitSelector={config.hasUnitSelector}
+          onChange={onBalanceChange}
+          onScaleChange={setBalanceScale}
+        />
+
+        {/* Weekly Income row - for non-stones currencies */}
+        {!isStones && (
+          <>
+            <span className="text-xs text-slate-400">Weekly</span>
+            <CurrencyInputField
+              value={income.weeklyIncome}
+              scale={incomeScale}
+              hasUnitSelector={config.hasUnitSelector}
+              onChange={onWeeklyIncomeChange}
+              onScaleChange={setIncomeScale}
+            />
+          </>
+        )}
+
+        {/* Growth rate row */}
+        <span className="text-xs text-slate-400">Growth</span>
+        <div className="flex items-center gap-2">
+          <Input
+            type="number"
+            value={income.growthRatePercent || ''}
+            onChange={handleGrowthChange}
+            className="w-20 h-8 text-right text-sm bg-slate-800/50"
+            placeholder="0"
+            min={-100}
+            max={1000}
+          />
+          <span className="text-xs text-slate-500">% / week</span>
+        </div>
+      </div>
+
+      {/* Stone breakdown - shown only for stones, visually connected to Weekly */}
+      {isStones && stoneBreakdown && onStoneBreakdownChange && (
+        <StoneBreakdownComponent
+          breakdown={stoneBreakdown}
+          weeklyTotal={income.weeklyIncome}
+          onUpdate={onStoneBreakdownChange}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/features/spending-planner/income/currency-input-field.tsx
+++ b/src/features/spending-planner/income/currency-input-field.tsx
@@ -1,0 +1,86 @@
+/**
+ * Currency Input Field Component
+ *
+ * Reusable input field with optional scale selector for currency values.
+ * Used within a labeled grid layout - does not render its own label.
+ */
+
+import { Input } from '@/components/ui/input'
+import { Select } from '@/components/ui/select'
+import { formatLargeNumber, parseShorthandNumber } from '@/shared/formatting/number-scale'
+import { SCALE_OPTIONS } from './scale-options'
+
+
+
+interface CurrencyInputFieldProps {
+  value: number
+  scale: string
+  hasUnitSelector: boolean
+  onChange: (value: number) => void
+  onScaleChange: (scale: string) => void
+  readOnly?: boolean
+}
+
+export function CurrencyInputField({
+  value,
+  scale,
+  hasUnitSelector,
+  onChange,
+  onScaleChange,
+  readOnly = false,
+}: CurrencyInputFieldProps) {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const rawValue = e.target.value
+    if (hasUnitSelector && scale) {
+      const multiplier = SCALE_OPTIONS.find((s) => s.value === scale)?.multiplier || 1
+      const numValue = parseFloat(rawValue) || 0
+      onChange(numValue * multiplier)
+    } else {
+      const parsed = parseShorthandNumber(rawValue)
+      onChange(parsed)
+    }
+  }
+
+  const handleScaleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    onScaleChange(e.target.value)
+  }
+
+  const displayValue = hasUnitSelector && scale
+    ? (value / (SCALE_OPTIONS.find((s) => s.value === scale)?.multiplier || 1)).toString()
+    : formatLargeNumber(value)
+
+  if (readOnly) {
+    return (
+      <span className="h-8 flex items-center justify-end text-sm text-slate-300 bg-slate-800/30 rounded px-3 border border-slate-600/50 min-w-[6rem]">
+        {value || 0}
+      </span>
+    )
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <Input
+        type="text"
+        value={displayValue === '0' ? '' : displayValue}
+        onChange={handleChange}
+        className="w-24 h-8 text-right text-sm bg-slate-800/50"
+        placeholder="0"
+      />
+      {hasUnitSelector && (
+        <Select
+          value={scale}
+          onChange={handleScaleChange}
+          size="compact"
+          width="sm"
+          className="w-16"
+        >
+          {SCALE_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </Select>
+      )}
+    </div>
+  )
+}

--- a/src/features/spending-planner/income/income-panel.tsx
+++ b/src/features/spending-planner/income/income-panel.tsx
@@ -1,0 +1,89 @@
+/**
+ * Income Panel Component
+ *
+ * Collapsible card for configuring income across all currencies.
+ * Uses card-based sections for clear visual grouping of each currency.
+ */
+
+import { CollapsibleCard } from '@/components/ui/collapsible-card'
+import { CurrencyIncomeRow } from './currency-income-row'
+import { CurrencyId } from '../types'
+import type { CurrencyIncome, StoneIncomeBreakdown } from '../types'
+import { CURRENCY_ORDER, getCurrencyConfig } from '../currencies/currency-config'
+
+interface IncomePanelProps {
+  incomes: CurrencyIncome[]
+  stoneBreakdown: StoneIncomeBreakdown
+  isCollapsed: boolean
+  onToggleCollapse: () => void
+  onBalanceChange: (currencyId: CurrencyId, value: number) => void
+  onWeeklyIncomeChange: (currencyId: CurrencyId, value: number) => void
+  onGrowthRateChange: (currencyId: CurrencyId, value: number) => void
+  onStoneBreakdownChange: (field: keyof StoneIncomeBreakdown, value: number) => void
+}
+
+export function IncomePanel({
+  incomes,
+  stoneBreakdown,
+  isCollapsed,
+  onToggleCollapse,
+  onBalanceChange,
+  onWeeklyIncomeChange,
+  onGrowthRateChange,
+  onStoneBreakdownChange,
+}: IncomePanelProps) {
+  // Sort incomes by currency order
+  const sortedIncomes = CURRENCY_ORDER.map((id) =>
+    incomes.find((i) => i.currencyId === id)
+  ).filter((i): i is CurrencyIncome => i !== undefined)
+
+  return (
+    <CollapsibleCard
+      title="Income Configuration"
+      isExpanded={!isCollapsed}
+      onToggle={onToggleCollapse}
+    >
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        {sortedIncomes.map((income) => {
+          const config = getCurrencyConfig(income.currencyId)
+          const isStones = income.currencyId === CurrencyId.Stones
+
+          return (
+            <CurrencySection
+              key={income.currencyId}
+              title={config.displayName}
+              colorClass={config.color}
+            >
+              <CurrencyIncomeRow
+                income={income}
+                stoneBreakdown={isStones ? stoneBreakdown : undefined}
+                onBalanceChange={(value) => onBalanceChange(income.currencyId, value)}
+                onWeeklyIncomeChange={(value) => onWeeklyIncomeChange(income.currencyId, value)}
+                onGrowthRateChange={(value) => onGrowthRateChange(income.currencyId, value)}
+                onStoneBreakdownChange={isStones ? onStoneBreakdownChange : undefined}
+              />
+            </CurrencySection>
+          )
+        })}
+      </div>
+    </CollapsibleCard>
+  )
+}
+
+/**
+ * Visual grouping wrapper for each currency's configuration.
+ */
+interface CurrencySectionProps {
+  title: string
+  colorClass: string
+  children: React.ReactNode
+}
+
+function CurrencySection({ title, colorClass, children }: CurrencySectionProps) {
+  return (
+    <div className="bg-slate-900/40 rounded-lg border border-slate-700/30 p-4">
+      <h3 className={`text-sm font-semibold ${colorClass} mb-3`}>{title}</h3>
+      {children}
+    </div>
+  )
+}

--- a/src/features/spending-planner/income/income-validation.test.ts
+++ b/src/features/spending-planner/income/income-validation.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect } from 'vitest'
+import {
+  validateCurrencyIncome,
+  validateStoneBreakdown,
+  clampNumber,
+  ensureNonNegative,
+  clampGrowthRate,
+} from './income-validation'
+import { CurrencyId } from '../types'
+import type { CurrencyIncome, StoneIncomeBreakdown } from '../types'
+
+describe('income-validation', () => {
+  describe('validateCurrencyIncome', () => {
+    it('should accept valid income', () => {
+      const income: CurrencyIncome = {
+        currencyId: CurrencyId.Coins,
+        currentBalance: 1000,
+        weeklyIncome: 500,
+        growthRatePercent: 5,
+      }
+      const result = validateCurrencyIncome(income)
+      expect(result.isValid).toBe(true)
+      expect(result.errors).toHaveLength(0)
+    })
+
+    it('should accept zero values', () => {
+      const income: CurrencyIncome = {
+        currencyId: CurrencyId.Stones,
+        currentBalance: 0,
+        weeklyIncome: 0,
+        growthRatePercent: 0,
+      }
+      const result = validateCurrencyIncome(income)
+      expect(result.isValid).toBe(true)
+    })
+
+    it('should reject negative balance', () => {
+      const income: CurrencyIncome = {
+        currencyId: CurrencyId.Coins,
+        currentBalance: -100,
+        weeklyIncome: 500,
+        growthRatePercent: 5,
+      }
+      const result = validateCurrencyIncome(income)
+      expect(result.isValid).toBe(false)
+      expect(result.errors).toContain('Current balance cannot be negative')
+    })
+
+    it('should reject negative income', () => {
+      const income: CurrencyIncome = {
+        currencyId: CurrencyId.Coins,
+        currentBalance: 100,
+        weeklyIncome: -500,
+        growthRatePercent: 5,
+      }
+      const result = validateCurrencyIncome(income)
+      expect(result.isValid).toBe(false)
+      expect(result.errors).toContain('Weekly income cannot be negative')
+    })
+
+    it('should reject growth rate below -100%', () => {
+      const income: CurrencyIncome = {
+        currencyId: CurrencyId.Coins,
+        currentBalance: 100,
+        weeklyIncome: 500,
+        growthRatePercent: -150,
+      }
+      const result = validateCurrencyIncome(income)
+      expect(result.isValid).toBe(false)
+      expect(result.errors).toContain('Growth rate cannot be less than -100%')
+    })
+
+    it('should reject growth rate above 1000%', () => {
+      const income: CurrencyIncome = {
+        currencyId: CurrencyId.Coins,
+        currentBalance: 100,
+        weeklyIncome: 500,
+        growthRatePercent: 1500,
+      }
+      const result = validateCurrencyIncome(income)
+      expect(result.isValid).toBe(false)
+      expect(result.errors).toContain('Growth rate cannot exceed 1000%')
+    })
+
+    it('should accept -100% growth rate', () => {
+      const income: CurrencyIncome = {
+        currencyId: CurrencyId.Coins,
+        currentBalance: 100,
+        weeklyIncome: 500,
+        growthRatePercent: -100,
+      }
+      const result = validateCurrencyIncome(income)
+      expect(result.isValid).toBe(true)
+    })
+
+    it('should collect multiple errors', () => {
+      const income: CurrencyIncome = {
+        currencyId: CurrencyId.Coins,
+        currentBalance: -100,
+        weeklyIncome: -500,
+        growthRatePercent: 5,
+      }
+      const result = validateCurrencyIncome(income)
+      expect(result.isValid).toBe(false)
+      expect(result.errors).toHaveLength(2)
+    })
+  })
+
+  describe('validateStoneBreakdown', () => {
+    it('should accept valid breakdown', () => {
+      const breakdown: StoneIncomeBreakdown = {
+        weeklyChallenges: 60,
+        eventStore: 0,
+        tournamentResults: 200,
+      }
+      const result = validateStoneBreakdown(breakdown)
+      expect(result.isValid).toBe(true)
+      expect(result.errors).toHaveLength(0)
+    })
+
+    it('should accept all zeros', () => {
+      const breakdown: StoneIncomeBreakdown = {
+        weeklyChallenges: 0,
+        eventStore: 0,
+        tournamentResults: 0,
+      }
+      const result = validateStoneBreakdown(breakdown)
+      expect(result.isValid).toBe(true)
+    })
+
+    it('should reject negative weekly challenges', () => {
+      const breakdown: StoneIncomeBreakdown = {
+        weeklyChallenges: -10,
+        eventStore: 0,
+        tournamentResults: 200,
+      }
+      const result = validateStoneBreakdown(breakdown)
+      expect(result.isValid).toBe(false)
+      expect(result.errors).toContain('Weekly challenges cannot be negative')
+    })
+
+    it('should reject negative event store', () => {
+      const breakdown: StoneIncomeBreakdown = {
+        weeklyChallenges: 60,
+        eventStore: -50,
+        tournamentResults: 200,
+      }
+      const result = validateStoneBreakdown(breakdown)
+      expect(result.isValid).toBe(false)
+      expect(result.errors).toContain('Event store cannot be negative')
+    })
+
+    it('should reject negative tournament results', () => {
+      const breakdown: StoneIncomeBreakdown = {
+        weeklyChallenges: 60,
+        eventStore: 0,
+        tournamentResults: -100,
+      }
+      const result = validateStoneBreakdown(breakdown)
+      expect(result.isValid).toBe(false)
+      expect(result.errors).toContain('Tournament results cannot be negative')
+    })
+  })
+
+  describe('clampNumber', () => {
+    it('should return value within range', () => {
+      expect(clampNumber(5, 0, 10)).toBe(5)
+    })
+
+    it('should clamp to minimum', () => {
+      expect(clampNumber(-5, 0, 10)).toBe(0)
+    })
+
+    it('should clamp to maximum', () => {
+      expect(clampNumber(15, 0, 10)).toBe(10)
+    })
+
+    it('should handle edge cases', () => {
+      expect(clampNumber(0, 0, 10)).toBe(0)
+      expect(clampNumber(10, 0, 10)).toBe(10)
+    })
+  })
+
+  describe('ensureNonNegative', () => {
+    it('should return positive values unchanged', () => {
+      expect(ensureNonNegative(100)).toBe(100)
+    })
+
+    it('should return zero unchanged', () => {
+      expect(ensureNonNegative(0)).toBe(0)
+    })
+
+    it('should convert negative to zero', () => {
+      expect(ensureNonNegative(-50)).toBe(0)
+    })
+  })
+
+  describe('clampGrowthRate', () => {
+    it('should return valid growth rate unchanged', () => {
+      expect(clampGrowthRate(5)).toBe(5)
+      expect(clampGrowthRate(0)).toBe(0)
+      expect(clampGrowthRate(100)).toBe(100)
+    })
+
+    it('should clamp to -100% minimum', () => {
+      expect(clampGrowthRate(-150)).toBe(-100)
+    })
+
+    it('should clamp to 1000% maximum', () => {
+      expect(clampGrowthRate(1500)).toBe(1000)
+    })
+
+    it('should allow boundary values', () => {
+      expect(clampGrowthRate(-100)).toBe(-100)
+      expect(clampGrowthRate(1000)).toBe(1000)
+    })
+  })
+})

--- a/src/features/spending-planner/income/income-validation.ts
+++ b/src/features/spending-planner/income/income-validation.ts
@@ -1,0 +1,88 @@
+/**
+ * Income Validation
+ *
+ * Validates income input values before saving.
+ */
+
+import type { CurrencyIncome, StoneIncomeBreakdown } from '../types'
+
+/**
+ * Result of validating income values.
+ */
+interface IncomeValidationResult {
+  isValid: boolean
+  errors: string[]
+}
+
+/**
+ * Validate a currency income configuration.
+ */
+export function validateCurrencyIncome(income: CurrencyIncome): IncomeValidationResult {
+  const errors: string[] = []
+
+  if (income.currentBalance < 0) {
+    errors.push('Current balance cannot be negative')
+  }
+
+  if (income.weeklyIncome < 0) {
+    errors.push('Weekly income cannot be negative')
+  }
+
+  if (income.growthRatePercent < -100) {
+    errors.push('Growth rate cannot be less than -100%')
+  }
+
+  if (income.growthRatePercent > 1000) {
+    errors.push('Growth rate cannot exceed 1000%')
+  }
+
+  return {
+    isValid: errors.length === 0,
+    errors,
+  }
+}
+
+/**
+ * Validate stone income breakdown.
+ */
+export function validateStoneBreakdown(breakdown: StoneIncomeBreakdown): IncomeValidationResult {
+  const errors: string[] = []
+
+  if (breakdown.weeklyChallenges < 0) {
+    errors.push('Weekly challenges cannot be negative')
+  }
+
+  if (breakdown.eventStore < 0) {
+    errors.push('Event store cannot be negative')
+  }
+
+  if (breakdown.tournamentResults < 0) {
+    errors.push('Tournament results cannot be negative')
+  }
+
+  return {
+    isValid: errors.length === 0,
+    errors,
+  }
+}
+
+/**
+ * Clamp a number to a valid range.
+ */
+export function clampNumber(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value))
+}
+
+/**
+ * Ensure a number is non-negative.
+ */
+export function ensureNonNegative(value: number): number {
+  return Math.max(0, value)
+}
+
+/**
+ * Clamp growth rate to valid range (-100% to 1000%).
+ */
+export function clampGrowthRate(value: number): number {
+  return clampNumber(value, -100, 1000)
+}

--- a/src/features/spending-planner/income/scale-detection.test.ts
+++ b/src/features/spending-planner/income/scale-detection.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Scale Detection Tests
+ *
+ * Tests for the getBestScaleForValue function.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { getBestScaleForValue } from './scale-detection'
+
+describe('getBestScaleForValue', () => {
+  it('returns empty string for zero', () => {
+    expect(getBestScaleForValue(0)).toBe('')
+  })
+
+  it('returns empty string for small values', () => {
+    expect(getBestScaleForValue(500)).toBe('')
+    expect(getBestScaleForValue(999)).toBe('')
+  })
+
+  it('returns K for thousands', () => {
+    expect(getBestScaleForValue(1000)).toBe('K')
+    expect(getBestScaleForValue(5000)).toBe('K')
+    expect(getBestScaleForValue(100_000)).toBe('K')
+    expect(getBestScaleForValue(999_000)).toBe('K')
+  })
+
+  it('returns M for millions', () => {
+    expect(getBestScaleForValue(1_000_000)).toBe('M')
+    expect(getBestScaleForValue(50_000_000)).toBe('M')
+    expect(getBestScaleForValue(999_000_000)).toBe('M')
+  })
+
+  it('returns B for billions', () => {
+    expect(getBestScaleForValue(1_000_000_000)).toBe('B')
+    expect(getBestScaleForValue(500_000_000_000)).toBe('B')
+  })
+
+  it('returns T for trillions', () => {
+    expect(getBestScaleForValue(1e12)).toBe('T')
+    expect(getBestScaleForValue(400e12)).toBe('T')
+    // 9999e12 = 9.999e15 which is quadrillion range, so uses q scale
+    expect(getBestScaleForValue(9999e12)).toBe('q')
+  })
+
+  it('returns q for quadrillions', () => {
+    expect(getBestScaleForValue(1e15)).toBe('q')
+    expect(getBestScaleForValue(500e15)).toBe('q')
+  })
+
+  it('returns Q for quintillions', () => {
+    expect(getBestScaleForValue(1e18)).toBe('Q')
+    expect(getBestScaleForValue(999e18)).toBe('Q') // 9.99e20, still quintillion
+  })
+
+  it('returns s for sextillions', () => {
+    expect(getBestScaleForValue(1e21)).toBe('s')
+    expect(getBestScaleForValue(9999e18)).toBe('s') // 9.999e21 is sextillion
+  })
+
+  it('handles values with decimal precision', () => {
+    expect(getBestScaleForValue(1.5e12)).toBe('T') // 1.5T
+    expect(getBestScaleForValue(2.75e9)).toBe('B') // 2.75B
+    expect(getBestScaleForValue(15.25e6)).toBe('M') // 15.25M
+  })
+
+  it('falls back to smaller scale for unclean large values', () => {
+    // 1.234567T would produce too many decimals at T scale
+    // Should fall back to B scale (1234.57B) or further
+    const value = 1.234567e12
+    const scale = getBestScaleForValue(value)
+    // Either T with rounded value or falls back
+    expect(['T', 'B', 'M', 'K', '']).toContain(scale)
+  })
+
+  it('handles boundary values correctly', () => {
+    // Exactly at scale boundaries
+    expect(getBestScaleForValue(1e3)).toBe('K')
+    expect(getBestScaleForValue(1e6)).toBe('M')
+    expect(getBestScaleForValue(1e9)).toBe('B')
+    expect(getBestScaleForValue(1e12)).toBe('T')
+    expect(getBestScaleForValue(1e15)).toBe('q')
+    expect(getBestScaleForValue(1e18)).toBe('Q')
+  })
+
+  it('uses cleaner scale when value spans multiple scales', () => {
+    // 500B = 0.5T, should use B since 500 is cleaner than 0.5
+    expect(getBestScaleForValue(500e9)).toBe('B')
+  })
+})

--- a/src/features/spending-planner/income/scale-detection.ts
+++ b/src/features/spending-planner/income/scale-detection.ts
@@ -1,0 +1,40 @@
+/**
+ * Scale Detection Utilities
+ *
+ * Pure functions for detecting the best scale suffix for currency values.
+ */
+
+import { SCALE_OPTIONS } from './scale-options'
+
+/**
+ * Determine the best scale suffix for a given numeric value.
+ * Finds the largest scale that produces a clean display value (1-9999 range).
+ *
+ * @param value - The numeric value to analyze
+ * @returns The scale suffix (e.g., 'K', 'M', 'T') or '' for small values
+ */
+export function getBestScaleForValue(value: number): string {
+  if (value === 0) {
+    return ''
+  }
+
+  // Sort scales from largest to smallest (excluding the empty scale)
+  const sortedScales = [...SCALE_OPTIONS]
+    .filter((s) => s.multiplier > 1)
+    .sort((a, b) => b.multiplier - a.multiplier)
+
+  for (const scale of sortedScales) {
+    const displayValue = value / scale.multiplier
+    // Use this scale if the result is in a reasonable display range
+    if (displayValue >= 1 && displayValue < 10000) {
+      // Check if it produces a clean number (at most 2 decimal places)
+      const rounded = Math.round(displayValue * 100) / 100
+      if (Math.abs(rounded - displayValue) < 0.001) {
+        return scale.value
+      }
+    }
+  }
+
+  // Fall back to no scale for small or unusual values
+  return ''
+}

--- a/src/features/spending-planner/income/scale-options.ts
+++ b/src/features/spending-planner/income/scale-options.ts
@@ -1,0 +1,17 @@
+/**
+ * Scale Options Configuration
+ *
+ * Defines available scale suffixes for currency values.
+ * Derived from the shared SCALE_DEFINITIONS to avoid duplication.
+ */
+
+import { SCALE_DEFINITIONS } from '@/shared/formatting/number-scale'
+
+export const SCALE_OPTIONS = [
+  { value: '', label: '--', multiplier: 1 },
+  ...SCALE_DEFINITIONS.map(({ suffix, multiplier }) => ({
+    value: suffix,
+    label: suffix,
+    multiplier,
+  })),
+] as const

--- a/src/features/spending-planner/income/stone-income-breakdown.tsx
+++ b/src/features/spending-planner/income/stone-income-breakdown.tsx
@@ -1,0 +1,76 @@
+/**
+ * Stone Income Breakdown Component
+ *
+ * Three-field breakdown for stone income sources that computes the weekly total.
+ * Displays inputs for daily missions, event store, and tournament results
+ * with a clear visual connection showing these sum to the Weekly income.
+ */
+
+import { Input } from '@/components/ui/input'
+import type { StoneIncomeBreakdown as BreakdownType } from '../types'
+
+interface StoneIncomeBreakdownProps {
+  breakdown: BreakdownType
+  weeklyTotal: number
+  onUpdate: (field: keyof BreakdownType, value: number) => void
+}
+
+export function StoneIncomeBreakdown({
+  breakdown,
+  weeklyTotal,
+  onUpdate,
+}: StoneIncomeBreakdownProps) {
+  const handleChange = (field: keyof BreakdownType) => (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = parseFloat(e.target.value) || 0
+    onUpdate(field, value)
+  }
+
+  return (
+    <div className="bg-slate-800/30 rounded-lg p-3 border border-slate-700/40">
+      {/* Header with computed total */}
+      <div className="flex items-center justify-between mb-3">
+        <span className="text-xs text-slate-400">Weekly Income Sources</span>
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-slate-500">Total:</span>
+          <span className="text-sm font-medium text-emerald-300 tabular-nums">
+            {weeklyTotal}
+          </span>
+          <span className="text-xs text-slate-500">/ week</span>
+        </div>
+      </div>
+
+      {/* Income source inputs in a clean grid */}
+      <div className="grid grid-cols-[1fr_auto] gap-x-3 gap-y-2 items-center">
+        <span className="text-xs text-slate-400">Weekly challenges</span>
+        <Input
+          type="number"
+          value={breakdown.weeklyChallenges || ''}
+          onChange={handleChange('weeklyChallenges')}
+          className="w-20 h-7 text-right text-sm bg-slate-900/50"
+          placeholder="0"
+          min={0}
+        />
+
+        <span className="text-xs text-slate-400">Event store</span>
+        <Input
+          type="number"
+          value={breakdown.eventStore || ''}
+          onChange={handleChange('eventStore')}
+          className="w-20 h-7 text-right text-sm bg-slate-900/50"
+          placeholder="0"
+          min={0}
+        />
+
+        <span className="text-xs text-slate-400">Tournament results</span>
+        <Input
+          type="number"
+          value={breakdown.tournamentResults || ''}
+          onChange={handleChange('tournamentResults')}
+          className="w-20 h-7 text-right text-sm bg-slate-900/50"
+          placeholder="0"
+          min={0}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/features/spending-planner/income/use-income-state.ts
+++ b/src/features/spending-planner/income/use-income-state.ts
@@ -1,0 +1,104 @@
+/**
+ * Income State Hook
+ *
+ * Manages income configuration state for all currencies.
+ */
+
+import { useCallback } from 'react'
+import { CurrencyId } from '../types'
+import type { CurrencyIncome, StoneIncomeBreakdown } from '../types'
+import { calculateStoneIncome } from '../currencies/currency-config'
+import { ensureNonNegative, clampGrowthRate } from './income-validation'
+
+interface UseIncomeStateReturn {
+  /** Update balance for a currency */
+  updateBalance: (currencyId: CurrencyId, balance: number) => void
+  /** Update weekly income for a currency */
+  updateWeeklyIncome: (currencyId: CurrencyId, income: number) => void
+  /** Update growth rate for a currency */
+  updateGrowthRate: (currencyId: CurrencyId, rate: number) => void
+  /** Update stone income breakdown field */
+  updateStoneBreakdown: (field: keyof StoneIncomeBreakdown, value: number) => void
+}
+
+interface UseIncomeStateProps {
+  incomes: CurrencyIncome[]
+  stoneBreakdown: StoneIncomeBreakdown
+  onIncomesChange: (incomes: CurrencyIncome[]) => void
+  onStoneBreakdownChange: (breakdown: StoneIncomeBreakdown) => void
+}
+
+/**
+ * Hook for managing income state with validation.
+ */
+export function useIncomeState({
+  incomes,
+  stoneBreakdown,
+  onIncomesChange,
+  onStoneBreakdownChange,
+}: UseIncomeStateProps): UseIncomeStateReturn {
+  const updateBalance = useCallback(
+    (currencyId: CurrencyId, balance: number) => {
+      const validBalance = ensureNonNegative(balance)
+      const updated = incomes.map((income) =>
+        income.currencyId === currencyId
+          ? { ...income, currentBalance: validBalance }
+          : income
+      )
+      onIncomesChange(updated)
+    },
+    [incomes, onIncomesChange]
+  )
+
+  const updateWeeklyIncome = useCallback(
+    (currencyId: CurrencyId, income: number) => {
+      const validIncome = ensureNonNegative(income)
+      const updated = incomes.map((i) =>
+        i.currencyId === currencyId ? { ...i, weeklyIncome: validIncome } : i
+      )
+      onIncomesChange(updated)
+    },
+    [incomes, onIncomesChange]
+  )
+
+  const updateGrowthRate = useCallback(
+    (currencyId: CurrencyId, rate: number) => {
+      const validRate = clampGrowthRate(rate)
+      const updated = incomes.map((income) =>
+        income.currencyId === currencyId
+          ? { ...income, growthRatePercent: validRate }
+          : income
+      )
+      onIncomesChange(updated)
+    },
+    [incomes, onIncomesChange]
+  )
+
+  const updateStoneBreakdown = useCallback(
+    (field: keyof StoneIncomeBreakdown, value: number) => {
+      const validValue = ensureNonNegative(value)
+      const updatedBreakdown = {
+        ...stoneBreakdown,
+        [field]: validValue,
+      }
+      onStoneBreakdownChange(updatedBreakdown)
+
+      // Also update the stones weeklyIncome based on breakdown
+      const totalStoneIncome = calculateStoneIncome(updatedBreakdown)
+      const updated = incomes.map((income) =>
+        income.currencyId === CurrencyId.Stones
+          ? { ...income, weeklyIncome: totalStoneIncome }
+          : income
+      )
+      onIncomesChange(updated)
+    },
+    [incomes, stoneBreakdown, onIncomesChange, onStoneBreakdownChange]
+  )
+
+  return {
+    updateBalance,
+    updateWeeklyIncome,
+    updateGrowthRate,
+    updateStoneBreakdown,
+  }
+}

--- a/src/features/spending-planner/persistence/spending-planner-persistence.test.ts
+++ b/src/features/spending-planner/persistence/spending-planner-persistence.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+  getDefaultState,
+  loadSpendingPlannerState,
+  saveSpendingPlannerState,
+  clearSpendingPlannerState,
+} from './spending-planner-persistence'
+import { CurrencyId } from '../types'
+import type { SpendingPlannerState } from '../types'
+
+describe('spending-planner-persistence', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  describe('getDefaultState', () => {
+    it('should return state with default incomes for both currencies', () => {
+      const state = getDefaultState()
+      expect(state.incomes).toHaveLength(2)
+      expect(state.incomes[0].currencyId).toBe(CurrencyId.Coins)
+      expect(state.incomes[1].currencyId).toBe(CurrencyId.Stones)
+    })
+
+    it('should return coins with 5% default growth', () => {
+      const state = getDefaultState()
+      const coins = state.incomes.find((i) => i.currencyId === CurrencyId.Coins)
+      expect(coins?.growthRatePercent).toBe(5)
+    })
+
+    it('should return stones with 0% default growth', () => {
+      const state = getDefaultState()
+      const stones = state.incomes.find((i) => i.currencyId === CurrencyId.Stones)
+      expect(stones?.growthRatePercent).toBe(0)
+    })
+
+    it('should return empty events array', () => {
+      const state = getDefaultState()
+      expect(state.events).toEqual([])
+    })
+
+    it('should return default timeline config of 12 weeks', () => {
+      const state = getDefaultState()
+      expect(state.timelineConfig.weeks).toBe(12)
+    })
+
+    it('should return default stone breakdown with all zeros', () => {
+      const state = getDefaultState()
+      expect(state.stoneIncomeBreakdown).toEqual({
+        weeklyChallenges: 0,
+        eventStore: 0,
+        tournamentResults: 0,
+      })
+    })
+  })
+
+  describe('loadSpendingPlannerState', () => {
+    it('should return default state when nothing stored', () => {
+      const state = loadSpendingPlannerState()
+      expect(state.incomes).toHaveLength(2)
+      expect(state.events).toEqual([])
+    })
+
+    it('should load valid stored state', () => {
+      const validState: SpendingPlannerState = {
+        incomes: [
+          { currencyId: CurrencyId.Coins, currentBalance: 1000, weeklyIncome: 500, growthRatePercent: 5 },
+          { currencyId: CurrencyId.Stones, currentBalance: 200, weeklyIncome: 100, growthRatePercent: 0 },
+        ],
+        stoneIncomeBreakdown: { weeklyChallenges: 60, eventStore: 0, tournamentResults: 40 },
+        events: [
+          { id: '1', name: 'Test', currencyId: CurrencyId.Coins, amount: 500, priority: 0 },
+        ],
+        timelineConfig: { weeks: 26 },
+        incomePanelCollapsed: false,
+        lastUpdated: Date.now(),
+      }
+      localStorage.setItem('tower-tracking-spending-planner', JSON.stringify(validState))
+
+      const loaded = loadSpendingPlannerState()
+      expect(loaded.incomes[0].currentBalance).toBe(1000)
+      expect(loaded.events).toHaveLength(1)
+      expect(loaded.timelineConfig.weeks).toBe(26)
+    })
+
+    it('should always return incomePanelCollapsed as true', () => {
+      const validState: SpendingPlannerState = {
+        incomes: [
+          { currencyId: CurrencyId.Coins, currentBalance: 0, weeklyIncome: 0, growthRatePercent: 5 },
+          { currencyId: CurrencyId.Stones, currentBalance: 0, weeklyIncome: 0, growthRatePercent: 0 },
+        ],
+        stoneIncomeBreakdown: { weeklyChallenges: 0, eventStore: 0, tournamentResults: 0 },
+        events: [],
+        timelineConfig: { weeks: 12 },
+        incomePanelCollapsed: false,
+        lastUpdated: Date.now(),
+      }
+      localStorage.setItem('tower-tracking-spending-planner', JSON.stringify(validState))
+
+      const loaded = loadSpendingPlannerState()
+      expect(loaded.incomePanelCollapsed).toBe(true)
+    })
+
+    it('should return default state for invalid JSON', () => {
+      localStorage.setItem('tower-tracking-spending-planner', 'invalid json')
+
+      const state = loadSpendingPlannerState()
+      expect(state).toEqual(expect.objectContaining({ events: [] }))
+    })
+
+    it('should return default state for missing required fields', () => {
+      localStorage.setItem('tower-tracking-spending-planner', JSON.stringify({ incomes: [] }))
+
+      const state = loadSpendingPlannerState()
+      expect(state.incomes).toHaveLength(2) // Falls back to default
+    })
+
+    it('should return default state for invalid currency ID', () => {
+      const invalidState = {
+        incomes: [
+          { currencyId: 'invalid', currentBalance: 0, weeklyIncome: 0, growthRatePercent: 0 },
+        ],
+        stoneIncomeBreakdown: { weeklyChallenges: 0, eventStore: 0, tournamentResults: 0 },
+        events: [],
+        timelineConfig: { weeks: 12 },
+        incomePanelCollapsed: false,
+        lastUpdated: Date.now(),
+      }
+      localStorage.setItem('tower-tracking-spending-planner', JSON.stringify(invalidState))
+
+      const state = loadSpendingPlannerState()
+      expect(state.incomes).toHaveLength(2) // Falls back to default
+    })
+
+    it('should return default state for invalid timeline weeks', () => {
+      const invalidState = {
+        incomes: [
+          { currencyId: 'coins', currentBalance: 0, weeklyIncome: 0, growthRatePercent: 5 },
+          { currencyId: 'stones', currentBalance: 0, weeklyIncome: 0, growthRatePercent: 0 },
+        ],
+        stoneIncomeBreakdown: { weeklyChallenges: 0, eventStore: 0, tournamentResults: 0 },
+        events: [],
+        timelineConfig: { weeks: 15 }, // Invalid week count
+        incomePanelCollapsed: false,
+        lastUpdated: Date.now(),
+      }
+      localStorage.setItem('tower-tracking-spending-planner', JSON.stringify(invalidState))
+
+      const state = loadSpendingPlannerState()
+      expect(state.timelineConfig.weeks).toBe(12) // Falls back to default
+    })
+  })
+
+  describe('saveSpendingPlannerState', () => {
+    it('should save state to localStorage', () => {
+      const state = getDefaultState()
+      state.incomes[0].currentBalance = 5000
+
+      saveSpendingPlannerState(state)
+
+      const stored = localStorage.getItem('tower-tracking-spending-planner')
+      expect(stored).toBeTruthy()
+      const parsed = JSON.parse(stored!)
+      expect(parsed.incomes[0].currentBalance).toBe(5000)
+    })
+
+    it('should update lastUpdated timestamp', () => {
+      const state = getDefaultState()
+      const originalTimestamp = state.lastUpdated
+
+      // Wait a tiny bit to ensure timestamp differs
+      vi.useFakeTimers()
+      vi.advanceTimersByTime(100)
+
+      saveSpendingPlannerState(state)
+
+      const stored = localStorage.getItem('tower-tracking-spending-planner')
+      const parsed = JSON.parse(stored!)
+      expect(parsed.lastUpdated).toBeGreaterThan(originalTimestamp)
+
+      vi.useRealTimers()
+    })
+  })
+
+  describe('clearSpendingPlannerState', () => {
+    it('should remove state from localStorage', () => {
+      const state = getDefaultState()
+      saveSpendingPlannerState(state)
+      expect(localStorage.getItem('tower-tracking-spending-planner')).toBeTruthy()
+
+      clearSpendingPlannerState()
+      expect(localStorage.getItem('tower-tracking-spending-planner')).toBeNull()
+    })
+
+    it('should not throw when nothing to clear', () => {
+      expect(() => clearSpendingPlannerState()).not.toThrow()
+    })
+  })
+
+  describe('event validation', () => {
+    it('should accept events with optional durationDays', () => {
+      const validState: SpendingPlannerState = {
+        incomes: [
+          { currencyId: CurrencyId.Coins, currentBalance: 0, weeklyIncome: 0, growthRatePercent: 5 },
+          { currencyId: CurrencyId.Stones, currentBalance: 0, weeklyIncome: 0, growthRatePercent: 0 },
+        ],
+        stoneIncomeBreakdown: { weeklyChallenges: 0, eventStore: 0, tournamentResults: 0 },
+        events: [
+          { id: '1', name: 'Lab', currencyId: CurrencyId.Coins, amount: 500, priority: 0, durationDays: 40 },
+        ],
+        timelineConfig: { weeks: 12 },
+        incomePanelCollapsed: false,
+        lastUpdated: Date.now(),
+      }
+      localStorage.setItem('tower-tracking-spending-planner', JSON.stringify(validState))
+
+      const loaded = loadSpendingPlannerState()
+      expect(loaded.events[0].durationDays).toBe(40)
+    })
+
+    it('should reject events with invalid currency', () => {
+      const invalidState = {
+        incomes: [
+          { currencyId: 'coins', currentBalance: 0, weeklyIncome: 0, growthRatePercent: 5 },
+          { currencyId: 'stones', currentBalance: 0, weeklyIncome: 0, growthRatePercent: 0 },
+        ],
+        stoneIncomeBreakdown: { weeklyChallenges: 0, eventStore: 0, tournamentResults: 0 },
+        events: [
+          { id: '1', name: 'Invalid', currencyId: 'gems', amount: 500, priority: 0 },
+        ],
+        timelineConfig: { weeks: 12 },
+        incomePanelCollapsed: false,
+        lastUpdated: Date.now(),
+      }
+      localStorage.setItem('tower-tracking-spending-planner', JSON.stringify(invalidState))
+
+      const loaded = loadSpendingPlannerState()
+      expect(loaded.events).toEqual([]) // Falls back to default
+    })
+  })
+})

--- a/src/features/spending-planner/persistence/spending-planner-persistence.ts
+++ b/src/features/spending-planner/persistence/spending-planner-persistence.ts
@@ -1,0 +1,197 @@
+/**
+ * Spending Planner Persistence
+ *
+ * Handles loading, saving, and validating spending planner state
+ * to/from localStorage.
+ */
+
+import type {
+  SpendingPlannerState,
+  CurrencyIncome,
+  SpendingEvent,
+  StoneIncomeBreakdown,
+  TimelineViewConfig,
+} from '../types'
+import {
+  CURRENCY_ORDER,
+  createDefaultIncome,
+  createDefaultStoneBreakdown,
+  isValidCurrencyId,
+} from '../currencies/currency-config'
+
+const STORAGE_KEY = 'tower-tracking-spending-planner'
+
+/**
+ * Create default spending planner state.
+ */
+export function getDefaultState(): SpendingPlannerState {
+  return {
+    incomes: CURRENCY_ORDER.map(createDefaultIncome),
+    stoneIncomeBreakdown: createDefaultStoneBreakdown(),
+    events: [],
+    timelineConfig: { weeks: 12 },
+    incomePanelCollapsed: false,
+    lastUpdated: Date.now(),
+  }
+}
+
+/**
+ * Load spending planner state from localStorage.
+ * Returns default state if none exists or if parsing fails.
+ * NOTE: incomePanelCollapsed always returns true (collapsed) on load.
+ */
+export function loadSpendingPlannerState(): SpendingPlannerState {
+  if (typeof window === 'undefined') {
+    return getDefaultState()
+  }
+
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (!stored) {
+      return getDefaultState()
+    }
+
+    const parsed = JSON.parse(stored) as SpendingPlannerState
+    const validated = validateStoredState(parsed)
+
+    // Always start with collapsed income panel
+    return {
+      ...validated,
+      incomePanelCollapsed: true,
+    }
+  } catch (error) {
+    console.warn('Failed to load spending planner state from localStorage:', error)
+    return getDefaultState()
+  }
+}
+
+/**
+ * Save spending planner state to localStorage.
+ */
+export function saveSpendingPlannerState(state: SpendingPlannerState): void {
+  if (typeof window === 'undefined') return
+
+  try {
+    const updated = {
+      ...state,
+      lastUpdated: Date.now(),
+    }
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(updated))
+  } catch (error) {
+    console.error('Failed to save spending planner state to localStorage:', error)
+  }
+}
+
+/**
+ * Clear spending planner state from localStorage.
+ */
+export function clearSpendingPlannerState(): void {
+  if (typeof window === 'undefined') return
+
+  try {
+    localStorage.removeItem(STORAGE_KEY)
+  } catch (error) {
+    console.error('Failed to clear spending planner state from localStorage:', error)
+  }
+}
+
+/**
+ * Validate stored state has all required fields with correct types.
+ */
+function validateStoredState(state: unknown): SpendingPlannerState {
+  const defaultState = getDefaultState()
+
+  if (!state || typeof state !== 'object') {
+    return defaultState
+  }
+
+  const s = state as Partial<SpendingPlannerState>
+
+  // Validate incomes array
+  if (!Array.isArray(s.incomes) || !s.incomes.every(isValidIncome)) {
+    return defaultState
+  }
+
+  // Validate stone breakdown
+  if (!isValidStoneBreakdown(s.stoneIncomeBreakdown)) {
+    return defaultState
+  }
+
+  // Validate events array
+  if (!Array.isArray(s.events) || !s.events.every(isValidEvent)) {
+    return defaultState
+  }
+
+  // Validate timeline config
+  if (!isValidTimelineConfig(s.timelineConfig)) {
+    return defaultState
+  }
+
+  // Validate boolean
+  if (typeof s.incomePanelCollapsed !== 'boolean') {
+    return defaultState
+  }
+
+  return s as SpendingPlannerState
+}
+
+/**
+ * Type guard for CurrencyIncome.
+ */
+function isValidIncome(value: unknown): value is CurrencyIncome {
+  if (!value || typeof value !== 'object') return false
+
+  const v = value as Partial<CurrencyIncome>
+  return (
+    typeof v.currencyId === 'string' &&
+    isValidCurrencyId(v.currencyId) &&
+    typeof v.currentBalance === 'number' &&
+    typeof v.weeklyIncome === 'number' &&
+    typeof v.growthRatePercent === 'number'
+  )
+}
+
+/**
+ * Type guard for StoneIncomeBreakdown.
+ */
+function isValidStoneBreakdown(value: unknown): value is StoneIncomeBreakdown {
+  if (!value || typeof value !== 'object') return false
+
+  const v = value as Partial<StoneIncomeBreakdown>
+  return (
+    typeof v.weeklyChallenges === 'number' &&
+    typeof v.eventStore === 'number' &&
+    typeof v.tournamentResults === 'number'
+  )
+}
+
+/**
+ * Type guard for SpendingEvent.
+ */
+function isValidEvent(value: unknown): value is SpendingEvent {
+  if (!value || typeof value !== 'object') return false
+
+  const v = value as Partial<SpendingEvent>
+  return (
+    typeof v.id === 'string' &&
+    typeof v.name === 'string' &&
+    typeof v.currencyId === 'string' &&
+    isValidCurrencyId(v.currencyId) &&
+    typeof v.amount === 'number' &&
+    typeof v.priority === 'number' &&
+    (v.durationDays === undefined || typeof v.durationDays === 'number')
+  )
+}
+
+/**
+ * Type guard for TimelineViewConfig.
+ */
+function isValidTimelineConfig(value: unknown): value is TimelineViewConfig {
+  if (!value || typeof value !== 'object') return false
+
+  const v = value as Partial<TimelineViewConfig>
+  return (
+    typeof v.weeks === 'number' &&
+    (v.weeks === 4 || v.weeks === 8 || v.weeks === 12 || v.weeks === 26 || v.weeks === 52)
+  )
+}

--- a/src/features/spending-planner/persistence/use-spending-planner-persistence.ts
+++ b/src/features/spending-planner/persistence/use-spending-planner-persistence.ts
@@ -1,0 +1,52 @@
+/**
+ * Spending Planner Persistence Hook
+ *
+ * Provides debounced auto-save functionality for spending planner state.
+ */
+
+import { useEffect, useRef, useCallback } from 'react'
+import { saveSpendingPlannerState } from './spending-planner-persistence'
+import type { SpendingPlannerState } from '../types'
+
+const DEBOUNCE_MS = 500
+
+/**
+ * Hook that auto-saves spending planner state with debouncing.
+ * Saves changes to localStorage after a 500ms delay.
+ *
+ * @param state - The current spending planner state to persist
+ */
+export function useSpendingPlannerPersistence(state: SpendingPlannerState): void {
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const isFirstRender = useRef(true)
+
+  // Debounced save function
+  const debouncedSave = useCallback((stateToSave: SpendingPlannerState) => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current)
+    }
+
+    timeoutRef.current = setTimeout(() => {
+      saveSpendingPlannerState(stateToSave)
+    }, DEBOUNCE_MS)
+  }, [])
+
+  // Auto-save on state changes (skip first render to avoid saving initial load)
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false
+      return
+    }
+
+    debouncedSave(state)
+  }, [state, debouncedSave])
+
+  // Cleanup timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current)
+      }
+    }
+  }, [])
+}

--- a/src/features/spending-planner/spending-planner.tsx
+++ b/src/features/spending-planner/spending-planner.tsx
@@ -1,0 +1,74 @@
+/**
+ * Spending Planner Component
+ *
+ * Main entry component for the spending planner feature.
+ * Assembles income configuration, event queue, and timeline visualization.
+ */
+
+import { useSpendingPlannerState } from './use-spending-planner-state'
+import { IncomePanel } from './income/income-panel'
+import { EventQueuePanel } from './events/event-queue-panel'
+import { TimelinePanel } from './timeline/timeline-panel'
+
+export function SpendingPlanner() {
+  const {
+    state,
+    timelineData,
+    income,
+    eventQueue,
+    timeline,
+    toggleIncomePanel,
+    handleAddEvent,
+    handleRemoveEvent,
+    handleEditEvent,
+    handleCloneEvent,
+    handleDrop,
+  } = useSpendingPlannerState()
+
+  return (
+    <div className="space-y-6">
+      {/* Page Header */}
+      <div>
+        <h1 className="text-2xl font-bold text-slate-100">Spending Planner</h1>
+        <p className="text-sm text-slate-400 mt-1">
+          Plan when you can afford tower upgrades, mastery unlocks, and labs.
+        </p>
+      </div>
+
+      {/* Income Configuration */}
+      <IncomePanel
+        incomes={state.incomes}
+        stoneBreakdown={state.stoneIncomeBreakdown}
+        isCollapsed={state.incomePanelCollapsed}
+        onToggleCollapse={toggleIncomePanel}
+        onBalanceChange={income.updateBalance}
+        onWeeklyIncomeChange={income.updateWeeklyIncome}
+        onGrowthRateChange={income.updateGrowthRate}
+        onStoneBreakdownChange={income.updateStoneBreakdown}
+      />
+
+      {/* Event Queue */}
+      <EventQueuePanel
+        events={state.events}
+        draggedIndex={eventQueue.draggedIndex}
+        draggedOverIndex={eventQueue.draggedOverIndex}
+        onDragStart={eventQueue.handleDragStart}
+        onDragEnter={eventQueue.handleDragEnter}
+        onDragEnd={handleDrop}
+        onAddEvent={handleAddEvent}
+        onRemoveEvent={handleRemoveEvent}
+        onEditEvent={handleEditEvent}
+        onCloneEvent={handleCloneEvent}
+      />
+
+      {/* Timeline Visualization */}
+      <TimelinePanel
+        timelineData={timelineData}
+        config={timeline.config}
+        weekOptions={timeline.weekOptions}
+        startDate={timeline.startDate}
+        onWeeksChange={timeline.setWeeks}
+      />
+    </div>
+  )
+}

--- a/src/features/spending-planner/timeline/event-positioning.ts
+++ b/src/features/spending-planner/timeline/event-positioning.ts
@@ -1,0 +1,101 @@
+/**
+ * Event Positioning Logic
+ *
+ * Pure functions for calculating event positions in the timeline grid.
+ */
+
+import type { TimelineEvent } from '../types'
+import { durationToWeeks } from './timeline-utils'
+
+interface PositionedEvent {
+  event: TimelineEvent
+  startWeek: number
+  spanWeeks: number
+  row: number
+}
+
+/**
+ * Sort events by trigger week, then by priority (lower priority number = higher priority = appears at top).
+ */
+function sortEventsByWeekAndPriority(events: TimelineEvent[]): TimelineEvent[] {
+  return [...events].sort((a, b) => {
+    if (a.triggerWeek !== b.triggerWeek) {
+      return a.triggerWeek - b.triggerWeek
+    }
+    return a.event.priority - b.event.priority
+  })
+}
+
+/**
+ * Check if a range of weeks is available in a row.
+ */
+function canPlaceInRow(occupiedWeeks: Set<number>, startWeek: number, spanWeeks: number): boolean {
+  for (let week = startWeek; week < startWeek + spanWeeks; week++) {
+    if (occupiedWeeks.has(week)) {
+      return false
+    }
+  }
+  return true
+}
+
+/**
+ * Mark weeks as occupied in a row.
+ */
+function markWeeksOccupied(
+  rowOccupancy: Map<number, Set<number>>,
+  row: number,
+  startWeek: number,
+  spanWeeks: number
+): void {
+  if (!rowOccupancy.has(row)) {
+    rowOccupancy.set(row, new Set())
+  }
+  const rowSet = rowOccupancy.get(row)!
+  for (let week = startWeek; week < startWeek + spanWeeks; week++) {
+    rowSet.add(week)
+  }
+}
+
+/**
+ * Find the first available row for an event.
+ */
+function findAvailableRow(
+  rowOccupancy: Map<number, Set<number>>,
+  startWeek: number,
+  spanWeeks: number
+): number {
+  let row = 0
+  while (true) {
+    const occupiedWeeks = rowOccupancy.get(row) ?? new Set()
+    if (canPlaceInRow(occupiedWeeks, startWeek, spanWeeks)) {
+      return row
+    }
+    row++
+  }
+}
+
+/**
+ * Calculate positioned events with row assignments to avoid overlaps.
+ */
+export function calculateEventPositions(
+  events: TimelineEvent[],
+  totalWeeks: number
+): PositionedEvent[] {
+  const positioned: PositionedEvent[] = []
+  const rowOccupancy: Map<number, Set<number>> = new Map()
+  const sortedEvents = sortEventsByWeekAndPriority(events)
+
+  for (const event of sortedEvents) {
+    const startWeek = event.triggerWeek
+    const spanWeeks = Math.min(
+      event.event.durationDays ? durationToWeeks(event.event.durationDays) : 1,
+      totalWeeks - startWeek
+    )
+
+    const row = findAvailableRow(rowOccupancy, startWeek, spanWeeks)
+    markWeeksOccupied(rowOccupancy, row, startWeek, spanWeeks)
+    positioned.push({ event, startWeek, spanWeeks, row })
+  }
+
+  return positioned
+}

--- a/src/features/spending-planner/timeline/timeline-event-pill.tsx
+++ b/src/features/spending-planner/timeline/timeline-event-pill.tsx
@@ -1,0 +1,54 @@
+/**
+ * Timeline Event Pill Component
+ *
+ * Compact pill showing an event in the timeline grid.
+ * Supports duration spans for labs.
+ */
+
+import { cn } from '@/shared/lib/utils'
+import { formatLargeNumber } from '@/shared/formatting/number-scale'
+import type { TimelineEvent } from '../types'
+import { getCurrencyConfig } from '../currencies/currency-config'
+import { durationToWeeks } from './timeline-utils'
+
+interface TimelineEventPillProps {
+  timelineEvent: TimelineEvent
+  /** Number of weeks this event spans (1 for instant, more for labs) */
+  weekSpan?: number
+}
+
+export function TimelineEventPill({ timelineEvent, weekSpan = 1 }: TimelineEventPillProps) {
+  const { event } = timelineEvent
+  const config = getCurrencyConfig(event.currencyId)
+  const formattedAmount = formatLargeNumber(event.amount)
+
+  // Check if this event spans multiple weeks (for styling purposes)
+  const isSpanning = weekSpan > 1 || (event.durationDays ? durationToWeeks(event.durationDays) > 1 : false)
+
+  return (
+    <div
+      className={cn(
+        'flex flex-col p-1.5 rounded border text-xs h-full',
+        'bg-slate-700/60 border-slate-600/50',
+        'hover:bg-slate-600/60 transition-colors',
+        isSpanning && 'relative overflow-hidden'
+      )}
+      title={`${event.name}: ${formattedAmount} ${config.abbreviation}${event.durationDays ? ` (${event.durationDays} days)` : ''}`}
+    >
+      {/* Event name */}
+      <span className="text-slate-200 font-medium truncate text-[11px] leading-tight">
+        {event.name}
+      </span>
+
+      {/* Cost */}
+      <span className={cn('text-[10px] leading-tight', config.color)}>
+        -{formattedAmount}
+      </span>
+
+      {/* Duration indicator for spanning events */}
+      {isSpanning && (
+        <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-gradient-to-r from-orange-500/50 to-orange-500/20" />
+      )}
+    </div>
+  )
+}

--- a/src/features/spending-planner/timeline/timeline-events-grid.tsx
+++ b/src/features/spending-planner/timeline/timeline-events-grid.tsx
@@ -1,0 +1,92 @@
+/**
+ * Timeline Events Grid Component
+ *
+ * Grid-based layout for rendering events that can span multiple weeks.
+ * Uses CSS Grid to position events across columns.
+ */
+
+import { useMemo } from 'react'
+import type { TimelineEvent } from '../types'
+import { TimelineEventPill } from './timeline-event-pill'
+import { calculateEventPositions } from './event-positioning'
+
+interface TimelineEventsGridProps {
+  events: TimelineEvent[]
+  weeks: number
+  labelWidth: number
+  columnWidth: number
+}
+
+export function TimelineEventsGrid({
+  events,
+  weeks,
+  labelWidth,
+  columnWidth,
+}: TimelineEventsGridProps) {
+  const positionedEvents = useMemo(
+    () => calculateEventPositions(events, weeks),
+    [events, weeks]
+  )
+
+  const maxRows = useMemo(() => {
+    if (positionedEvents.length === 0) return 1
+    return Math.max(...positionedEvents.map((e) => e.row)) + 1
+  }, [positionedEvents])
+
+  if (events.length === 0) {
+    return (
+      <div className="flex border-t border-slate-700/50">
+        <div
+          className="shrink-0 border-r border-slate-700/50 px-2 py-2 text-xs text-slate-400 font-medium"
+          style={{ width: labelWidth }}
+        >
+          Events
+        </div>
+        <div className="flex-1 p-2 text-xs text-slate-500 italic">
+          No events scheduled
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex border-t border-slate-700/50">
+      {/* Events label */}
+      <div
+        className="shrink-0 border-r border-slate-700/50 px-2 py-2 text-xs text-slate-400 font-medium"
+        style={{ width: labelWidth }}
+      >
+        Events
+      </div>
+
+      {/* Events grid - uses CSS Grid matching the week columns above */}
+      <div
+        className="relative"
+        style={{
+          display: 'grid',
+          gridTemplateColumns: `repeat(${weeks}, ${columnWidth}px)`,
+          gridTemplateRows: `repeat(${maxRows}, auto)`,
+          gap: '4px 0', /* vertical gap only, columns are flush */
+          padding: '4px 0',
+          minHeight: maxRows * 40,
+        }}
+      >
+        {positionedEvents.map(({ event, startWeek, spanWeeks, row }) => (
+          <div
+            key={event.event.id}
+            className="px-0.5" /* small horizontal padding within each cell */
+            style={{
+              gridColumn: `${startWeek + 1} / span ${spanWeeks}`,
+              gridRow: row + 1,
+            }}
+          >
+            <TimelineEventPill
+              timelineEvent={event}
+              weekSpan={spanWeeks}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/features/spending-planner/timeline/timeline-panel.tsx
+++ b/src/features/spending-planner/timeline/timeline-panel.tsx
@@ -1,0 +1,116 @@
+/**
+ * Timeline Panel Component
+ *
+ * Main Gantt-style visualization showing when events trigger.
+ */
+
+import { useMemo } from 'react'
+import { Button } from '@/components/ui/button'
+import type { TimelineData, TimelineViewConfig, TimelineWeeks, CurrencyId } from '../types'
+import { CURRENCY_ORDER } from '../currencies/currency-config'
+import { generateWeekDates } from './timeline-utils'
+import { TimelineWeekColumn } from './timeline-week-column'
+import { TimelineRowLabels } from './timeline-row-labels'
+import { TimelineEventsGrid } from './timeline-events-grid'
+
+interface TimelinePanelProps {
+  timelineData: TimelineData
+  config: TimelineViewConfig
+  weekOptions: TimelineWeeks[]
+  startDate: Date
+  onWeeksChange: (weeks: TimelineWeeks) => void
+}
+
+const LABEL_WIDTH = 80
+const COLUMN_WIDTH = 110
+
+function getDataForWeek(
+  weekIndex: number,
+  currencyOrder: readonly CurrencyId[],
+  dataByWeek: Map<CurrencyId, number[]>
+): Map<CurrencyId, number> {
+  const result = new Map<CurrencyId, number>()
+  for (const currencyId of currencyOrder) {
+    const data = dataByWeek.get(currencyId)
+    result.set(currencyId, data?.[weekIndex] ?? 0)
+  }
+  return result
+}
+
+export function TimelinePanel({
+  timelineData,
+  config,
+  weekOptions,
+  startDate,
+  onWeeksChange,
+}: TimelinePanelProps) {
+  const weekDates = useMemo(
+    () => generateWeekDates(startDate, config.weeks),
+    [startDate, config.weeks]
+  )
+
+  return (
+    <div className="bg-slate-800/30 rounded-lg border border-slate-700/50">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-slate-700/50">
+        <h2 className="text-sm font-semibold text-slate-200">Timeline</h2>
+        <div className="flex gap-1">
+          {weekOptions.map((weeks) => (
+            <Button
+              key={weeks}
+              size="compact"
+              variant="outline"
+              selected={config.weeks === weeks}
+              onClick={() => onWeeksChange(weeks)}
+              className="px-2 py-1 text-xs"
+            >
+              {weeks}w
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      <div className="overflow-x-auto">
+        {/* Income/Balance grid */}
+        <div className="flex">
+          <TimelineRowLabels width={LABEL_WIDTH} />
+          {weekDates.map((date, index) => (
+            <TimelineWeekColumn
+              key={index}
+              date={date}
+              incomes={getDataForWeek(index, CURRENCY_ORDER, timelineData.incomeByWeek)}
+              balances={getDataForWeek(index, CURRENCY_ORDER, timelineData.balancesByWeek)}
+              isCurrentWeek={index === 0}
+              width={COLUMN_WIDTH}
+            />
+          ))}
+        </div>
+
+        {/* Events grid with spanning support */}
+        <TimelineEventsGrid
+          events={timelineData.events}
+          weeks={config.weeks}
+          labelWidth={LABEL_WIDTH}
+          columnWidth={COLUMN_WIDTH}
+        />
+      </div>
+
+      {timelineData.unaffordableEvents.length > 0 && (
+        <div className="px-4 py-3 border-t border-slate-700/50 bg-red-500/10">
+          <div className="text-xs text-red-400">
+            <span className="font-medium">
+              {timelineData.unaffordableEvents.length} event(s) cannot be afforded
+            </span>
+            <span className="text-red-400/70 ml-2">within the {config.weeks}-week timeline:</span>
+          </div>
+          <div className="flex flex-wrap gap-2 mt-2">
+            {timelineData.unaffordableEvents.map((event) => (
+              <span key={event.id} className="text-xs px-2 py-0.5 rounded bg-red-500/20 text-red-300">
+                {event.name}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/features/spending-planner/timeline/timeline-row-labels.tsx
+++ b/src/features/spending-planner/timeline/timeline-row-labels.tsx
@@ -1,0 +1,52 @@
+/**
+ * Timeline Row Labels Component
+ *
+ * Left column showing row labels for income, balance, and events.
+ */
+
+import { cn } from '@/shared/lib/utils'
+import { CURRENCY_ORDER, getCurrencyConfig } from '../currencies/currency-config'
+
+interface TimelineRowLabelsProps {
+  width: number
+}
+
+export function TimelineRowLabels({ width }: TimelineRowLabelsProps) {
+  return (
+    <div
+      className="flex flex-col shrink-0 border-r border-slate-700/50"
+      style={{ width }}
+    >
+      {/* Empty header cell */}
+      <div className="py-1.5 border-b border-slate-700/50 text-xs text-slate-400 px-2 font-medium">
+        Week
+      </div>
+
+      {/* Income labels */}
+      <div className="px-2 py-1.5 border-b border-slate-700/30 space-y-0.5">
+        <div className="text-xs text-slate-400 font-medium">Income</div>
+        {CURRENCY_ORDER.map((currencyId) => {
+          const currencyConfig = getCurrencyConfig(currencyId)
+          return (
+            <div key={currencyId} className={cn('text-xs pl-2', currencyConfig.color)}>
+              {currencyConfig.displayName}
+            </div>
+          )
+        })}
+      </div>
+
+      {/* Balance labels */}
+      <div className="px-2 py-1.5 space-y-0.5">
+        <div className="text-xs text-slate-400 font-medium">Balance</div>
+        {CURRENCY_ORDER.map((currencyId) => {
+          const currencyConfig = getCurrencyConfig(currencyId)
+          return (
+            <div key={currencyId} className={cn('text-xs pl-2', currencyConfig.color)}>
+              {currencyConfig.displayName}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/features/spending-planner/timeline/timeline-utils.test.ts
+++ b/src/features/spending-planner/timeline/timeline-utils.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest'
+import {
+  generateWeekDates,
+  daysBetween,
+  isDateInWeek,
+  durationToWeeks,
+  getWeekStart,
+  formatDateRange,
+} from './timeline-utils'
+
+describe('timeline-utils', () => {
+  describe('generateWeekDates', () => {
+    it('should generate correct number of week dates', () => {
+      const start = new Date(2025, 0, 1)
+      const dates = generateWeekDates(start, 4)
+
+      expect(dates).toHaveLength(4)
+    })
+
+    it('should space dates 7 days apart', () => {
+      const start = new Date(2025, 0, 1)
+      const dates = generateWeekDates(start, 3)
+
+      expect(dates[0].getDate()).toBe(1)
+      expect(dates[1].getDate()).toBe(8)
+      expect(dates[2].getDate()).toBe(15)
+    })
+
+    it('should handle empty weeks', () => {
+      const start = new Date(2025, 0, 1)
+      const dates = generateWeekDates(start, 0)
+
+      expect(dates).toHaveLength(0)
+    })
+  })
+
+  describe('daysBetween', () => {
+    it('should return 0 for same date', () => {
+      const date = new Date(2025, 0, 1)
+      expect(daysBetween(date, date)).toBe(0)
+    })
+
+    it('should return correct number of days', () => {
+      const start = new Date(2025, 0, 1)
+      const end = new Date(2025, 0, 15)
+      expect(daysBetween(start, end)).toBe(14)
+    })
+
+    it('should handle month boundaries', () => {
+      const start = new Date(2025, 0, 25)
+      const end = new Date(2025, 1, 5)
+      expect(daysBetween(start, end)).toBe(11)
+    })
+  })
+
+  describe('isDateInWeek', () => {
+    const weekStart = new Date(2025, 0, 6) // Monday
+
+    it('should return true for first day of week', () => {
+      const date = new Date(2025, 0, 6)
+      expect(isDateInWeek(date, weekStart)).toBe(true)
+    })
+
+    it('should return true for mid-week day', () => {
+      const date = new Date(2025, 0, 9)
+      expect(isDateInWeek(date, weekStart)).toBe(true)
+    })
+
+    it('should return true for last day of week', () => {
+      const date = new Date(2025, 0, 12)
+      expect(isDateInWeek(date, weekStart)).toBe(true)
+    })
+
+    it('should return false for next week', () => {
+      const date = new Date(2025, 0, 13)
+      expect(isDateInWeek(date, weekStart)).toBe(false)
+    })
+
+    it('should return false for previous week', () => {
+      const date = new Date(2025, 0, 5)
+      expect(isDateInWeek(date, weekStart)).toBe(false)
+    })
+  })
+
+  describe('durationToWeeks', () => {
+    it('should return 1 for 1-7 days', () => {
+      expect(durationToWeeks(1)).toBe(1)
+      expect(durationToWeeks(7)).toBe(1)
+    })
+
+    it('should return 2 for 8-14 days', () => {
+      expect(durationToWeeks(8)).toBe(2)
+      expect(durationToWeeks(14)).toBe(2)
+    })
+
+    it('should round up partial weeks', () => {
+      expect(durationToWeeks(10)).toBe(2)
+      expect(durationToWeeks(15)).toBe(3)
+    })
+
+    it('should handle 0 days', () => {
+      expect(durationToWeeks(0)).toBe(0)
+    })
+  })
+
+  describe('getWeekStart', () => {
+    it('should return Monday for a Monday', () => {
+      const monday = new Date(2025, 0, 6) // Monday
+      const result = getWeekStart(monday)
+      expect(result.getDate()).toBe(6)
+    })
+
+    it('should return previous Monday for mid-week date', () => {
+      const wednesday = new Date(2025, 0, 8) // Wednesday
+      const result = getWeekStart(wednesday)
+      expect(result.getDate()).toBe(6) // Previous Monday
+    })
+
+    it('should return previous Monday for Sunday', () => {
+      const sunday = new Date(2025, 0, 12) // Sunday
+      const result = getWeekStart(sunday)
+      expect(result.getDate()).toBe(6) // Previous Monday
+    })
+  })
+
+  describe('formatDateRange', () => {
+    it('should format a date range using locale-aware format', () => {
+      const start = new Date(2025, 0, 5)
+      const end = new Date(2025, 0, 15)
+      expect(formatDateRange(start, end)).toBe('Jan 5 - Jan 15')
+    })
+  })
+})

--- a/src/features/spending-planner/timeline/timeline-utils.ts
+++ b/src/features/spending-planner/timeline/timeline-utils.ts
@@ -1,0 +1,74 @@
+/**
+ * Timeline Utilities
+ *
+ * Helper functions for timeline date calculations and formatting.
+ */
+
+import { formatDisplayMonthDay } from '@/shared/formatting/date-formatters'
+
+/**
+ * Generate an array of week start dates for the timeline.
+ *
+ * @param startDate - Starting date (week 0)
+ * @param weeks - Number of weeks to generate
+ */
+export function generateWeekDates(startDate: Date, weeks: number): Date[] {
+  const dates: Date[] = []
+  for (let i = 0; i < weeks; i++) {
+    const date = new Date(startDate)
+    date.setDate(date.getDate() + i * 7)
+    dates.push(date)
+  }
+  return dates
+}
+
+/**
+ * Get the number of days between two dates.
+ */
+export function daysBetween(start: Date, end: Date): number {
+  const diffMs = end.getTime() - start.getTime()
+  return Math.floor(diffMs / (1000 * 60 * 60 * 24))
+}
+
+/**
+ * Check if a date falls within a week range.
+ *
+ * @param date - Date to check
+ * @param weekStart - Start of the week
+ * @returns true if date is within the 7-day week starting at weekStart
+ */
+export function isDateInWeek(date: Date, weekStart: Date): boolean {
+  const weekEnd = new Date(weekStart)
+  weekEnd.setDate(weekEnd.getDate() + 7)
+  return date >= weekStart && date < weekEnd
+}
+
+/**
+ * Calculate how many weeks an event spans.
+ *
+ * @param durationDays - Duration in days
+ * @returns Number of weeks (rounded up)
+ */
+export function durationToWeeks(durationDays: number): number {
+  return Math.ceil(durationDays / 7)
+}
+
+/**
+ * Get start of week (Monday) for a given date.
+ */
+export function getWeekStart(date: Date): Date {
+  const result = new Date(date)
+  const day = result.getDay()
+  // Adjust to Monday (day 1), handling Sunday (day 0)
+  const diff = day === 0 ? -6 : 1 - day
+  result.setDate(result.getDate() + diff)
+  result.setHours(0, 0, 0, 0)
+  return result
+}
+
+/**
+ * Format a date range for display.
+ */
+export function formatDateRange(start: Date, end: Date): string {
+  return `${formatDisplayMonthDay(start)} - ${formatDisplayMonthDay(end)}`
+}

--- a/src/features/spending-planner/timeline/timeline-week-column.tsx
+++ b/src/features/spending-planner/timeline/timeline-week-column.tsx
@@ -1,0 +1,93 @@
+/**
+ * Timeline Week Column Component
+ *
+ * A single week column in the timeline showing:
+ * - Week header with date
+ * - Income for each currency
+ * - Balance for each currency
+ *
+ * Events are rendered separately in a grid overlay.
+ */
+
+import { cn } from '@/shared/lib/utils'
+import { formatLargeNumber } from '@/shared/formatting/number-scale'
+import { formatDisplayMonthDay } from '@/shared/formatting/date-formatters'
+import type { CurrencyId } from '../types'
+import { CURRENCY_ORDER, getCurrencyConfig } from '../currencies/currency-config'
+
+interface TimelineWeekColumnProps {
+  date: Date
+  incomes: Map<CurrencyId, number>
+  balances: Map<CurrencyId, number>
+  isCurrentWeek: boolean
+  width: number
+}
+
+export function TimelineWeekColumn({
+  date,
+  incomes,
+  balances,
+  isCurrentWeek,
+  width,
+}: TimelineWeekColumnProps) {
+  const dateLabel = formatDisplayMonthDay(date)
+
+  return (
+    <div
+      className={cn(
+        'flex flex-col shrink-0 border-r border-slate-700/30',
+        isCurrentWeek && 'bg-orange-500/5'
+      )}
+      style={{ width }}
+    >
+      {/* Header */}
+      <div
+        className={cn(
+          'text-center py-1.5 border-b border-slate-700/50 text-xs font-medium',
+          isCurrentWeek ? 'text-orange-400' : 'text-slate-400'
+        )}
+      >
+        {dateLabel}
+      </div>
+
+      {/* Income section */}
+      <div className="px-2 py-1.5 border-b border-slate-700/30 space-y-0.5">
+        {/* Empty row to align with "Income" label */}
+        <div className="text-xs text-transparent select-none">&nbsp;</div>
+        {CURRENCY_ORDER.map((currencyId) => {
+          const income = incomes.get(currencyId) ?? 0
+          const config = getCurrencyConfig(currencyId)
+          return (
+            <div
+              key={currencyId}
+              className={cn('text-xs text-right', config.color)}
+            >
+              +{formatLargeNumber(income)}
+            </div>
+          )
+        })}
+      </div>
+
+      {/* Balance section */}
+      <div className="px-2 py-1.5 space-y-0.5">
+        {/* Empty row to align with "Balance" label */}
+        <div className="text-xs text-transparent select-none">&nbsp;</div>
+        {CURRENCY_ORDER.map((currencyId) => {
+          const balance = balances.get(currencyId) ?? 0
+          const config = getCurrencyConfig(currencyId)
+          return (
+            <div
+              key={currencyId}
+              className={cn(
+                'text-xs text-right font-medium',
+                balance < 0 ? 'text-red-400' : config.color
+              )}
+            >
+              {formatLargeNumber(balance)}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/features/spending-planner/timeline/use-timeline-view.ts
+++ b/src/features/spending-planner/timeline/use-timeline-view.ts
@@ -1,0 +1,60 @@
+/**
+ * Timeline View Hook
+ *
+ * Manages timeline view state including week count and scroll position.
+ */
+
+import { useState, useCallback, useMemo } from 'react'
+import type { TimelineWeeks, TimelineViewConfig } from '../types'
+
+interface UseTimelineViewReturn {
+  /** Current timeline configuration */
+  config: TimelineViewConfig
+  /** Update week count */
+  setWeeks: (weeks: TimelineWeeks) => void
+  /** Available week options */
+  weekOptions: TimelineWeeks[]
+  /** Start date for timeline */
+  startDate: Date
+}
+
+interface UseTimelineViewProps {
+  initialConfig: TimelineViewConfig
+  onConfigChange: (config: TimelineViewConfig) => void
+}
+
+/**
+ * Hook for managing timeline view state.
+ */
+export function useTimelineView({
+  initialConfig,
+  onConfigChange,
+}: UseTimelineViewProps): UseTimelineViewReturn {
+  const [config, setConfig] = useState<TimelineViewConfig>(initialConfig)
+
+  const setWeeks = useCallback(
+    (weeks: TimelineWeeks) => {
+      const newConfig = { ...config, weeks }
+      setConfig(newConfig)
+      onConfigChange(newConfig)
+    },
+    [config, onConfigChange]
+  )
+
+  const weekOptions: TimelineWeeks[] = useMemo(() => [4, 8, 12, 26, 52], [])
+
+  // Start from the current week
+  const startDate = useMemo(() => {
+    const now = new Date()
+    // Round to start of current week
+    now.setHours(0, 0, 0, 0)
+    return now
+  }, [])
+
+  return {
+    config,
+    setWeeks,
+    weekOptions,
+    startDate,
+  }
+}

--- a/src/features/spending-planner/types.ts
+++ b/src/features/spending-planner/types.ts
@@ -1,0 +1,168 @@
+/**
+ * Spending Planner Types
+ *
+ * Core type definitions for the spending planner feature.
+ * Supports planning tower upgrades across multiple currencies.
+ */
+
+// =============================================================================
+// Currency System
+// =============================================================================
+
+/**
+ * Supported currency identifiers.
+ * Extensible enum - add new currencies here when needed.
+ * Using enum instead of union type for better type safety and refactoring support.
+ */
+export enum CurrencyId {
+  Coins = 'coins',
+  Stones = 'stones',
+}
+
+/**
+ * Configuration for a currency type.
+ * Each currency has unique display and input characteristics.
+ */
+export interface CurrencyConfig {
+  /** Unique identifier for the currency */
+  id: CurrencyId
+  /** Human-readable name (e.g., "Coins", "Stones") */
+  displayName: string
+  /** Short abbreviation for compact display (e.g., "c", "st") */
+  abbreviation: string
+  /** Tailwind color class for visual distinction */
+  color: string
+  /** Whether this currency needs a unit selector (K, M, B, T, etc.) */
+  hasUnitSelector: boolean
+}
+
+// =============================================================================
+// Income Configuration
+// =============================================================================
+
+/**
+ * Income configuration for a single currency.
+ * Tracks current balance and weekly income with growth projections.
+ */
+export interface CurrencyIncome {
+  /** Which currency this income belongs to */
+  currencyId: CurrencyId
+  /** Current balance of this currency */
+  currentBalance: number
+  /** Weekly income (sum of all sources) */
+  weeklyIncome: number
+  /** Weekly growth rate as a percentage (e.g., 5 for 5%) */
+  growthRatePercent: number
+}
+
+/**
+ * Breakdown of stone income sources.
+ * Stones come from multiple fixed sources per week.
+ */
+export interface StoneIncomeBreakdown {
+  /** Stones from weekly challenges (per week) */
+  weeklyChallenges: number
+  /** Stones from event store (per week) */
+  eventStore: number
+  /** Stones from tournament results (per week) */
+  tournamentResults: number
+}
+
+// =============================================================================
+// Spending Events
+// =============================================================================
+
+/**
+ * A planned spending event (upgrade, unlock, etc.).
+ * Events are processed in priority order.
+ */
+export interface SpendingEvent {
+  /** Unique identifier for the event */
+  id: string
+  /** User-defined name (e.g., "Unlock Damage Mastery") */
+  name: string
+  /** Which currency this event costs */
+  currencyId: CurrencyId
+  /** Cost amount in the specified currency */
+  amount: number
+  /** Optional duration in days (for labs) */
+  durationDays?: number
+  /** Priority order (lower = higher priority) */
+  priority: number
+}
+
+// =============================================================================
+// Timeline Results
+// =============================================================================
+
+/**
+ * Result of timeline calculation for a single event.
+ * Indicates when an event can be afforded and executed.
+ */
+export interface TimelineEvent {
+  /** The original spending event */
+  event: SpendingEvent
+  /** Week number when the event triggers (0 = current week) */
+  triggerWeek: number
+  /** Calculated date when the event triggers */
+  triggerDate: Date
+  /** End date for events with duration (labs) */
+  endDate?: Date
+  /** Balance of the relevant currency at trigger time */
+  balanceAtTrigger: number
+}
+
+/**
+ * Complete timeline calculation result.
+ * Contains projected balances and scheduled events.
+ */
+export interface TimelineData {
+  /** Timeline events with trigger dates */
+  events: TimelineEvent[]
+  /** Projected balance per week for each currency */
+  balancesByWeek: Map<CurrencyId, number[]>
+  /** Projected income per week for each currency (with growth applied) */
+  incomeByWeek: Map<CurrencyId, number[]>
+  /** Events that cannot be afforded within the timeline */
+  unaffordableEvents: SpendingEvent[]
+}
+
+// =============================================================================
+// Timeline View Configuration
+// =============================================================================
+
+/**
+ * Available timeline duration options in weeks.
+ */
+export type TimelineWeeks = 4 | 8 | 12 | 26 | 52
+
+/**
+ * Timeline view state configuration.
+ */
+export interface TimelineViewConfig {
+  /** Number of weeks to display */
+  weeks: TimelineWeeks
+}
+
+// =============================================================================
+// Persisted State
+// =============================================================================
+
+/**
+ * Complete spending planner state for persistence.
+ * This is what gets saved to localStorage.
+ */
+export interface SpendingPlannerState {
+  /** Income configuration per currency */
+  incomes: CurrencyIncome[]
+  /** Stone income breakdown (manual entry) */
+  stoneIncomeBreakdown: StoneIncomeBreakdown
+  /** Planned spending events in priority order */
+  events: SpendingEvent[]
+  /** Timeline view configuration */
+  timelineConfig: TimelineViewConfig
+  /** UI state: whether income panel is collapsed */
+  incomePanelCollapsed: boolean
+  /** Timestamp of last update */
+  lastUpdated: number
+}

--- a/src/features/spending-planner/use-spending-planner-state.ts
+++ b/src/features/spending-planner/use-spending-planner-state.ts
@@ -1,0 +1,161 @@
+/**
+ * Spending Planner State Hook
+ *
+ * Main orchestration hook that combines all state management
+ * for the spending planner feature.
+ */
+
+import { useState, useCallback, useMemo } from 'react'
+import type {
+  SpendingPlannerState,
+  CurrencyIncome,
+  StoneIncomeBreakdown,
+  TimelineViewConfig,
+  TimelineData,
+} from './types'
+import {
+  loadSpendingPlannerState,
+} from './persistence/spending-planner-persistence'
+import { useSpendingPlannerPersistence } from './persistence/use-spending-planner-persistence'
+import { useIncomeState } from './income/use-income-state'
+import { useEventQueue } from './events/use-event-queue'
+import { useTimelineView } from './timeline/use-timeline-view'
+import { calculateTimeline } from './calculations/timeline-calculator'
+import type { AddEventData, EditEventData } from './events/event-queue-panel'
+
+interface UseSpendingPlannerStateReturn {
+  /** Current state */
+  state: SpendingPlannerState
+  /** Timeline calculation result */
+  timelineData: TimelineData
+  /** Income state handlers */
+  income: ReturnType<typeof useIncomeState>
+  /** Event queue handlers */
+  eventQueue: ReturnType<typeof useEventQueue>
+  /** Timeline view handlers */
+  timeline: ReturnType<typeof useTimelineView>
+  /** Toggle income panel collapse */
+  toggleIncomePanel: () => void
+  /** Add a new event */
+  handleAddEvent: (data: AddEventData) => void
+  /** Remove an event */
+  handleRemoveEvent: (eventId: string) => void
+  /** Edit an event */
+  handleEditEvent: (data: EditEventData) => void
+  /** Clone an event */
+  handleCloneEvent: (eventId: string) => void
+  /** Handle drag drop completion */
+  handleDrop: () => void
+}
+
+/**
+ * Main hook for spending planner state management.
+ */
+export function useSpendingPlannerState(): UseSpendingPlannerStateReturn {
+  // Load initial state from localStorage
+  const [state, setState] = useState<SpendingPlannerState>(() =>
+    loadSpendingPlannerState()
+  )
+
+  // Auto-persist state changes
+  useSpendingPlannerPersistence(state)
+
+  // Income state management
+  const income = useIncomeState({
+    incomes: state.incomes,
+    stoneBreakdown: state.stoneIncomeBreakdown,
+    onIncomesChange: useCallback((incomes: CurrencyIncome[]) => {
+      setState((prev) => ({ ...prev, incomes }))
+    }, []),
+    onStoneBreakdownChange: useCallback((stoneIncomeBreakdown: StoneIncomeBreakdown) => {
+      setState((prev) => ({ ...prev, stoneIncomeBreakdown }))
+    }, []),
+  })
+
+  // Event queue state management
+  const eventQueue = useEventQueue()
+
+  // Timeline view state
+  const timeline = useTimelineView({
+    initialConfig: state.timelineConfig,
+    onConfigChange: useCallback((timelineConfig: TimelineViewConfig) => {
+      setState((prev) => ({ ...prev, timelineConfig }))
+    }, []),
+  })
+
+  // Toggle income panel collapse
+  const toggleIncomePanel = useCallback(() => {
+    setState((prev) => ({
+      ...prev,
+      incomePanelCollapsed: !prev.incomePanelCollapsed,
+    }))
+  }, [])
+
+  // Add event handler
+  const handleAddEvent = useCallback(
+    (data: AddEventData) => {
+      const newEvents = eventQueue.addEvent(state.events, data)
+      setState((prev) => ({ ...prev, events: newEvents }))
+    },
+    [eventQueue, state.events]
+  )
+
+  // Remove event handler
+  const handleRemoveEvent = useCallback(
+    (eventId: string) => {
+      const newEvents = eventQueue.removeEvent(state.events, eventId)
+      setState((prev) => ({ ...prev, events: newEvents }))
+    },
+    [eventQueue, state.events]
+  )
+
+  // Edit event handler
+  const handleEditEvent = useCallback(
+    (data: EditEventData) => {
+      const { eventId, ...updates } = data
+      const newEvents = eventQueue.updateEvent(state.events, eventId, updates)
+      setState((prev) => ({ ...prev, events: newEvents }))
+    },
+    [eventQueue, state.events]
+  )
+
+  // Clone event handler
+  const handleCloneEvent = useCallback(
+    (eventId: string) => {
+      const newEvents = eventQueue.cloneEvent(state.events, eventId)
+      setState((prev) => ({ ...prev, events: newEvents }))
+    },
+    [eventQueue, state.events]
+  )
+
+  // Handle drop (reorder) completion
+  const handleDrop = useCallback(() => {
+    const newEvents = eventQueue.handleDrop(state.events)
+    setState((prev) => ({ ...prev, events: newEvents }))
+    eventQueue.handleDragEnd()
+  }, [eventQueue, state.events])
+
+  // Calculate timeline
+  const timelineData = useMemo(() => {
+    return calculateTimeline(
+      state.incomes,
+      state.events,
+      state.timelineConfig.weeks,
+      timeline.startDate
+    )
+  }, [state.incomes, state.events, state.timelineConfig.weeks, timeline.startDate])
+
+  return {
+    state,
+    timelineData,
+    income,
+    eventQueue,
+    timeline,
+    toggleIncomePanel,
+    handleAddEvent,
+    handleRemoveEvent,
+    handleEditEvent,
+    handleCloneEvent,
+    handleDrop,
+  }
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as IndexRouteImport } from './routes/index'
 import { Route as SettingsIndexRouteImport } from './routes/settings/index'
 import { Route as RunsIndexRouteImport } from './routes/runs/index'
 import { Route as ChartsIndexRouteImport } from './routes/charts/index'
+import { Route as ToolsSpendingPlannerRouteImport } from './routes/tools/spending-planner'
 import { Route as ToolsModuleCalculatorRouteImport } from './routes/tools/module-calculator'
 import { Route as SettingsLocaleRouteImport } from './routes/settings/locale'
 import { Route as SettingsImportRouteImport } from './routes/settings/import'
@@ -73,6 +74,11 @@ const ChartsIndexRoute = ChartsIndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => ChartsRoute,
+} as any)
+const ToolsSpendingPlannerRoute = ToolsSpendingPlannerRouteImport.update({
+  id: '/spending-planner',
+  path: '/spending-planner',
+  getParentRoute: () => ToolsRoute,
 } as any)
 const ToolsModuleCalculatorRoute = ToolsModuleCalculatorRouteImport.update({
   id: '/module-calculator',
@@ -177,6 +183,7 @@ export interface FileRoutesByFullPath {
   '/settings/import': typeof SettingsImportRoute
   '/settings/locale': typeof SettingsLocaleRoute
   '/tools/module-calculator': typeof ToolsModuleCalculatorRoute
+  '/tools/spending-planner': typeof ToolsSpendingPlannerRoute
   '/charts/': typeof ChartsIndexRoute
   '/runs/': typeof RunsIndexRoute
   '/settings/': typeof SettingsIndexRoute
@@ -200,6 +207,7 @@ export interface FileRoutesByTo {
   '/settings/import': typeof SettingsImportRoute
   '/settings/locale': typeof SettingsLocaleRoute
   '/tools/module-calculator': typeof ToolsModuleCalculatorRoute
+  '/tools/spending-planner': typeof ToolsSpendingPlannerRoute
   '/charts': typeof ChartsIndexRoute
   '/runs': typeof RunsIndexRoute
   '/settings': typeof SettingsIndexRoute
@@ -227,6 +235,7 @@ export interface FileRoutesById {
   '/settings/import': typeof SettingsImportRoute
   '/settings/locale': typeof SettingsLocaleRoute
   '/tools/module-calculator': typeof ToolsModuleCalculatorRoute
+  '/tools/spending-planner': typeof ToolsSpendingPlannerRoute
   '/charts/': typeof ChartsIndexRoute
   '/runs/': typeof RunsIndexRoute
   '/settings/': typeof SettingsIndexRoute
@@ -255,6 +264,7 @@ export interface FileRouteTypes {
     | '/settings/import'
     | '/settings/locale'
     | '/tools/module-calculator'
+    | '/tools/spending-planner'
     | '/charts/'
     | '/runs/'
     | '/settings/'
@@ -278,6 +288,7 @@ export interface FileRouteTypes {
     | '/settings/import'
     | '/settings/locale'
     | '/tools/module-calculator'
+    | '/tools/spending-planner'
     | '/charts'
     | '/runs'
     | '/settings'
@@ -304,6 +315,7 @@ export interface FileRouteTypes {
     | '/settings/import'
     | '/settings/locale'
     | '/tools/module-calculator'
+    | '/tools/spending-planner'
     | '/charts/'
     | '/runs/'
     | '/settings/'
@@ -374,6 +386,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/charts/'
       preLoaderRoute: typeof ChartsIndexRouteImport
       parentRoute: typeof ChartsRoute
+    }
+    '/tools/spending-planner': {
+      id: '/tools/spending-planner'
+      path: '/spending-planner'
+      fullPath: '/tools/spending-planner'
+      preLoaderRoute: typeof ToolsSpendingPlannerRouteImport
+      parentRoute: typeof ToolsRoute
     }
     '/tools/module-calculator': {
       id: '/tools/module-calculator'
@@ -555,10 +574,12 @@ const SettingsRouteWithChildren = SettingsRoute._addFileChildren(
 
 interface ToolsRouteChildren {
   ToolsModuleCalculatorRoute: typeof ToolsModuleCalculatorRoute
+  ToolsSpendingPlannerRoute: typeof ToolsSpendingPlannerRoute
 }
 
 const ToolsRouteChildren: ToolsRouteChildren = {
   ToolsModuleCalculatorRoute: ToolsModuleCalculatorRoute,
+  ToolsSpendingPlannerRoute: ToolsSpendingPlannerRoute,
 }
 
 const ToolsRouteWithChildren = ToolsRoute._addFileChildren(ToolsRouteChildren)

--- a/src/routes/tools/spending-planner.tsx
+++ b/src/routes/tools/spending-planner.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { SpendingPlanner } from '@/features/spending-planner/spending-planner'
+
+export const Route = createFileRoute('/tools/spending-planner')({
+  component: SpendingPlannerPage,
+})
+
+function SpendingPlannerPage() {
+  return <SpendingPlanner />
+}

--- a/src/shared/formatting/number-scale.ts
+++ b/src/shared/formatting/number-scale.ts
@@ -16,7 +16,7 @@ import { getNumberFormatter, getImportFormat } from '@/shared/locale/locale-stor
  * All multipliers are exactly 1000x apart (powers of 10^3), which enables
  * O(1) lookup using: index = floor(log10(value) / 3) - 1
  */
-const SCALE_DEFINITIONS = [
+export const SCALE_DEFINITIONS = [
   { suffix: 'K', multiplier: 1e3 },   // Thousand
   { suffix: 'M', multiplier: 1e6 },   // Million
   { suffix: 'B', multiplier: 1e9 },   // Billion


### PR DESCRIPTION
## Summary
Players can now plan expensive tower upgrades using a new Spending Planner tool that visualizes when purchases become affordable. Instead of maintaining manual spreadsheets to track currency accumulation, users add spending events in priority order and see a Gantt-style timeline showing exactly which week each purchase will trigger based on projected income.

The tool supports coins (with unit selector for T/Q/etc scales) and stones (with manual income breakdown), configurable growth rates, and drag-drop priority reordering with instant timeline updates.

## Technical Details
- Added `spending-planner` feature with calculations for income projection and timeline scheduling
- Implemented currency configuration system designed for extensibility (coins, stones now; gems, cells later)
- Created event queue management with priority-based reordering using DnD Kit
- Built timeline calculator that enforces queue sequence (later events wait for earlier ones)
- Added comprehensive test coverage for income projection and timeline calculations
- Integrated into navigation with new planner icon and route
