### PR TITLE
IMPROVE: Add Reroll Shards and Gems currencies to Spending Planner

### DIFF
--- a/src/features/spending-planner/currencies/currency-config.test.ts
+++ b/src/features/spending-planner/currencies/currency-config.test.ts
@@ -2,12 +2,14 @@ import { describe, it, expect } from 'vitest'
 import {
   CURRENCY_CONFIGS,
   CURRENCY_ORDER,
+  CURRENCY_VISUAL_STYLES,
   getCurrencyConfig,
   getAllCurrencyConfigs,
   isValidCurrencyId,
   createDefaultIncome,
   createDefaultStoneBreakdown,
   calculateStoneIncome,
+  getCurrencyVisualStyles,
 } from './currency-config'
 import { CurrencyId } from '../types'
 
@@ -32,11 +34,37 @@ describe('currency-config', () => {
         hasUnitSelector: false,
       })
     })
+
+    it('should define reroll shards currency', () => {
+      expect(CURRENCY_CONFIGS[CurrencyId.RerollShards]).toEqual({
+        id: CurrencyId.RerollShards,
+        displayName: 'Reroll Shards',
+        timelineName: 'Shards',
+        abbreviation: 'rs',
+        color: 'text-blue-400',
+        hasUnitSelector: true,
+      })
+    })
+
+    it('should define gems currency', () => {
+      expect(CURRENCY_CONFIGS[CurrencyId.Gems]).toEqual({
+        id: CurrencyId.Gems,
+        displayName: 'Gems',
+        abbreviation: 'g',
+        color: 'text-purple-400',
+        hasUnitSelector: false,
+      })
+    })
   })
 
   describe('CURRENCY_ORDER', () => {
-    it('should have coins before stones', () => {
-      expect(CURRENCY_ORDER).toEqual([CurrencyId.Coins, CurrencyId.Stones])
+    it('should have all currencies in correct order', () => {
+      expect(CURRENCY_ORDER).toEqual([
+        CurrencyId.Coins,
+        CurrencyId.Stones,
+        CurrencyId.RerollShards,
+        CurrencyId.Gems,
+      ])
     })
   })
 
@@ -52,14 +80,28 @@ describe('currency-config', () => {
       expect(config.id).toBe(CurrencyId.Stones)
       expect(config.hasUnitSelector).toBe(false)
     })
+
+    it('should return reroll shards config', () => {
+      const config = getCurrencyConfig(CurrencyId.RerollShards)
+      expect(config.id).toBe(CurrencyId.RerollShards)
+      expect(config.hasUnitSelector).toBe(true)
+    })
+
+    it('should return gems config', () => {
+      const config = getCurrencyConfig(CurrencyId.Gems)
+      expect(config.id).toBe(CurrencyId.Gems)
+      expect(config.hasUnitSelector).toBe(false)
+    })
   })
 
   describe('getAllCurrencyConfigs', () => {
     it('should return all configs in order', () => {
       const configs = getAllCurrencyConfigs()
-      expect(configs).toHaveLength(2)
+      expect(configs).toHaveLength(4)
       expect(configs[0].id).toBe(CurrencyId.Coins)
       expect(configs[1].id).toBe(CurrencyId.Stones)
+      expect(configs[2].id).toBe(CurrencyId.RerollShards)
+      expect(configs[3].id).toBe(CurrencyId.Gems)
     })
   })
 
@@ -72,8 +114,16 @@ describe('currency-config', () => {
       expect(isValidCurrencyId(CurrencyId.Stones)).toBe(true)
     })
 
+    it('should return true for reroll shards', () => {
+      expect(isValidCurrencyId(CurrencyId.RerollShards)).toBe(true)
+    })
+
+    it('should return true for gems', () => {
+      expect(isValidCurrencyId(CurrencyId.Gems)).toBe(true)
+    })
+
     it('should return false for invalid currency', () => {
-      expect(isValidCurrencyId('gems')).toBe(false)
+      expect(isValidCurrencyId('gold')).toBe(false)
       expect(isValidCurrencyId('')).toBe(false)
       expect(isValidCurrencyId('invalid')).toBe(false)
     })
@@ -99,6 +149,26 @@ describe('currency-config', () => {
         growthRatePercent: 0,
       })
     })
+
+    it('should create default reroll shards income with 0% growth', () => {
+      const income = createDefaultIncome(CurrencyId.RerollShards)
+      expect(income).toEqual({
+        currencyId: CurrencyId.RerollShards,
+        currentBalance: 0,
+        weeklyIncome: 0,
+        growthRatePercent: 0,
+      })
+    })
+
+    it('should create default gems income with 0% growth', () => {
+      const income = createDefaultIncome(CurrencyId.Gems)
+      expect(income).toEqual({
+        currencyId: CurrencyId.Gems,
+        currentBalance: 0,
+        weeklyIncome: 0,
+        growthRatePercent: 0,
+      })
+    })
   })
 
   describe('createDefaultStoneBreakdown', () => {
@@ -108,6 +178,7 @@ describe('currency-config', () => {
         weeklyChallenges: 0,
         eventStore: 0,
         tournamentResults: 0,
+        purchasedWithMoney: 0,
       })
     })
   })
@@ -118,6 +189,7 @@ describe('currency-config', () => {
         weeklyChallenges: 60,
         eventStore: 0,
         tournamentResults: 200,
+        purchasedWithMoney: 0,
       }
       expect(calculateStoneIncome(breakdown)).toBe(260)
     })
@@ -132,8 +204,96 @@ describe('currency-config', () => {
         weeklyChallenges: 100,
         eventStore: 50,
         tournamentResults: 150,
+        purchasedWithMoney: 0,
       }
       expect(calculateStoneIncome(breakdown)).toBe(300)
+    })
+
+    it('should include purchased with money in total', () => {
+      const breakdown = {
+        weeklyChallenges: 100,
+        eventStore: 50,
+        tournamentResults: 100,
+        purchasedWithMoney: 50,
+      }
+      expect(calculateStoneIncome(breakdown)).toBe(300)
+    })
+  })
+
+  describe('CURRENCY_VISUAL_STYLES', () => {
+    it('should define visual styles for all currencies', () => {
+      expect(Object.keys(CURRENCY_VISUAL_STYLES)).toHaveLength(4)
+      expect(CURRENCY_VISUAL_STYLES[CurrencyId.Coins]).toBeDefined()
+      expect(CURRENCY_VISUAL_STYLES[CurrencyId.Stones]).toBeDefined()
+      expect(CURRENCY_VISUAL_STYLES[CurrencyId.RerollShards]).toBeDefined()
+      expect(CURRENCY_VISUAL_STYLES[CurrencyId.Gems]).toBeDefined()
+    })
+
+    it('should have all required style properties for each currency', () => {
+      for (const currencyId of CURRENCY_ORDER) {
+        const styles = CURRENCY_VISUAL_STYLES[currencyId]
+        expect(styles.borderLeft).toBeDefined()
+        expect(styles.bgGradient).toBeDefined()
+        expect(styles.timelineBorderLeft).toBeDefined()
+      }
+    })
+
+    it('should define coins visual styles', () => {
+      expect(CURRENCY_VISUAL_STYLES[CurrencyId.Coins]).toEqual({
+        borderLeft: 'border-l-yellow-400/40',
+        bgGradient: 'bg-gradient-to-r from-yellow-500/10 to-transparent',
+        timelineBorderLeft: 'border-l-2 border-l-yellow-400/50',
+      })
+    })
+
+    it('should define stones visual styles', () => {
+      expect(CURRENCY_VISUAL_STYLES[CurrencyId.Stones]).toEqual({
+        borderLeft: 'border-l-emerald-400/40',
+        bgGradient: 'bg-gradient-to-r from-emerald-500/10 to-transparent',
+        timelineBorderLeft: 'border-l-2 border-l-emerald-400/50',
+      })
+    })
+
+    it('should define reroll shards visual styles', () => {
+      expect(CURRENCY_VISUAL_STYLES[CurrencyId.RerollShards]).toEqual({
+        borderLeft: 'border-l-blue-400/40',
+        bgGradient: 'bg-gradient-to-r from-blue-500/10 to-transparent',
+        timelineBorderLeft: 'border-l-2 border-l-blue-400/50',
+      })
+    })
+
+    it('should define gems visual styles', () => {
+      expect(CURRENCY_VISUAL_STYLES[CurrencyId.Gems]).toEqual({
+        borderLeft: 'border-l-purple-400/40',
+        bgGradient: 'bg-gradient-to-r from-purple-500/10 to-transparent',
+        timelineBorderLeft: 'border-l-2 border-l-purple-400/50',
+      })
+    })
+  })
+
+  describe('getCurrencyVisualStyles', () => {
+    it('should return visual styles for coins', () => {
+      const styles = getCurrencyVisualStyles(CurrencyId.Coins)
+      expect(styles.borderLeft).toBe('border-l-yellow-400/40')
+      expect(styles.bgGradient).toContain('yellow')
+    })
+
+    it('should return visual styles for stones', () => {
+      const styles = getCurrencyVisualStyles(CurrencyId.Stones)
+      expect(styles.borderLeft).toBe('border-l-emerald-400/40')
+      expect(styles.bgGradient).toContain('emerald')
+    })
+
+    it('should return visual styles for reroll shards', () => {
+      const styles = getCurrencyVisualStyles(CurrencyId.RerollShards)
+      expect(styles.borderLeft).toBe('border-l-blue-400/40')
+      expect(styles.bgGradient).toContain('blue')
+    })
+
+    it('should return visual styles for gems', () => {
+      const styles = getCurrencyVisualStyles(CurrencyId.Gems)
+      expect(styles.borderLeft).toBe('border-l-purple-400/40')
+      expect(styles.bgGradient).toContain('purple')
     })
   })
 })

--- a/src/features/spending-planner/currencies/currency-config.ts
+++ b/src/features/spending-planner/currencies/currency-config.ts
@@ -6,7 +6,12 @@
  */
 
 import { CurrencyId } from '../types'
-import type { CurrencyConfig, CurrencyIncome, StoneIncomeBreakdown } from '../types'
+import type {
+  CurrencyConfig,
+  CurrencyIncome,
+  StoneIncomeBreakdown,
+  GemIncomeBreakdown,
+} from '../types'
 
 /**
  * Configuration for all supported currencies.
@@ -27,12 +32,32 @@ export const CURRENCY_CONFIGS: Record<CurrencyId, CurrencyConfig> = {
     color: 'text-emerald-400',
     hasUnitSelector: false,
   },
+  [CurrencyId.RerollShards]: {
+    id: CurrencyId.RerollShards,
+    displayName: 'Reroll Shards',
+    timelineName: 'Shards',
+    abbreviation: 'rs',
+    color: 'text-blue-400',
+    hasUnitSelector: true,
+  },
+  [CurrencyId.Gems]: {
+    id: CurrencyId.Gems,
+    displayName: 'Gems',
+    abbreviation: 'g',
+    color: 'text-purple-400',
+    hasUnitSelector: false,
+  },
 }
 
 /**
  * Ordered list of currency IDs for consistent display.
  */
-export const CURRENCY_ORDER: CurrencyId[] = [CurrencyId.Coins, CurrencyId.Stones]
+export const CURRENCY_ORDER: CurrencyId[] = [
+  CurrencyId.Coins,
+  CurrencyId.Stones,
+  CurrencyId.RerollShards,
+  CurrencyId.Gems,
+]
 
 /**
  * Get configuration for a specific currency.
@@ -75,6 +100,7 @@ export function createDefaultStoneBreakdown(): StoneIncomeBreakdown {
     weeklyChallenges: 0,
     eventStore: 0,
     tournamentResults: 0,
+    purchasedWithMoney: 0,
   }
 }
 
@@ -82,5 +108,150 @@ export function createDefaultStoneBreakdown(): StoneIncomeBreakdown {
  * Calculate total stone income from breakdown.
  */
 export function calculateStoneIncome(breakdown: StoneIncomeBreakdown): number {
-  return breakdown.weeklyChallenges + breakdown.eventStore + breakdown.tournamentResults
+  return (
+    breakdown.weeklyChallenges +
+    breakdown.eventStore +
+    breakdown.tournamentResults +
+    breakdown.purchasedWithMoney
+  )
+}
+
+/**
+ * Create default gem income breakdown.
+ */
+export function createDefaultGemBreakdown(): GemIncomeBreakdown {
+  return {
+    adGems: 0,
+    floatingGems: 0,
+    storeDailyGems: 0,
+    storeWeeklyGems: 0,
+    missionsDailyCompletion: 0,
+    missionsWeeklyChests: 0,
+    tournaments: 0,
+    biweeklyEventShop: 0,
+    guildWeeklyChests: 0,
+    guildSeasonalStore: 0,
+    offerWalls: 0,
+    purchasedWithMoney: 0,
+  }
+}
+
+/**
+ * Calculate total gem income from breakdown.
+ */
+export function calculateGemIncome(breakdown: GemIncomeBreakdown): number {
+  return (
+    breakdown.adGems +
+    breakdown.floatingGems +
+    breakdown.storeDailyGems +
+    breakdown.storeWeeklyGems +
+    breakdown.missionsDailyCompletion +
+    breakdown.missionsWeeklyChests +
+    breakdown.tournaments +
+    breakdown.biweeklyEventShop +
+    breakdown.guildWeeklyChests +
+    breakdown.guildSeasonalStore +
+    breakdown.offerWalls +
+    breakdown.purchasedWithMoney
+  )
+}
+
+// =============================================================================
+// Currency Visual Styles
+// =============================================================================
+
+/**
+ * Visual styling classes for currency display in various contexts.
+ * Centralized here to ensure consistency when colors change or currencies are added.
+ */
+interface CurrencyVisualStyles {
+  /** Subtle left border for card/section styling */
+  borderLeft: string
+  /** Subtle background gradient from currency color */
+  bgGradient: string
+  /** Left border accent for timeline pills */
+  timelineBorderLeft: string
+}
+
+/**
+ * Visual style mappings for all currencies.
+ * Derived from base color in CURRENCY_CONFIGS for consistency.
+ */
+export const CURRENCY_VISUAL_STYLES: Record<CurrencyId, CurrencyVisualStyles> = {
+  [CurrencyId.Coins]: {
+    borderLeft: 'border-l-yellow-400/40',
+    bgGradient: 'bg-gradient-to-r from-yellow-500/10 to-transparent',
+    timelineBorderLeft: 'border-l-2 border-l-yellow-400/50',
+  },
+  [CurrencyId.Stones]: {
+    borderLeft: 'border-l-emerald-400/40',
+    bgGradient: 'bg-gradient-to-r from-emerald-500/10 to-transparent',
+    timelineBorderLeft: 'border-l-2 border-l-emerald-400/50',
+  },
+  [CurrencyId.RerollShards]: {
+    borderLeft: 'border-l-blue-400/40',
+    bgGradient: 'bg-gradient-to-r from-blue-500/10 to-transparent',
+    timelineBorderLeft: 'border-l-2 border-l-blue-400/50',
+  },
+  [CurrencyId.Gems]: {
+    borderLeft: 'border-l-purple-400/40',
+    bgGradient: 'bg-gradient-to-r from-purple-500/10 to-transparent',
+    timelineBorderLeft: 'border-l-2 border-l-purple-400/50',
+  },
+}
+
+/**
+ * Get visual styles for a specific currency.
+ */
+export function getCurrencyVisualStyles(currencyId: CurrencyId): CurrencyVisualStyles {
+  return CURRENCY_VISUAL_STYLES[currencyId]
+}
+
+// =============================================================================
+// Currency Enable/Disable Logic
+// =============================================================================
+
+/**
+ * Toggle a currency's enabled state.
+ * Prevents disabling all currencies - at least one must remain enabled.
+ *
+ * @param enabledCurrencies - Current list of enabled currency IDs
+ * @param currencyId - Currency to toggle
+ * @returns Updated list of enabled currencies, or original if toggle would leave none enabled
+ */
+export function toggleCurrencyEnabled(
+  enabledCurrencies: CurrencyId[],
+  currencyId: CurrencyId
+): CurrencyId[] {
+  const isCurrentlyEnabled = enabledCurrencies.includes(currencyId)
+
+  if (isCurrentlyEnabled) {
+    // Prevent disabling if this is the last enabled currency
+    if (enabledCurrencies.length <= 1) {
+      return enabledCurrencies
+    }
+    return enabledCurrencies.filter((id) => id !== currencyId)
+  } else {
+    // Enable the currency, maintaining CURRENCY_ORDER
+    return CURRENCY_ORDER.filter(
+      (id) => id === currencyId || enabledCurrencies.includes(id)
+    )
+  }
+}
+
+/**
+ * Check if a currency is enabled.
+ */
+export function isCurrencyEnabled(
+  enabledCurrencies: CurrencyId[],
+  currencyId: CurrencyId
+): boolean {
+  return enabledCurrencies.includes(currencyId)
+}
+
+/**
+ * Get enabled currencies in display order.
+ */
+export function getEnabledCurrenciesInOrder(enabledCurrencies: CurrencyId[]): CurrencyId[] {
+  return CURRENCY_ORDER.filter((id) => enabledCurrencies.includes(id))
 }

--- a/src/features/spending-planner/currencies/currency-enabled.test.ts
+++ b/src/features/spending-planner/currencies/currency-enabled.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest'
+import {
+  CURRENCY_ORDER,
+  toggleCurrencyEnabled,
+  isCurrencyEnabled,
+  getEnabledCurrenciesInOrder,
+} from './currency-config'
+import { CurrencyId } from '../types'
+
+describe('currency-enabled', () => {
+  describe('toggleCurrencyEnabled', () => {
+    it('should disable an enabled currency', () => {
+      const enabled = [CurrencyId.Coins, CurrencyId.Stones, CurrencyId.Gems]
+      const result = toggleCurrencyEnabled(enabled, CurrencyId.Stones)
+      expect(result).toEqual([CurrencyId.Coins, CurrencyId.Gems])
+    })
+
+    it('should enable a disabled currency', () => {
+      const enabled = [CurrencyId.Coins, CurrencyId.Gems]
+      const result = toggleCurrencyEnabled(enabled, CurrencyId.Stones)
+      // Should maintain CURRENCY_ORDER
+      expect(result).toEqual([CurrencyId.Coins, CurrencyId.Stones, CurrencyId.Gems])
+    })
+
+    it('should not disable the last enabled currency', () => {
+      const enabled = [CurrencyId.Coins]
+      const result = toggleCurrencyEnabled(enabled, CurrencyId.Coins)
+      expect(result).toEqual([CurrencyId.Coins])
+    })
+
+    it('should maintain CURRENCY_ORDER when enabling', () => {
+      const enabled = [CurrencyId.Gems]
+      const result = toggleCurrencyEnabled(enabled, CurrencyId.Coins)
+      expect(result).toEqual([CurrencyId.Coins, CurrencyId.Gems])
+    })
+
+    it('should handle enabling RerollShards in correct order', () => {
+      const enabled = [CurrencyId.Coins, CurrencyId.Gems]
+      const result = toggleCurrencyEnabled(enabled, CurrencyId.RerollShards)
+      expect(result).toEqual([CurrencyId.Coins, CurrencyId.RerollShards, CurrencyId.Gems])
+    })
+  })
+
+  describe('isCurrencyEnabled', () => {
+    it('should return true for enabled currency', () => {
+      const enabled = [CurrencyId.Coins, CurrencyId.Stones]
+      expect(isCurrencyEnabled(enabled, CurrencyId.Coins)).toBe(true)
+      expect(isCurrencyEnabled(enabled, CurrencyId.Stones)).toBe(true)
+    })
+
+    it('should return false for disabled currency', () => {
+      const enabled = [CurrencyId.Coins, CurrencyId.Stones]
+      expect(isCurrencyEnabled(enabled, CurrencyId.Gems)).toBe(false)
+      expect(isCurrencyEnabled(enabled, CurrencyId.RerollShards)).toBe(false)
+    })
+
+    it('should return false for empty enabled list', () => {
+      const enabled: CurrencyId[] = []
+      expect(isCurrencyEnabled(enabled, CurrencyId.Coins)).toBe(false)
+    })
+  })
+
+  describe('getEnabledCurrenciesInOrder', () => {
+    it('should return enabled currencies in CURRENCY_ORDER', () => {
+      const enabled = [CurrencyId.Gems, CurrencyId.Coins, CurrencyId.Stones]
+      const result = getEnabledCurrenciesInOrder(enabled)
+      expect(result).toEqual([CurrencyId.Coins, CurrencyId.Stones, CurrencyId.Gems])
+    })
+
+    it('should filter out non-enabled currencies', () => {
+      const enabled = [CurrencyId.Coins, CurrencyId.Gems]
+      const result = getEnabledCurrenciesInOrder(enabled)
+      expect(result).toEqual([CurrencyId.Coins, CurrencyId.Gems])
+      expect(result).not.toContain(CurrencyId.Stones)
+      expect(result).not.toContain(CurrencyId.RerollShards)
+    })
+
+    it('should return empty array for empty input', () => {
+      const enabled: CurrencyId[] = []
+      const result = getEnabledCurrenciesInOrder(enabled)
+      expect(result).toEqual([])
+    })
+
+    it('should return all currencies in order when all enabled', () => {
+      const enabled = [...CURRENCY_ORDER]
+      const result = getEnabledCurrenciesInOrder(enabled)
+      expect(result).toEqual(CURRENCY_ORDER)
+    })
+  })
+})

--- a/src/features/spending-planner/events/add-event-dialog.tsx
+++ b/src/features/spending-planner/events/add-event-dialog.tsx
@@ -4,7 +4,7 @@
  * Dialog for adding new spending events to the queue.
  */
 
-import { useState } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 import {
   Dialog,
   DialogContent,
@@ -15,24 +15,36 @@ import {
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { CurrencyId } from '../types'
-import { getAllCurrencyConfigs } from '../currencies/currency-config'
+import type { CurrencyConfig } from '../types'
 import { AddEventForm, SCALE_OPTIONS } from './add-event-form'
 
 interface AddEventDialogProps {
   isOpen: boolean
+  currencies: CurrencyConfig[]
   onClose: () => void
   onAdd: (name: string, currencyId: CurrencyId, amount: number, durationDays?: number) => void
 }
 
-export function AddEventDialog({ isOpen, onClose, onAdd }: AddEventDialogProps) {
+export function AddEventDialog({ isOpen, currencies, onClose, onAdd }: AddEventDialogProps) {
   const [name, setName] = useState('')
   const [currencyId, setCurrencyId] = useState<CurrencyId>(CurrencyId.Coins)
   const [amountValue, setAmountValue] = useState('')
   const [amountScale, setAmountScale] = useState('T')
   const [durationDays, setDurationDays] = useState('')
 
-  const currencies = getAllCurrencyConfigs()
-  const selectedCurrency = currencies.find((c) => c.id === currencyId)!
+  // When dialog opens, ensure selected currency is valid (in case it was disabled)
+  useEffect(() => {
+    if (isOpen && currencies.length > 0) {
+      const isCurrentValid = currencies.some((c) => c.id === currencyId)
+      if (!isCurrentValid) {
+        setCurrencyId(currencies[0].id)
+      }
+    }
+  }, [isOpen, currencies, currencyId])
+
+  const selectedCurrency = useMemo(() => {
+    return currencies.find((c) => c.id === currencyId) ?? currencies[0]
+  }, [currencies, currencyId])
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()

--- a/src/features/spending-planner/events/edit-event-dialog.tsx
+++ b/src/features/spending-planner/events/edit-event-dialog.tsx
@@ -15,8 +15,7 @@ import {
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { CurrencyId } from '../types'
-import type { SpendingEvent } from '../types'
-import { getAllCurrencyConfigs } from '../currencies/currency-config'
+import type { SpendingEvent, CurrencyConfig } from '../types'
 import { AddEventForm } from './add-event-form'
 import { getDisplayValueAndScale, calculateFinalAmount, parseDurationDays } from './event-form-utils'
 
@@ -30,20 +29,22 @@ interface SaveEventData {
 
 interface EditEventDialogProps {
   event: SpendingEvent | null
+  currencies: CurrencyConfig[]
   isOpen: boolean
   onClose: () => void
   onSave: (data: SaveEventData) => void
 }
 
-export function EditEventDialog({ event, isOpen, onClose, onSave }: EditEventDialogProps) {
+export function EditEventDialog({ event, currencies, isOpen, onClose, onSave }: EditEventDialogProps) {
   const [name, setName] = useState('')
   const [currencyId, setCurrencyId] = useState<CurrencyId>(CurrencyId.Coins)
   const [amountValue, setAmountValue] = useState('')
   const [amountScale, setAmountScale] = useState('T')
   const [durationDays, setDurationDays] = useState('')
 
-  const currencies = useMemo(() => getAllCurrencyConfigs(), [])
-  const selectedCurrency = currencies.find((c) => c.id === currencyId)!
+  const selectedCurrency = useMemo(() => {
+    return currencies.find((c) => c.id === currencyId) ?? currencies[0]
+  }, [currencies, currencyId])
 
   // Populate form when event changes
   useEffect(() => {

--- a/src/features/spending-planner/events/event-pill.tsx
+++ b/src/features/spending-planner/events/event-pill.tsx
@@ -7,7 +7,7 @@
 import { cn } from '@/shared/lib/utils'
 import { formatLargeNumber } from '@/shared/formatting/number-scale'
 import type { SpendingEvent } from '../types'
-import { getCurrencyConfig } from '../currencies/currency-config'
+import { getCurrencyConfig, getCurrencyVisualStyles } from '../currencies/currency-config'
 import { EventPillActions } from './event-pill-actions'
 import { createEventDragHandlers, createEventActionHandlers } from './event-pill-handlers'
 
@@ -37,6 +37,7 @@ export function EventPill({
   onClone,
 }: EventPillProps) {
   const config = getCurrencyConfig(event.currencyId)
+  const visualStyles = getCurrencyVisualStyles(event.currencyId)
   const formattedAmount = formatLargeNumber(event.amount)
 
   const dragHandlers = createEventDragHandlers(index, onDragStart, onDragEnter)
@@ -67,8 +68,11 @@ export function EventPill({
         </svg>
       </div>
 
-      {/* Content area */}
-      <div className="flex-1 flex flex-col py-2 px-2 min-w-0">
+      {/* Content area with subtle currency color gradient */}
+      <div className={cn(
+        'flex-1 flex flex-col py-2 px-2 min-w-0 rounded-r-lg',
+        visualStyles.bgGradient
+      )}>
         <span className="text-sm text-slate-200 font-medium truncate">{event.name}</span>
         <span className={cn('text-xs mt-0.5', config.color)}>
           -{formattedAmount} {config.abbreviation}

--- a/src/features/spending-planner/events/event-queue-panel.tsx
+++ b/src/features/spending-planner/events/event-queue-panel.tsx
@@ -4,12 +4,14 @@
  * Panel displaying the draggable queue of spending events.
  */
 
-import { useState } from 'react'
+import { useState, useMemo } from 'react'
 import { Button } from '@/components/ui/button'
 import { EventPill } from './event-pill'
 import { AddEventDialog } from './add-event-dialog'
 import { EditEventDialog } from './edit-event-dialog'
 import type { SpendingEvent, CurrencyId } from '../types'
+import { getEnabledCurrenciesInOrder, getCurrencyConfig } from '../currencies/currency-config'
+import type { CurrencyConfig } from '../types'
 
 export interface AddEventData {
   name: string
@@ -24,6 +26,7 @@ export interface EditEventData extends AddEventData {
 
 interface EventQueuePanelProps {
   events: SpendingEvent[]
+  enabledCurrencies: CurrencyId[]
   draggedIndex: number | null
   draggedOverIndex: number | null
   onDragStart: (index: number) => void
@@ -37,6 +40,7 @@ interface EventQueuePanelProps {
 
 export function EventQueuePanel({
   events,
+  enabledCurrencies,
   draggedIndex,
   draggedOverIndex,
   onDragStart,
@@ -49,6 +53,11 @@ export function EventQueuePanel({
 }: EventQueuePanelProps) {
   const [isAddDialogOpen, setIsAddDialogOpen] = useState(false)
   const [editingEvent, setEditingEvent] = useState<SpendingEvent | null>(null)
+
+  // Get enabled currency configs in order
+  const enabledCurrencyConfigs = useMemo((): CurrencyConfig[] => {
+    return getEnabledCurrenciesInOrder(enabledCurrencies).map(getCurrencyConfig)
+  }, [enabledCurrencies])
 
   const handleEditClick = (event: SpendingEvent) => {
     setEditingEvent(event)
@@ -115,6 +124,7 @@ export function EventQueuePanel({
       {/* Add Event Dialog */}
       <AddEventDialog
         isOpen={isAddDialogOpen}
+        currencies={enabledCurrencyConfigs}
         onClose={() => setIsAddDialogOpen(false)}
         onAdd={handleAddEvent}
       />
@@ -122,6 +132,7 @@ export function EventQueuePanel({
       {/* Edit Event Dialog */}
       <EditEventDialog
         event={editingEvent}
+        currencies={enabledCurrencyConfigs}
         isOpen={editingEvent !== null}
         onClose={() => setEditingEvent(null)}
         onSave={handleEditSave}

--- a/src/features/spending-planner/income/currency-income-row.tsx
+++ b/src/features/spending-planner/income/currency-income-row.tsx
@@ -8,31 +8,38 @@
 import { useEffect, useState } from 'react'
 import { Input } from '@/components/ui/input'
 import { CurrencyId } from '../types'
-import type { CurrencyIncome, StoneIncomeBreakdown } from '../types'
+import type { CurrencyIncome, StoneIncomeBreakdown, GemIncomeBreakdown } from '../types'
 import { getCurrencyConfig } from '../currencies/currency-config'
 import { StoneIncomeBreakdown as StoneBreakdownComponent } from './stone-income-breakdown'
+import { GemIncomeBreakdown as GemBreakdownComponent } from './gem-income-breakdown'
 import { CurrencyInputField } from './currency-input-field'
 import { getBestScaleForValue } from './scale-detection'
 
 interface CurrencyIncomeRowProps {
   income: CurrencyIncome
   stoneBreakdown?: StoneIncomeBreakdown
+  gemBreakdown?: GemIncomeBreakdown
   onBalanceChange: (value: number) => void
   onWeeklyIncomeChange: (value: number) => void
   onGrowthRateChange: (value: number) => void
   onStoneBreakdownChange?: (field: keyof StoneIncomeBreakdown, value: number) => void
+  onGemBreakdownChange?: (field: keyof GemIncomeBreakdown, value: number) => void
 }
 
 export function CurrencyIncomeRow({
   income,
   stoneBreakdown,
+  gemBreakdown,
   onBalanceChange,
   onWeeklyIncomeChange,
   onGrowthRateChange,
   onStoneBreakdownChange,
+  onGemBreakdownChange,
 }: CurrencyIncomeRowProps) {
   const config = getCurrencyConfig(income.currencyId)
   const isStones = income.currencyId === CurrencyId.Stones
+  const isGems = income.currencyId === CurrencyId.Gems
+  const hasBreakdown = isStones || isGems
 
   const [balanceScale, setBalanceScale] = useState(() =>
     getBestScaleForValue(income.currentBalance)
@@ -55,9 +62,9 @@ export function CurrencyIncomeRow({
   }
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-3">
       {/* Main income fields in a consistent grid */}
-      <div className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-3 items-center">
+      <div className="grid grid-cols-[auto_1fr] gap-x-2 gap-y-2 items-center">
         {/* Balance row */}
         <span className="text-xs text-slate-400">Balance</span>
         <CurrencyInputField
@@ -68,8 +75,8 @@ export function CurrencyIncomeRow({
           onScaleChange={setBalanceScale}
         />
 
-        {/* Weekly Income row - for non-stones currencies */}
-        {!isStones && (
+        {/* Weekly Income row - for currencies without breakdown */}
+        {!hasBreakdown && (
           <>
             <span className="text-xs text-slate-400">Weekly</span>
             <CurrencyInputField
@@ -104,6 +111,15 @@ export function CurrencyIncomeRow({
           breakdown={stoneBreakdown}
           weeklyTotal={income.weeklyIncome}
           onUpdate={onStoneBreakdownChange}
+        />
+      )}
+
+      {/* Gem breakdown - shown only for gems, visually connected to Weekly */}
+      {isGems && gemBreakdown && onGemBreakdownChange && (
+        <GemBreakdownComponent
+          breakdown={gemBreakdown}
+          weeklyTotal={income.weeklyIncome}
+          onUpdate={onGemBreakdownChange}
         />
       )}
     </div>

--- a/src/features/spending-planner/income/gem-income-breakdown.tsx
+++ b/src/features/spending-planner/income/gem-income-breakdown.tsx
@@ -1,0 +1,94 @@
+/**
+ * Gem Income Breakdown Component
+ *
+ * Multi-field breakdown for gem income sources that computes the weekly total.
+ * Displays inputs for various gem sources with a clear visual connection
+ * showing these sum to the Weekly income.
+ */
+
+import { Input } from '@/components/ui/input'
+import type { GemIncomeBreakdown as BreakdownType } from '../types'
+
+interface GemIncomeBreakdownProps {
+  breakdown: BreakdownType
+  weeklyTotal: number
+  onUpdate: (field: keyof BreakdownType, value: number) => void
+}
+
+/** Configuration for gem income source fields */
+const GEM_SOURCE_FIELDS: Array<{ field: keyof BreakdownType; label: string }> = [
+  { field: 'adGems', label: 'Ad gems' },
+  { field: 'floatingGems', label: 'Floating Gems' },
+  { field: 'storeDailyGems', label: 'Store Free Daily gems' },
+  { field: 'storeWeeklyGems', label: 'Store Free Weekly gems (web)' },
+  { field: 'missionsDailyCompletion', label: 'Missions Daily completion' },
+  { field: 'missionsWeeklyChests', label: 'Missions Weekly Chests' },
+  { field: 'tournaments', label: 'Tournaments' },
+  { field: 'biweeklyEventShop', label: 'Biweekly Event Shop' },
+  { field: 'guildWeeklyChests', label: 'Guild Weekly Chests' },
+  { field: 'guildSeasonalStore', label: 'Guild Seasonal Store' },
+  { field: 'offerWalls', label: 'Offerwall/TapJoy' },
+  { field: 'purchasedWithMoney', label: 'Purchased (real money)' },
+]
+
+export function GemIncomeBreakdown({
+  breakdown,
+  weeklyTotal,
+  onUpdate,
+}: GemIncomeBreakdownProps) {
+  const handleChange = (field: keyof BreakdownType) => (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = parseFloat(e.target.value) || 0
+    onUpdate(field, value)
+  }
+
+  return (
+    <div className="bg-slate-800/30 rounded-lg p-3 border border-slate-700/40">
+      {/* Header with computed total */}
+      <div className="flex items-center justify-between mb-3">
+        <span className="text-xs font-medium text-slate-300">Weekly Income Sources</span>
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-slate-500">Total:</span>
+          <span className="text-sm font-medium text-purple-300 tabular-nums">
+            {weeklyTotal}
+          </span>
+          <span className="text-xs text-slate-500">/ week</span>
+        </div>
+      </div>
+
+      {/* Income source inputs in a clean grid */}
+      <div className="grid grid-cols-[1fr_auto] gap-x-3 gap-y-2 items-center">
+        {GEM_SOURCE_FIELDS.map(({ field, label }) => (
+          <BreakdownInputField
+            key={field}
+            label={label}
+            value={breakdown[field]}
+            onChange={handleChange(field)}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+/** Individual input field for a breakdown source */
+interface BreakdownInputFieldProps {
+  label: string
+  value: number
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
+}
+
+function BreakdownInputField({ label, value, onChange }: BreakdownInputFieldProps) {
+  return (
+    <>
+      <span className="text-xs text-slate-400">{label}</span>
+      <Input
+        type="number"
+        value={value || ''}
+        onChange={onChange}
+        className="w-20 h-7 text-right text-sm bg-slate-900/50"
+        placeholder="0"
+        min={0}
+      />
+    </>
+  )
+}

--- a/src/features/spending-planner/income/income-panel.tsx
+++ b/src/features/spending-planner/income/income-panel.tsx
@@ -6,31 +6,40 @@
  */
 
 import { CollapsibleCard } from '@/components/ui/collapsible-card'
+import { ToggleSwitch } from '@/components/ui/toggle-switch'
 import { CurrencyIncomeRow } from './currency-income-row'
 import { CurrencyId } from '../types'
-import type { CurrencyIncome, StoneIncomeBreakdown } from '../types'
-import { CURRENCY_ORDER, getCurrencyConfig } from '../currencies/currency-config'
+import type { CurrencyIncome, StoneIncomeBreakdown, GemIncomeBreakdown } from '../types'
+import { CURRENCY_ORDER, getCurrencyConfig, getCurrencyVisualStyles } from '../currencies/currency-config'
 
 interface IncomePanelProps {
   incomes: CurrencyIncome[]
   stoneBreakdown: StoneIncomeBreakdown
+  gemBreakdown: GemIncomeBreakdown
+  enabledCurrencies: CurrencyId[]
   isCollapsed: boolean
   onToggleCollapse: () => void
+  onToggleCurrency: (currencyId: CurrencyId) => void
   onBalanceChange: (currencyId: CurrencyId, value: number) => void
   onWeeklyIncomeChange: (currencyId: CurrencyId, value: number) => void
   onGrowthRateChange: (currencyId: CurrencyId, value: number) => void
   onStoneBreakdownChange: (field: keyof StoneIncomeBreakdown, value: number) => void
+  onGemBreakdownChange: (field: keyof GemIncomeBreakdown, value: number) => void
 }
 
 export function IncomePanel({
   incomes,
   stoneBreakdown,
+  gemBreakdown,
+  enabledCurrencies,
   isCollapsed,
   onToggleCollapse,
+  onToggleCurrency,
   onBalanceChange,
   onWeeklyIncomeChange,
   onGrowthRateChange,
   onStoneBreakdownChange,
+  onGemBreakdownChange,
 }: IncomePanelProps) {
   // Sort incomes by currency order
   const sortedIncomes = CURRENCY_ORDER.map((id) =>
@@ -43,25 +52,36 @@ export function IncomePanel({
       isExpanded={!isCollapsed}
       onToggle={onToggleCollapse}
     >
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
         {sortedIncomes.map((income) => {
           const config = getCurrencyConfig(income.currencyId)
           const isStones = income.currencyId === CurrencyId.Stones
+          const isGems = income.currencyId === CurrencyId.Gems
+          const isEnabled = enabledCurrencies.includes(income.currencyId)
+          const isLastEnabled = enabledCurrencies.length === 1 && isEnabled
 
           return (
             <CurrencySection
               key={income.currencyId}
               title={config.displayName}
               colorClass={config.color}
+              currencyId={income.currencyId}
+              isEnabled={isEnabled}
+              isLastEnabled={isLastEnabled}
+              onToggle={() => onToggleCurrency(income.currencyId)}
             >
-              <CurrencyIncomeRow
-                income={income}
-                stoneBreakdown={isStones ? stoneBreakdown : undefined}
-                onBalanceChange={(value) => onBalanceChange(income.currencyId, value)}
-                onWeeklyIncomeChange={(value) => onWeeklyIncomeChange(income.currencyId, value)}
-                onGrowthRateChange={(value) => onGrowthRateChange(income.currencyId, value)}
-                onStoneBreakdownChange={isStones ? onStoneBreakdownChange : undefined}
-              />
+              {isEnabled && (
+                <CurrencyIncomeRow
+                  income={income}
+                  stoneBreakdown={isStones ? stoneBreakdown : undefined}
+                  gemBreakdown={isGems ? gemBreakdown : undefined}
+                  onBalanceChange={(value) => onBalanceChange(income.currencyId, value)}
+                  onWeeklyIncomeChange={(value) => onWeeklyIncomeChange(income.currencyId, value)}
+                  onGrowthRateChange={(value) => onGrowthRateChange(income.currencyId, value)}
+                  onStoneBreakdownChange={isStones ? onStoneBreakdownChange : undefined}
+                  onGemBreakdownChange={isGems ? onGemBreakdownChange : undefined}
+                />
+              )}
             </CurrencySection>
           )
         })}
@@ -76,13 +96,39 @@ export function IncomePanel({
 interface CurrencySectionProps {
   title: string
   colorClass: string
+  currencyId: CurrencyId
+  isEnabled: boolean
+  isLastEnabled: boolean
+  onToggle: () => void
   children: React.ReactNode
 }
 
-function CurrencySection({ title, colorClass, children }: CurrencySectionProps) {
+function CurrencySection({
+  title,
+  colorClass,
+  currencyId,
+  isEnabled,
+  isLastEnabled,
+  onToggle,
+  children,
+}: CurrencySectionProps) {
+  const visualStyles = getCurrencyVisualStyles(currencyId)
+
   return (
-    <div className="bg-slate-900/40 rounded-lg border border-slate-700/30 p-4">
-      <h3 className={`text-sm font-semibold ${colorClass} mb-3`}>{title}</h3>
+    <div
+      className={`bg-slate-900/40 rounded-lg border border-slate-700/30 border-l-2 ${visualStyles.borderLeft} p-3 ${
+        !isEnabled ? 'opacity-60' : ''
+      }`}
+    >
+      <div className="flex items-center justify-between mb-2">
+        <h3 className={`text-sm font-semibold ${colorClass}`}>{title}</h3>
+        <ToggleSwitch
+          checked={isEnabled}
+          onCheckedChange={onToggle}
+          disabled={isLastEnabled}
+          aria-label={`${isEnabled ? 'Disable' : 'Enable'} ${title} tracking`}
+        />
+      </div>
       {children}
     </div>
   )

--- a/src/features/spending-planner/income/income-validation.test.ts
+++ b/src/features/spending-planner/income/income-validation.test.ts
@@ -112,6 +112,7 @@ describe('income-validation', () => {
         weeklyChallenges: 60,
         eventStore: 0,
         tournamentResults: 200,
+        purchasedWithMoney: 0,
       }
       const result = validateStoneBreakdown(breakdown)
       expect(result.isValid).toBe(true)
@@ -123,6 +124,7 @@ describe('income-validation', () => {
         weeklyChallenges: 0,
         eventStore: 0,
         tournamentResults: 0,
+        purchasedWithMoney: 0,
       }
       const result = validateStoneBreakdown(breakdown)
       expect(result.isValid).toBe(true)
@@ -133,6 +135,7 @@ describe('income-validation', () => {
         weeklyChallenges: -10,
         eventStore: 0,
         tournamentResults: 200,
+        purchasedWithMoney: 0,
       }
       const result = validateStoneBreakdown(breakdown)
       expect(result.isValid).toBe(false)
@@ -144,6 +147,7 @@ describe('income-validation', () => {
         weeklyChallenges: 60,
         eventStore: -50,
         tournamentResults: 200,
+        purchasedWithMoney: 0,
       }
       const result = validateStoneBreakdown(breakdown)
       expect(result.isValid).toBe(false)
@@ -155,6 +159,7 @@ describe('income-validation', () => {
         weeklyChallenges: 60,
         eventStore: 0,
         tournamentResults: -100,
+        purchasedWithMoney: 0,
       }
       const result = validateStoneBreakdown(breakdown)
       expect(result.isValid).toBe(false)

--- a/src/features/spending-planner/income/stone-income-breakdown.tsx
+++ b/src/features/spending-planner/income/stone-income-breakdown.tsx
@@ -2,7 +2,7 @@
  * Stone Income Breakdown Component
  *
  * Three-field breakdown for stone income sources that computes the weekly total.
- * Displays inputs for daily missions, event store, and tournament results
+ * Displays inputs for missions, event shop, tournaments, and purchased
  * with a clear visual connection showing these sum to the Weekly income.
  */
 
@@ -29,7 +29,7 @@ export function StoneIncomeBreakdown({
     <div className="bg-slate-800/30 rounded-lg p-3 border border-slate-700/40">
       {/* Header with computed total */}
       <div className="flex items-center justify-between mb-3">
-        <span className="text-xs text-slate-400">Weekly Income Sources</span>
+        <span className="text-xs font-medium text-slate-300">Weekly Income Sources</span>
         <div className="flex items-center gap-2">
           <span className="text-xs text-slate-500">Total:</span>
           <span className="text-sm font-medium text-emerald-300 tabular-nums">
@@ -41,7 +41,7 @@ export function StoneIncomeBreakdown({
 
       {/* Income source inputs in a clean grid */}
       <div className="grid grid-cols-[1fr_auto] gap-x-3 gap-y-2 items-center">
-        <span className="text-xs text-slate-400">Weekly challenges</span>
+        <span className="text-xs text-slate-400">Missions Weekly Chests</span>
         <Input
           type="number"
           value={breakdown.weeklyChallenges || ''}
@@ -51,7 +51,7 @@ export function StoneIncomeBreakdown({
           min={0}
         />
 
-        <span className="text-xs text-slate-400">Event store</span>
+        <span className="text-xs text-slate-400">Biweekly Event Shop</span>
         <Input
           type="number"
           value={breakdown.eventStore || ''}
@@ -61,11 +61,21 @@ export function StoneIncomeBreakdown({
           min={0}
         />
 
-        <span className="text-xs text-slate-400">Tournament results</span>
+        <span className="text-xs text-slate-400">Tournaments</span>
         <Input
           type="number"
           value={breakdown.tournamentResults || ''}
           onChange={handleChange('tournamentResults')}
+          className="w-20 h-7 text-right text-sm bg-slate-900/50"
+          placeholder="0"
+          min={0}
+        />
+
+        <span className="text-xs text-slate-400">Purchased (real money)</span>
+        <Input
+          type="number"
+          value={breakdown.purchasedWithMoney || ''}
+          onChange={handleChange('purchasedWithMoney')}
           className="w-20 h-7 text-right text-sm bg-slate-900/50"
           placeholder="0"
           min={0}

--- a/src/features/spending-planner/persistence/enabled-currencies-migration.test.ts
+++ b/src/features/spending-planner/persistence/enabled-currencies-migration.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { loadSpendingPlannerState } from './spending-planner-persistence'
+import { CurrencyId } from '../types'
+
+describe('enabledCurrencies migration', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('should migrate old state without enabledCurrencies to have all currencies enabled', () => {
+    const oldState = {
+      incomes: [
+        { currencyId: CurrencyId.Coins, currentBalance: 1000, weeklyIncome: 500, growthRatePercent: 5 },
+        { currencyId: CurrencyId.Stones, currentBalance: 200, weeklyIncome: 100, growthRatePercent: 0 },
+        { currencyId: CurrencyId.RerollShards, currentBalance: 0, weeklyIncome: 0, growthRatePercent: 0 },
+        { currencyId: CurrencyId.Gems, currentBalance: 0, weeklyIncome: 0, growthRatePercent: 0 },
+      ],
+      stoneIncomeBreakdown: { weeklyChallenges: 60, eventStore: 0, tournamentResults: 40, purchasedWithMoney: 0 },
+      gemIncomeBreakdown: {
+        adGems: 0, floatingGems: 0, storeDailyGems: 0, storeWeeklyGems: 0,
+        missionsDailyCompletion: 0, missionsWeeklyChests: 0, tournaments: 0,
+        biweeklyEventShop: 0, guildWeeklyChests: 0, guildSeasonalStore: 0,
+        offerWalls: 0, purchasedWithMoney: 0,
+      },
+      events: [],
+      timelineConfig: { weeks: 12 },
+      incomePanelCollapsed: false,
+      lastUpdated: Date.now(),
+      // Note: no enabledCurrencies field
+    }
+    localStorage.setItem('tower-tracking-spending-planner', JSON.stringify(oldState))
+
+    const loaded = loadSpendingPlannerState()
+    expect(loaded.enabledCurrencies).toEqual([
+      CurrencyId.Coins,
+      CurrencyId.Stones,
+      CurrencyId.RerollShards,
+      CurrencyId.Gems,
+    ])
+  })
+
+  it('should preserve existing enabledCurrencies when present', () => {
+    const stateWithEnabledCurrencies = {
+      incomes: [
+        { currencyId: CurrencyId.Coins, currentBalance: 0, weeklyIncome: 0, growthRatePercent: 5 },
+        { currencyId: CurrencyId.Stones, currentBalance: 0, weeklyIncome: 0, growthRatePercent: 0 },
+        { currencyId: CurrencyId.RerollShards, currentBalance: 0, weeklyIncome: 0, growthRatePercent: 0 },
+        { currencyId: CurrencyId.Gems, currentBalance: 0, weeklyIncome: 0, growthRatePercent: 0 },
+      ],
+      stoneIncomeBreakdown: { weeklyChallenges: 0, eventStore: 0, tournamentResults: 0, purchasedWithMoney: 0 },
+      gemIncomeBreakdown: {
+        adGems: 0, floatingGems: 0, storeDailyGems: 0, storeWeeklyGems: 0,
+        missionsDailyCompletion: 0, missionsWeeklyChests: 0, tournaments: 0,
+        biweeklyEventShop: 0, guildWeeklyChests: 0, guildSeasonalStore: 0,
+        offerWalls: 0, purchasedWithMoney: 0,
+      },
+      events: [],
+      timelineConfig: { weeks: 12 },
+      incomePanelCollapsed: false,
+      enabledCurrencies: [CurrencyId.Coins, CurrencyId.Gems],
+      lastUpdated: Date.now(),
+    }
+    localStorage.setItem('tower-tracking-spending-planner', JSON.stringify(stateWithEnabledCurrencies))
+
+    const loaded = loadSpendingPlannerState()
+    expect(loaded.enabledCurrencies).toEqual([CurrencyId.Coins, CurrencyId.Gems])
+  })
+
+  it('should filter out invalid currency IDs from enabledCurrencies', () => {
+    const stateWithInvalidCurrencies = {
+      incomes: [
+        { currencyId: CurrencyId.Coins, currentBalance: 0, weeklyIncome: 0, growthRatePercent: 5 },
+        { currencyId: CurrencyId.Stones, currentBalance: 0, weeklyIncome: 0, growthRatePercent: 0 },
+        { currencyId: CurrencyId.RerollShards, currentBalance: 0, weeklyIncome: 0, growthRatePercent: 0 },
+        { currencyId: CurrencyId.Gems, currentBalance: 0, weeklyIncome: 0, growthRatePercent: 0 },
+      ],
+      stoneIncomeBreakdown: { weeklyChallenges: 0, eventStore: 0, tournamentResults: 0, purchasedWithMoney: 0 },
+      gemIncomeBreakdown: {
+        adGems: 0, floatingGems: 0, storeDailyGems: 0, storeWeeklyGems: 0,
+        missionsDailyCompletion: 0, missionsWeeklyChests: 0, tournaments: 0,
+        biweeklyEventShop: 0, guildWeeklyChests: 0, guildSeasonalStore: 0,
+        offerWalls: 0, purchasedWithMoney: 0,
+      },
+      events: [],
+      timelineConfig: { weeks: 12 },
+      incomePanelCollapsed: false,
+      enabledCurrencies: [CurrencyId.Coins, 'invalid', CurrencyId.Gems],
+      lastUpdated: Date.now(),
+    }
+    localStorage.setItem('tower-tracking-spending-planner', JSON.stringify(stateWithInvalidCurrencies))
+
+    const loaded = loadSpendingPlannerState()
+    expect(loaded.enabledCurrencies).toEqual([CurrencyId.Coins, CurrencyId.Gems])
+  })
+
+  it('should default to all currencies when enabledCurrencies is empty after filtering', () => {
+    const stateWithAllInvalidCurrencies = {
+      incomes: [
+        { currencyId: CurrencyId.Coins, currentBalance: 0, weeklyIncome: 0, growthRatePercent: 5 },
+        { currencyId: CurrencyId.Stones, currentBalance: 0, weeklyIncome: 0, growthRatePercent: 0 },
+        { currencyId: CurrencyId.RerollShards, currentBalance: 0, weeklyIncome: 0, growthRatePercent: 0 },
+        { currencyId: CurrencyId.Gems, currentBalance: 0, weeklyIncome: 0, growthRatePercent: 0 },
+      ],
+      stoneIncomeBreakdown: { weeklyChallenges: 0, eventStore: 0, tournamentResults: 0, purchasedWithMoney: 0 },
+      gemIncomeBreakdown: {
+        adGems: 0, floatingGems: 0, storeDailyGems: 0, storeWeeklyGems: 0,
+        missionsDailyCompletion: 0, missionsWeeklyChests: 0, tournaments: 0,
+        biweeklyEventShop: 0, guildWeeklyChests: 0, guildSeasonalStore: 0,
+        offerWalls: 0, purchasedWithMoney: 0,
+      },
+      events: [],
+      timelineConfig: { weeks: 12 },
+      incomePanelCollapsed: false,
+      enabledCurrencies: ['invalid1', 'invalid2'],
+      lastUpdated: Date.now(),
+    }
+    localStorage.setItem('tower-tracking-spending-planner', JSON.stringify(stateWithAllInvalidCurrencies))
+
+    const loaded = loadSpendingPlannerState()
+    expect(loaded.enabledCurrencies).toEqual([
+      CurrencyId.Coins,
+      CurrencyId.Stones,
+      CurrencyId.RerollShards,
+      CurrencyId.Gems,
+    ])
+  })
+})

--- a/src/features/spending-planner/spending-planner.tsx
+++ b/src/features/spending-planner/spending-planner.tsx
@@ -18,6 +18,7 @@ export function SpendingPlanner() {
     eventQueue,
     timeline,
     toggleIncomePanel,
+    handleToggleCurrency,
     handleAddEvent,
     handleRemoveEvent,
     handleEditEvent,
@@ -39,17 +40,22 @@ export function SpendingPlanner() {
       <IncomePanel
         incomes={state.incomes}
         stoneBreakdown={state.stoneIncomeBreakdown}
+        gemBreakdown={state.gemIncomeBreakdown}
+        enabledCurrencies={state.enabledCurrencies}
         isCollapsed={state.incomePanelCollapsed}
         onToggleCollapse={toggleIncomePanel}
+        onToggleCurrency={handleToggleCurrency}
         onBalanceChange={income.updateBalance}
         onWeeklyIncomeChange={income.updateWeeklyIncome}
         onGrowthRateChange={income.updateGrowthRate}
         onStoneBreakdownChange={income.updateStoneBreakdown}
+        onGemBreakdownChange={income.updateGemBreakdown}
       />
 
       {/* Event Queue */}
       <EventQueuePanel
         events={state.events}
+        enabledCurrencies={state.enabledCurrencies}
         draggedIndex={eventQueue.draggedIndex}
         draggedOverIndex={eventQueue.draggedOverIndex}
         onDragStart={eventQueue.handleDragStart}
@@ -64,6 +70,7 @@ export function SpendingPlanner() {
       {/* Timeline Visualization */}
       <TimelinePanel
         timelineData={timelineData}
+        enabledCurrencies={state.enabledCurrencies}
         config={timeline.config}
         weekOptions={timeline.weekOptions}
         startDate={timeline.startDate}

--- a/src/features/spending-planner/timeline/timeline-event-pill.tsx
+++ b/src/features/spending-planner/timeline/timeline-event-pill.tsx
@@ -8,7 +8,7 @@
 import { cn } from '@/shared/lib/utils'
 import { formatLargeNumber } from '@/shared/formatting/number-scale'
 import type { TimelineEvent } from '../types'
-import { getCurrencyConfig } from '../currencies/currency-config'
+import { getCurrencyConfig, getCurrencyVisualStyles } from '../currencies/currency-config'
 import { durationToWeeks } from './timeline-utils'
 
 interface TimelineEventPillProps {
@@ -20,6 +20,7 @@ interface TimelineEventPillProps {
 export function TimelineEventPill({ timelineEvent, weekSpan = 1 }: TimelineEventPillProps) {
   const { event } = timelineEvent
   const config = getCurrencyConfig(event.currencyId)
+  const visualStyles = getCurrencyVisualStyles(event.currencyId)
   const formattedAmount = formatLargeNumber(event.amount)
 
   // Check if this event spans multiple weeks (for styling purposes)
@@ -31,6 +32,7 @@ export function TimelineEventPill({ timelineEvent, weekSpan = 1 }: TimelineEvent
         'flex flex-col p-1.5 rounded border text-xs h-full',
         'bg-slate-700/60 border-slate-600/50',
         'hover:bg-slate-600/60 transition-colors',
+        visualStyles.timelineBorderLeft,
         isSpanning && 'relative overflow-hidden'
       )}
       title={`${event.name}: ${formattedAmount} ${config.abbreviation}${event.durationDays ? ` (${event.durationDays} days)` : ''}`}

--- a/src/features/spending-planner/timeline/timeline-panel.tsx
+++ b/src/features/spending-planner/timeline/timeline-panel.tsx
@@ -7,7 +7,7 @@
 import { useMemo } from 'react'
 import { Button } from '@/components/ui/button'
 import type { TimelineData, TimelineViewConfig, TimelineWeeks, CurrencyId } from '../types'
-import { CURRENCY_ORDER } from '../currencies/currency-config'
+import { getEnabledCurrenciesInOrder } from '../currencies/currency-config'
 import { generateWeekDates } from './timeline-utils'
 import { TimelineWeekColumn } from './timeline-week-column'
 import { TimelineRowLabels } from './timeline-row-labels'
@@ -15,6 +15,7 @@ import { TimelineEventsGrid } from './timeline-events-grid'
 
 interface TimelinePanelProps {
   timelineData: TimelineData
+  enabledCurrencies: CurrencyId[]
   config: TimelineViewConfig
   weekOptions: TimelineWeeks[]
   startDate: Date
@@ -39,6 +40,7 @@ function getDataForWeek(
 
 export function TimelinePanel({
   timelineData,
+  enabledCurrencies,
   config,
   weekOptions,
   startDate,
@@ -47,6 +49,12 @@ export function TimelinePanel({
   const weekDates = useMemo(
     () => generateWeekDates(startDate, config.weeks),
     [startDate, config.weeks]
+  )
+
+  // Get enabled currencies in display order
+  const orderedEnabledCurrencies = useMemo(
+    () => getEnabledCurrenciesInOrder(enabledCurrencies),
+    [enabledCurrencies]
   )
 
   return (
@@ -72,13 +80,14 @@ export function TimelinePanel({
       <div className="overflow-x-auto">
         {/* Income/Balance grid */}
         <div className="flex">
-          <TimelineRowLabels width={LABEL_WIDTH} />
+          <TimelineRowLabels width={LABEL_WIDTH} enabledCurrencies={orderedEnabledCurrencies} />
           {weekDates.map((date, index) => (
             <TimelineWeekColumn
               key={index}
               date={date}
-              incomes={getDataForWeek(index, CURRENCY_ORDER, timelineData.incomeByWeek)}
-              balances={getDataForWeek(index, CURRENCY_ORDER, timelineData.balancesByWeek)}
+              incomes={getDataForWeek(index, orderedEnabledCurrencies, timelineData.incomeByWeek)}
+              balances={getDataForWeek(index, orderedEnabledCurrencies, timelineData.balancesByWeek)}
+              enabledCurrencies={orderedEnabledCurrencies}
               isCurrentWeek={index === 0}
               width={COLUMN_WIDTH}
             />

--- a/src/features/spending-planner/timeline/timeline-row-labels.tsx
+++ b/src/features/spending-planner/timeline/timeline-row-labels.tsx
@@ -5,13 +5,15 @@
  */
 
 import { cn } from '@/shared/lib/utils'
-import { CURRENCY_ORDER, getCurrencyConfig } from '../currencies/currency-config'
+import type { CurrencyId } from '../types'
+import { getCurrencyConfig } from '../currencies/currency-config'
 
 interface TimelineRowLabelsProps {
   width: number
+  enabledCurrencies: CurrencyId[]
 }
 
-export function TimelineRowLabels({ width }: TimelineRowLabelsProps) {
+export function TimelineRowLabels({ width, enabledCurrencies }: TimelineRowLabelsProps) {
   return (
     <div
       className="flex flex-col shrink-0 border-r border-slate-700/50"
@@ -25,11 +27,12 @@ export function TimelineRowLabels({ width }: TimelineRowLabelsProps) {
       {/* Income labels */}
       <div className="px-2 py-1.5 border-b border-slate-700/30 space-y-0.5">
         <div className="text-xs text-slate-400 font-medium">Income</div>
-        {CURRENCY_ORDER.map((currencyId) => {
+        {enabledCurrencies.map((currencyId) => {
           const currencyConfig = getCurrencyConfig(currencyId)
+          const displayName = currencyConfig.timelineName ?? currencyConfig.displayName
           return (
             <div key={currencyId} className={cn('text-xs pl-2', currencyConfig.color)}>
-              {currencyConfig.displayName}
+              {displayName}
             </div>
           )
         })}
@@ -38,11 +41,12 @@ export function TimelineRowLabels({ width }: TimelineRowLabelsProps) {
       {/* Balance labels */}
       <div className="px-2 py-1.5 space-y-0.5">
         <div className="text-xs text-slate-400 font-medium">Balance</div>
-        {CURRENCY_ORDER.map((currencyId) => {
+        {enabledCurrencies.map((currencyId) => {
           const currencyConfig = getCurrencyConfig(currencyId)
+          const displayName = currencyConfig.timelineName ?? currencyConfig.displayName
           return (
             <div key={currencyId} className={cn('text-xs pl-2', currencyConfig.color)}>
-              {currencyConfig.displayName}
+              {displayName}
             </div>
           )
         })}

--- a/src/features/spending-planner/timeline/timeline-week-column.tsx
+++ b/src/features/spending-planner/timeline/timeline-week-column.tsx
@@ -13,12 +13,13 @@ import { cn } from '@/shared/lib/utils'
 import { formatLargeNumber } from '@/shared/formatting/number-scale'
 import { formatDisplayMonthDay } from '@/shared/formatting/date-formatters'
 import type { CurrencyId } from '../types'
-import { CURRENCY_ORDER, getCurrencyConfig } from '../currencies/currency-config'
+import { getCurrencyConfig } from '../currencies/currency-config'
 
 interface TimelineWeekColumnProps {
   date: Date
   incomes: Map<CurrencyId, number>
   balances: Map<CurrencyId, number>
+  enabledCurrencies: CurrencyId[]
   isCurrentWeek: boolean
   width: number
 }
@@ -27,6 +28,7 @@ export function TimelineWeekColumn({
   date,
   incomes,
   balances,
+  enabledCurrencies,
   isCurrentWeek,
   width,
 }: TimelineWeekColumnProps) {
@@ -54,7 +56,7 @@ export function TimelineWeekColumn({
       <div className="px-2 py-1.5 border-b border-slate-700/30 space-y-0.5">
         {/* Empty row to align with "Income" label */}
         <div className="text-xs text-transparent select-none">&nbsp;</div>
-        {CURRENCY_ORDER.map((currencyId) => {
+        {enabledCurrencies.map((currencyId) => {
           const income = incomes.get(currencyId) ?? 0
           const config = getCurrencyConfig(currencyId)
           return (
@@ -72,7 +74,7 @@ export function TimelineWeekColumn({
       <div className="px-2 py-1.5 space-y-0.5">
         {/* Empty row to align with "Balance" label */}
         <div className="text-xs text-transparent select-none">&nbsp;</div>
-        {CURRENCY_ORDER.map((currencyId) => {
+        {enabledCurrencies.map((currencyId) => {
           const balance = balances.get(currencyId) ?? 0
           const config = getCurrencyConfig(currencyId)
           return (

--- a/src/features/spending-planner/types.ts
+++ b/src/features/spending-planner/types.ts
@@ -17,6 +17,8 @@
 export enum CurrencyId {
   Coins = 'coins',
   Stones = 'stones',
+  RerollShards = 'rerollShards',
+  Gems = 'gems',
 }
 
 /**
@@ -28,6 +30,8 @@ export interface CurrencyConfig {
   id: CurrencyId
   /** Human-readable name (e.g., "Coins", "Stones") */
   displayName: string
+  /** Shorter name for timeline display where space is limited (defaults to displayName) */
+  timelineName?: string
   /** Short abbreviation for compact display (e.g., "c", "st") */
   abbreviation: string
   /** Tailwind color class for visual distinction */
@@ -66,6 +70,39 @@ export interface StoneIncomeBreakdown {
   eventStore: number
   /** Stones from tournament results (per week) */
   tournamentResults: number
+  /** Stones purchased with real money (per week average) */
+  purchasedWithMoney: number
+}
+
+/**
+ * Breakdown of gem income sources.
+ * Gems come from various in-game activities.
+ */
+export interface GemIncomeBreakdown {
+  /** Gems from watching ads */
+  adGems: number
+  /** Floating gems (Bob) collected during runs */
+  floatingGems: number
+  /** Free daily gems from store */
+  storeDailyGems: number
+  /** Free weekly gems from store (web) */
+  storeWeeklyGems: number
+  /** Gems from daily mission completion */
+  missionsDailyCompletion: number
+  /** Gems from weekly mission chests */
+  missionsWeeklyChests: number
+  /** Gems from tournament participation */
+  tournaments: number
+  /** Gems from biweekly event shop */
+  biweeklyEventShop: number
+  /** Gems from guild weekly chests */
+  guildWeeklyChests: number
+  /** Gems from guild seasonal store */
+  guildSeasonalStore: number
+  /** Gems from offer walls/TapJoy */
+  offerWalls: number
+  /** Gems purchased with real money */
+  purchasedWithMoney: number
 }
 
 // =============================================================================
@@ -157,12 +194,16 @@ export interface SpendingPlannerState {
   incomes: CurrencyIncome[]
   /** Stone income breakdown (manual entry) */
   stoneIncomeBreakdown: StoneIncomeBreakdown
+  /** Gem income breakdown (manual entry) */
+  gemIncomeBreakdown: GemIncomeBreakdown
   /** Planned spending events in priority order */
   events: SpendingEvent[]
   /** Timeline view configuration */
   timelineConfig: TimelineViewConfig
   /** UI state: whether income panel is collapsed */
   incomePanelCollapsed: boolean
+  /** Which currencies are enabled for tracking */
+  enabledCurrencies: CurrencyId[]
   /** Timestamp of last update */
   lastUpdated: number
 }

--- a/src/features/spending-planner/use-spending-planner-state.ts
+++ b/src/features/spending-planner/use-spending-planner-state.ts
@@ -10,8 +10,10 @@ import type {
   SpendingPlannerState,
   CurrencyIncome,
   StoneIncomeBreakdown,
+  GemIncomeBreakdown,
   TimelineViewConfig,
   TimelineData,
+  CurrencyId,
 } from './types'
 import {
   loadSpendingPlannerState,
@@ -21,6 +23,7 @@ import { useIncomeState } from './income/use-income-state'
 import { useEventQueue } from './events/use-event-queue'
 import { useTimelineView } from './timeline/use-timeline-view'
 import { calculateTimeline } from './calculations/timeline-calculator'
+import { toggleCurrencyEnabled } from './currencies/currency-config'
 import type { AddEventData, EditEventData } from './events/event-queue-panel'
 
 interface UseSpendingPlannerStateReturn {
@@ -36,6 +39,8 @@ interface UseSpendingPlannerStateReturn {
   timeline: ReturnType<typeof useTimelineView>
   /** Toggle income panel collapse */
   toggleIncomePanel: () => void
+  /** Toggle currency enabled state */
+  handleToggleCurrency: (currencyId: CurrencyId) => void
   /** Add a new event */
   handleAddEvent: (data: AddEventData) => void
   /** Remove an event */
@@ -64,11 +69,15 @@ export function useSpendingPlannerState(): UseSpendingPlannerStateReturn {
   const income = useIncomeState({
     incomes: state.incomes,
     stoneBreakdown: state.stoneIncomeBreakdown,
+    gemBreakdown: state.gemIncomeBreakdown,
     onIncomesChange: useCallback((incomes: CurrencyIncome[]) => {
       setState((prev) => ({ ...prev, incomes }))
     }, []),
     onStoneBreakdownChange: useCallback((stoneIncomeBreakdown: StoneIncomeBreakdown) => {
       setState((prev) => ({ ...prev, stoneIncomeBreakdown }))
+    }, []),
+    onGemBreakdownChange: useCallback((gemIncomeBreakdown: GemIncomeBreakdown) => {
+      setState((prev) => ({ ...prev, gemIncomeBreakdown }))
     }, []),
   })
 
@@ -88,6 +97,14 @@ export function useSpendingPlannerState(): UseSpendingPlannerStateReturn {
     setState((prev) => ({
       ...prev,
       incomePanelCollapsed: !prev.incomePanelCollapsed,
+    }))
+  }, [])
+
+  // Toggle currency enabled state
+  const handleToggleCurrency = useCallback((currencyId: CurrencyId) => {
+    setState((prev) => ({
+      ...prev,
+      enabledCurrencies: toggleCurrencyEnabled(prev.enabledCurrencies, currencyId),
     }))
   }, [])
 
@@ -152,6 +169,7 @@ export function useSpendingPlannerState(): UseSpendingPlannerStateReturn {
     eventQueue,
     timeline,
     toggleIncomePanel,
+    handleToggleCurrency,
     handleAddEvent,
     handleRemoveEvent,
     handleEditEvent,


### PR DESCRIPTION
## Summary
Extends the Spending Planner to support all four major game currencies: Coins, Stones, Reroll Shards, and Gems. Each currency can be enabled/disabled independently, and Gems includes a comprehensive 12-source income breakdown covering ads, floating gems, store freebies, missions, tournaments, events, guild rewards, and offer walls.

## Technical Details
- Added `RerollShards` and `Gems` to `CurrencyId` enum with full configuration
- Created `GemIncomeBreakdown` type with 12 income source fields
- Implemented `gem-income-breakdown.tsx` component mirroring stone breakdown pattern
- Added `CurrencyVisualStyles` system for consistent border/gradient styling per currency
- Implemented currency enable/disable with `toggleCurrencyEnabled()` preventing disabling all
- Updated event dialogs to only show enabled currencies in dropdown
- Added `purchasedWithMoney` field to stone breakdown, standardized "Tournaments" label
- Updated timeline pills and rows to use currency-specific color gradients
- Added persistence migration for `enabledCurrencies` and `gemIncomeBreakdown` fields

## Context
The original spending planner only tracked Coins and Stones. Reroll Shards and Gems are equally important for tower upgrade planning, particularly for late-game players managing multiple lab upgrades and card purchases.