### PR TITLE
IMPROVE: Add percentage change overlay option to time series charts

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -115,11 +115,6 @@
       "count": 1
     }
   },
-  "src/features/analysis/time-series/time-series-chart.tsx": {
-    "max-lines-per-function": {
-      "count": 1
-    }
-  },
   "src/features/data-export/csv-export/csv-exporter.ts": {
     "complexity": {
       "count": 3

--- a/src/features/analysis/time-series/chart-types.ts
+++ b/src/features/analysis/time-series/chart-types.ts
@@ -21,6 +21,8 @@ export interface ChartDataPoint {
   periodInfo?: PeriodInfo
   /** Moving average value at this point, null if insufficient preceding data */
   movingAverage?: number | null
+  /** Period-over-period percentage change (first point is always 0%) */
+  percentChange?: number
 }
 
 

--- a/src/features/analysis/time-series/moving-average/index.ts
+++ b/src/features/analysis/time-series/moving-average/index.ts
@@ -1,0 +1,5 @@
+export { calculateMovingAverage } from './moving-average-calculation'
+export { useMovingAverage } from './use-moving-average'
+export { MovingAverageSelector } from './moving-average-selector'
+
+export type { MovingAveragePeriod } from './moving-average-types'

--- a/src/features/analysis/time-series/percent-change/index.ts
+++ b/src/features/analysis/time-series/percent-change/index.ts
@@ -1,0 +1,5 @@
+export { calculatePercentChange } from './percent-change-calculation'
+export { usePercentChange } from './use-percent-change'
+export { PercentChangeToggle } from './percent-change-toggle'
+
+

--- a/src/features/analysis/time-series/percent-change/percent-change-calculation.test.ts
+++ b/src/features/analysis/time-series/percent-change/percent-change-calculation.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest'
+import { calculatePercentChange } from './percent-change-calculation'
+import type { ChartDataPoint } from '../chart-types'
+
+function createDataPoint(
+  value: number,
+  date: string = '2024-01-01'
+): ChartDataPoint {
+  return {
+    date,
+    value,
+    timestamp: new Date(date),
+  }
+}
+
+describe('calculatePercentChange', () => {
+  describe('standard calculations', () => {
+    it('sets first data point to 0%', () => {
+      const dataPoints = [createDataPoint(100)]
+      const result = calculatePercentChange(dataPoints)
+      expect(result[0].percentChange).toBe(0)
+    })
+
+    it('calculates positive percentage change correctly', () => {
+      const dataPoints = [createDataPoint(100), createDataPoint(150)]
+      const result = calculatePercentChange(dataPoints)
+      expect(result[0].percentChange).toBe(0)
+      expect(result[1].percentChange).toBe(50) // (150-100)/100 * 100
+    })
+
+    it('calculates negative percentage change correctly', () => {
+      const dataPoints = [createDataPoint(200), createDataPoint(100)]
+      const result = calculatePercentChange(dataPoints)
+      expect(result[1].percentChange).toBe(-50) // (100-200)/200 * 100
+    })
+
+    it('calculates multi-point series correctly', () => {
+      const dataPoints = [
+        createDataPoint(100),
+        createDataPoint(200), // +100%
+        createDataPoint(150), // -25%
+        createDataPoint(150), // 0%
+      ]
+      const result = calculatePercentChange(dataPoints)
+      expect(result[0].percentChange).toBe(0)
+      expect(result[1].percentChange).toBe(100)
+      expect(result[2].percentChange).toBe(-25)
+      expect(result[3].percentChange).toBe(0)
+    })
+
+    it('handles doubling correctly', () => {
+      const dataPoints = [createDataPoint(50), createDataPoint(100)]
+      const result = calculatePercentChange(dataPoints)
+      expect(result[1].percentChange).toBe(100) // doubled = +100%
+    })
+
+    it('handles halving correctly', () => {
+      const dataPoints = [createDataPoint(100), createDataPoint(50)]
+      const result = calculatePercentChange(dataPoints)
+      expect(result[1].percentChange).toBe(-50) // halved = -50%
+    })
+  })
+
+  describe('edge cases', () => {
+    it('returns empty array for empty input', () => {
+      const result = calculatePercentChange([])
+      expect(result).toEqual([])
+    })
+
+    it('handles previous value of zero (increase)', () => {
+      const dataPoints = [createDataPoint(0), createDataPoint(100)]
+      const result = calculatePercentChange(dataPoints)
+      expect(result[1].percentChange).toBe(100)
+    })
+
+    it('handles previous value of zero (decrease)', () => {
+      const dataPoints = [createDataPoint(0), createDataPoint(-50)]
+      const result = calculatePercentChange(dataPoints)
+      expect(result[1].percentChange).toBe(-100)
+    })
+
+    it('handles both values zero', () => {
+      const dataPoints = [createDataPoint(0), createDataPoint(0)]
+      const result = calculatePercentChange(dataPoints)
+      expect(result[1].percentChange).toBe(0)
+    })
+
+    it('preserves original data point properties', () => {
+      const dataPoints: ChartDataPoint[] = [
+        {
+          date: '2024-01-01',
+          value: 100,
+          timestamp: new Date('2024-01-01'),
+          runInfo: {
+            tier: 5,
+            wave: 10,
+            realTime: 3600,
+            timestamp: new Date('2024-01-01 10:00'),
+          },
+        },
+        {
+          date: '2024-01-02',
+          value: 200,
+          timestamp: new Date('2024-01-02'),
+          movingAverage: 150,
+        },
+      ]
+      const result = calculatePercentChange(dataPoints)
+      expect(result[0].runInfo).toEqual(dataPoints[0].runInfo)
+      expect(result[1].movingAverage).toBe(150)
+    })
+  })
+
+  describe('does not mutate input', () => {
+    it('returns new array without modifying original', () => {
+      const dataPoints = [createDataPoint(100), createDataPoint(200)]
+      const originalValues = dataPoints.map((p) => ({ ...p }))
+
+      calculatePercentChange(dataPoints)
+
+      expect(dataPoints).toEqual(originalValues)
+      expect(dataPoints[0]).not.toHaveProperty('percentChange')
+    })
+  })
+
+  describe('large changes', () => {
+    it('handles very large positive changes', () => {
+      const dataPoints = [createDataPoint(1), createDataPoint(1000)]
+      const result = calculatePercentChange(dataPoints)
+      expect(result[1].percentChange).toBe(99900) // (1000-1)/1 * 100
+    })
+
+    it('handles very small changes', () => {
+      const dataPoints = [createDataPoint(1000000), createDataPoint(1000001)]
+      const result = calculatePercentChange(dataPoints)
+      expect(result[1].percentChange).toBeCloseTo(0.0001, 4)
+    })
+  })
+})

--- a/src/features/analysis/time-series/percent-change/percent-change-calculation.ts
+++ b/src/features/analysis/time-series/percent-change/percent-change-calculation.ts
@@ -1,0 +1,41 @@
+import type { ChartDataPoint } from '../chart-types'
+
+/**
+ * Calculate period-over-period percentage change for chart data points.
+ *
+ * Formula: (currentValue - previousValue) / |previousValue| * 100
+ *
+ * @param dataPoints - Array of chart data points with values
+ * @returns New array with percentChange property added to each point
+ *
+ * @remarks
+ * - First data point is always 0% (no prior period)
+ * - Division by zero is handled: if previousValue is 0 and current > 0, returns 100%
+ * - If both are 0, returns 0%
+ */
+export function calculatePercentChange(
+  dataPoints: ChartDataPoint[]
+): ChartDataPoint[] {
+  return dataPoints.map((point, index) => ({
+    ...point,
+    percentChange:
+      index === 0
+        ? 0 // First point has no prior period to compare
+        : calculatePointPercentChange(dataPoints[index - 1].value, point.value),
+  }))
+}
+
+/**
+ * Calculate percentage change between two values.
+ * Extracted for clarity and testing.
+ */
+function calculatePointPercentChange(
+  previousValue: number,
+  currentValue: number
+): number {
+  if (previousValue === 0) {
+    // Handle division by zero
+    return currentValue > 0 ? 100 : currentValue < 0 ? -100 : 0
+  }
+  return ((currentValue - previousValue) / Math.abs(previousValue)) * 100
+}

--- a/src/features/analysis/time-series/percent-change/percent-change-display.test.ts
+++ b/src/features/analysis/time-series/percent-change/percent-change-display.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import {
+  getPercentChangeColorClass,
+  formatPercentChangeDisplay,
+} from './percent-change-display'
+
+describe('getPercentChangeColorClass', () => {
+  it('returns green for positive values', () => {
+    expect(getPercentChangeColorClass(50)).toBe('text-green-400')
+    expect(getPercentChangeColorClass(0.1)).toBe('text-green-400')
+    expect(getPercentChangeColorClass(100)).toBe('text-green-400')
+  })
+
+  it('returns red for negative values', () => {
+    expect(getPercentChangeColorClass(-50)).toBe('text-red-400')
+    expect(getPercentChangeColorClass(-0.1)).toBe('text-red-400')
+    expect(getPercentChangeColorClass(-100)).toBe('text-red-400')
+  })
+
+  it('returns neutral gray for zero', () => {
+    expect(getPercentChangeColorClass(0)).toBe('text-slate-400')
+  })
+})
+
+describe('formatPercentChangeDisplay', () => {
+  describe('positive values', () => {
+    it('adds plus prefix', () => {
+      expect(formatPercentChangeDisplay(50)).toBe('+50.0%')
+      expect(formatPercentChangeDisplay(100)).toBe('+100.0%')
+    })
+
+    it('handles small positive values', () => {
+      expect(formatPercentChangeDisplay(0.1)).toBe('+0.1%')
+      expect(formatPercentChangeDisplay(0.05)).toBe('+0.1%') // rounds to 1 decimal
+    })
+  })
+
+  describe('negative values', () => {
+    it('uses natural minus sign', () => {
+      expect(formatPercentChangeDisplay(-50)).toBe('-50.0%')
+      expect(formatPercentChangeDisplay(-100)).toBe('-100.0%')
+    })
+
+    it('handles small negative values', () => {
+      expect(formatPercentChangeDisplay(-0.1)).toBe('-0.1%')
+    })
+  })
+
+  describe('zero', () => {
+    it('formats without sign prefix', () => {
+      expect(formatPercentChangeDisplay(0)).toBe('0.0%')
+    })
+  })
+
+  describe('precision', () => {
+    it('rounds to one decimal place', () => {
+      expect(formatPercentChangeDisplay(33.333)).toBe('+33.3%')
+      expect(formatPercentChangeDisplay(33.355)).toBe('+33.4%')
+      expect(formatPercentChangeDisplay(-66.666)).toBe('-66.7%')
+    })
+
+    it('handles large values', () => {
+      expect(formatPercentChangeDisplay(1000)).toBe('+1000.0%')
+      expect(formatPercentChangeDisplay(-500.5)).toBe('-500.5%')
+    })
+  })
+})

--- a/src/features/analysis/time-series/percent-change/percent-change-display.ts
+++ b/src/features/analysis/time-series/percent-change/percent-change-display.ts
@@ -1,0 +1,26 @@
+/**
+ * Pure display functions for percentage change values.
+ * Extracted for testability and reuse.
+ */
+
+/** Color class names for percentage change values */
+type PercentChangeColorClass = 'text-green-400' | 'text-red-400' | 'text-slate-400'
+
+/**
+ * Get CSS color class for percentage change value.
+ * Positive = green, negative = red, zero = neutral gray.
+ */
+export function getPercentChangeColorClass(value: number): PercentChangeColorClass {
+  if (value > 0) return 'text-green-400'
+  if (value < 0) return 'text-red-400'
+  return 'text-slate-400'
+}
+
+/**
+ * Format percentage change with sign prefix.
+ * Positive values get a "+" prefix, negative use their natural "-".
+ */
+export function formatPercentChangeDisplay(value: number): string {
+  const prefix = value > 0 ? '+' : ''
+  return `${prefix}${value.toFixed(1)}%`
+}

--- a/src/features/analysis/time-series/percent-change/percent-change-persistence.ts
+++ b/src/features/analysis/time-series/percent-change/percent-change-persistence.ts
@@ -1,0 +1,43 @@
+const STORAGE_KEY = 'tower-tracking-percent-change-config'
+
+interface PercentChangeConfig {
+  [metricKey: string]: boolean
+}
+
+/**
+ * Load percent change toggle state for a specific metric from localStorage.
+ * Returns false as default if no stored value or on SSR.
+ */
+export function loadPercentChangeEnabled(metricKey: string): boolean {
+  if (typeof window === 'undefined') return false
+
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (!stored) return false
+
+    const config: PercentChangeConfig = JSON.parse(stored)
+    return config[metricKey] === true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Save percent change toggle state for a specific metric to localStorage.
+ * Merges with existing config, SSR-safe.
+ */
+export function savePercentChangeEnabled(
+  metricKey: string,
+  enabled: boolean
+): void {
+  if (typeof window === 'undefined') return
+
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    const config: PercentChangeConfig = stored ? JSON.parse(stored) : {}
+    config[metricKey] = enabled
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(config))
+  } catch (error) {
+    console.error('Failed to save percent change config:', error)
+  }
+}

--- a/src/features/analysis/time-series/percent-change/percent-change-toggle.tsx
+++ b/src/features/analysis/time-series/percent-change/percent-change-toggle.tsx
@@ -1,0 +1,39 @@
+import { FormControl, ToggleSwitch } from '@/components/ui'
+import { cn } from '@/shared/lib/utils'
+
+interface PercentChangeToggleProps {
+  enabled: boolean
+  onToggle: (enabled: boolean) => void
+}
+
+/**
+ * Toggle switch for enabling/disabling percentage change overlay.
+ * Positioned between MovingAverageSelector and DataPointsCount.
+ *
+ * Shows a cyan accent when enabled to match the line color on the chart.
+ */
+export function PercentChangeToggle({
+  enabled,
+  onToggle,
+}: PercentChangeToggleProps) {
+  return (
+    <FormControl label="% Change" layout="vertical">
+      <div
+        className={cn(
+          'h-8 [@media(pointer:coarse)]:h-10 flex items-center px-2.5 rounded-md border transition-colors duration-200',
+          enabled
+            ? 'bg-cyan-950/30 border-cyan-500/50'
+            : 'bg-transparent border-transparent'
+        )}
+      >
+        <ToggleSwitch
+          checked={enabled}
+          onCheckedChange={onToggle}
+          aria-label="Toggle percentage change overlay"
+          data-testid="percent-change-toggle"
+          className={cn(enabled && 'bg-cyan-500 hover:bg-cyan-600')}
+        />
+      </div>
+    </FormControl>
+  )
+}

--- a/src/features/analysis/time-series/percent-change/use-percent-change.test.tsx
+++ b/src/features/analysis/time-series/percent-change/use-percent-change.test.tsx
@@ -1,0 +1,173 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { usePercentChange } from './use-percent-change'
+
+describe('usePercentChange', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  describe('initial state', () => {
+    it('returns false as default when no stored value exists', () => {
+      const { result } = renderHook(() => usePercentChange('testMetric'))
+      expect(result.current.isEnabled).toBe(false)
+    })
+
+    it('loads persisted value on mount', () => {
+      localStorage.setItem(
+        'tower-tracking-percent-change-config',
+        JSON.stringify({
+          coinsEarned: true,
+        })
+      )
+
+      const { result } = renderHook(() => usePercentChange('coinsEarned'))
+      expect(result.current.isEnabled).toBe(true)
+    })
+
+    it('returns false for unset metric when other metrics are stored', () => {
+      localStorage.setItem(
+        'tower-tracking-percent-change-config',
+        JSON.stringify({
+          coinsEarned: true,
+        })
+      )
+
+      const { result } = renderHook(() => usePercentChange('cellsEarned'))
+      expect(result.current.isEnabled).toBe(false)
+    })
+  })
+
+  describe('setEnabled', () => {
+    it('updates isEnabled state to true', () => {
+      const { result } = renderHook(() => usePercentChange('testMetric'))
+
+      act(() => {
+        result.current.setEnabled(true)
+      })
+
+      expect(result.current.isEnabled).toBe(true)
+    })
+
+    it('updates isEnabled state to false', () => {
+      const { result } = renderHook(() => usePercentChange('testMetric'))
+
+      act(() => {
+        result.current.setEnabled(true)
+      })
+
+      act(() => {
+        result.current.setEnabled(false)
+      })
+
+      expect(result.current.isEnabled).toBe(false)
+    })
+
+    it('persists true value to localStorage', () => {
+      const { result } = renderHook(() => usePercentChange('testMetric'))
+
+      act(() => {
+        result.current.setEnabled(true)
+      })
+
+      const stored = localStorage.getItem('tower-tracking-percent-change-config')
+      expect(JSON.parse(stored!)).toEqual({ testMetric: true })
+    })
+
+    it('persists false value to localStorage', () => {
+      const { result } = renderHook(() => usePercentChange('testMetric'))
+
+      act(() => {
+        result.current.setEnabled(true)
+      })
+
+      act(() => {
+        result.current.setEnabled(false)
+      })
+
+      const stored = localStorage.getItem('tower-tracking-percent-change-config')
+      expect(JSON.parse(stored!)).toEqual({ testMetric: false })
+    })
+
+    it('preserves other metric settings when updating', () => {
+      localStorage.setItem(
+        'tower-tracking-percent-change-config',
+        JSON.stringify({
+          existingMetric: true,
+        })
+      )
+
+      const { result } = renderHook(() => usePercentChange('newMetric'))
+
+      act(() => {
+        result.current.setEnabled(true)
+      })
+
+      const stored = localStorage.getItem('tower-tracking-percent-change-config')
+      expect(JSON.parse(stored!)).toEqual({
+        existingMetric: true,
+        newMetric: true,
+      })
+    })
+  })
+
+  describe('toggle', () => {
+    it('toggles from false to true', () => {
+      const { result } = renderHook(() => usePercentChange('testMetric'))
+
+      act(() => {
+        result.current.toggle()
+      })
+
+      expect(result.current.isEnabled).toBe(true)
+    })
+
+    it('toggles from true to false', () => {
+      const { result } = renderHook(() => usePercentChange('testMetric'))
+
+      act(() => {
+        result.current.setEnabled(true)
+      })
+
+      act(() => {
+        result.current.toggle()
+      })
+
+      expect(result.current.isEnabled).toBe(false)
+    })
+
+    it('persists toggled value to localStorage', () => {
+      const { result } = renderHook(() => usePercentChange('testMetric'))
+
+      act(() => {
+        result.current.toggle()
+      })
+
+      const stored = localStorage.getItem('tower-tracking-percent-change-config')
+      expect(JSON.parse(stored!)).toEqual({ testMetric: true })
+    })
+  })
+
+  describe('metric key changes', () => {
+    it('loads new metric value when key changes', () => {
+      localStorage.setItem(
+        'tower-tracking-percent-change-config',
+        JSON.stringify({
+          metricA: true,
+          metricB: false,
+        })
+      )
+
+      const { result, rerender } = renderHook(
+        ({ metric }) => usePercentChange(metric),
+        { initialProps: { metric: 'metricA' } }
+      )
+
+      expect(result.current.isEnabled).toBe(true)
+
+      rerender({ metric: 'metricB' })
+
+      expect(result.current.isEnabled).toBe(false)
+    })
+  })
+})

--- a/src/features/analysis/time-series/percent-change/use-percent-change.ts
+++ b/src/features/analysis/time-series/percent-change/use-percent-change.ts
@@ -1,0 +1,51 @@
+import { useState, useEffect, useCallback } from 'react'
+import {
+  loadPercentChangeEnabled,
+  savePercentChangeEnabled,
+} from './percent-change-persistence'
+
+interface UsePercentChangeResult {
+  /** Whether percentage change overlay is enabled */
+  isEnabled: boolean
+  /** Set percentage change on/off (persists to localStorage) */
+  setEnabled: (enabled: boolean) => void
+  /** Convenience toggle function */
+  toggle: () => void
+}
+
+/**
+ * Hook to manage percentage change toggle state with localStorage persistence.
+ * Loads persisted value on mount and saves changes automatically.
+ *
+ * @param metricKey - Unique key to identify this chart's setting
+ * @returns Percentage change state and setter functions
+ */
+export function usePercentChange(metricKey: string): UsePercentChangeResult {
+  const [isEnabled, setIsEnabledState] = useState(false)
+
+  // Load persisted value on mount (SSR-safe)
+  useEffect(() => {
+    const savedEnabled = loadPercentChangeEnabled(metricKey)
+    setIsEnabledState(savedEnabled)
+  }, [metricKey])
+
+  // Handle enable/disable with persistence
+  const setEnabled = useCallback(
+    (enabled: boolean) => {
+      setIsEnabledState(enabled)
+      savePercentChangeEnabled(metricKey, enabled)
+    },
+    [metricKey]
+  )
+
+  // Convenience toggle
+  const toggle = useCallback(() => {
+    setEnabled(!isEnabled)
+  }, [isEnabled, setEnabled])
+
+  return {
+    isEnabled,
+    setEnabled,
+    toggle,
+  }
+}

--- a/src/features/analysis/time-series/time-series-chart-body.tsx
+++ b/src/features/analysis/time-series/time-series-chart-body.tsx
@@ -1,0 +1,101 @@
+import { Area, ComposedChart, Line, XAxis, YAxis, Tooltip } from 'recharts'
+import { ChartContainer } from '@/components/ui'
+import type { ChartDataPoint, TimePeriodConfig } from './chart-types'
+import { TimeSeriesChartTooltip } from './time-series-tooltip'
+
+const chartConfig = { value: { label: 'Value' } }
+const AXIS_STYLE = { fontSize: 12, fill: '#94a3b8' }
+/** Cyan axis style at reduced opacity for subtlety - matches overlay line opacity */
+const PERCENT_AXIS_STYLE = { fontSize: 12, fill: 'rgba(34, 211, 238, 0.7)' }
+const MOVING_AVG_DOT = { r: 4, stroke: '#f97316', strokeWidth: 2, fill: '#1e293b' }
+const PERCENT_DOT = { r: 4, stroke: '#22d3ee', strokeWidth: 2, fill: '#1e293b' }
+const formatPercent = (value: number) => `${value.toFixed(0)}%`
+
+interface TimeSeriesChartBodyProps {
+  chartData: ChartDataPoint[]
+  metric: string
+  currentConfig: TimePeriodConfig
+  yAxisTicks: number[]
+  formatter: (value: number) => string
+  selectedPeriod: string
+  tooltipLabel: string
+  isAverageEnabled: boolean
+  percentChangeEnabled: boolean
+}
+
+/** Renders the Recharts chart with all overlays. Extracted to reduce parent complexity. */
+export function TimeSeriesChartBody({
+  chartData, metric, currentConfig, yAxisTicks, formatter,
+  selectedPeriod, tooltipLabel, isAverageEnabled, percentChangeEnabled,
+}: TimeSeriesChartBodyProps) {
+  const { color } = currentConfig
+  const activeDot = {
+    r: 6, stroke: color, strokeWidth: 2, fill: '#1e293b',
+    filter: `drop-shadow(0 0 6px ${color}50)`,
+  }
+
+  return (
+    <div className="transition-all duration-300 ease-in-out">
+      <ChartContainer config={chartConfig} className="h-[400px] w-full">
+        <ComposedChart
+          data={chartData}
+          margin={{ top: 20, right: percentChangeEnabled ? 60 : 20, left: 20, bottom: 20 }}
+        >
+          <defs>
+            <linearGradient id={`gradient-${metric}`} x1="0" y1="0" x2="0" y2="1">
+              <stop offset="5%" stopColor={color} stopOpacity={0.3} />
+              <stop offset="95%" stopColor={color} stopOpacity={0.05} />
+            </linearGradient>
+          </defs>
+
+          <XAxis dataKey="date" axisLine={false} tickLine={false} tick={AXIS_STYLE} tickMargin={8} />
+          <YAxis
+            yAxisId="primary" axisLine={false} tickLine={false} tick={AXIS_STYLE}
+            tickFormatter={formatter} ticks={yAxisTicks} domain={[0, 'dataMax']} tickMargin={8}
+          />
+
+          {percentChangeEnabled && (
+            <YAxis
+              yAxisId="percent" orientation="right" axisLine={false} tickLine={false}
+              tick={PERCENT_AXIS_STYLE} tickFormatter={formatPercent}
+              domain={['auto', 'auto']} tickMargin={8}
+            />
+          )}
+
+          <Tooltip
+            content={
+              <TimeSeriesChartTooltip
+                periodLabel={currentConfig.label} metricLabel={tooltipLabel}
+                formatter={formatter} isHourlyPeriod={selectedPeriod === 'hourly'}
+                accentColor={color} showTrendLine={isAverageEnabled}
+                showPercentChange={percentChangeEnabled}
+              />
+            }
+          />
+
+          <Area
+            type="monotone" dataKey="value" yAxisId="primary" stroke={color}
+            fill={`url(#gradient-${metric})`} strokeWidth={2}
+            dot={{ fill: color, strokeWidth: 0, r: 4 }} activeDot={activeDot}
+          />
+
+          {isAverageEnabled && (
+            <Line
+              type="monotone" dataKey="movingAverage" yAxisId="primary" stroke="#f97316"
+              strokeWidth={2} strokeDasharray="6 4" strokeOpacity={0.7}
+              dot={false} activeDot={MOVING_AVG_DOT} connectNulls={false}
+            />
+          )}
+
+          {percentChangeEnabled && (
+            <Line
+              type="monotone" dataKey="percentChange" yAxisId="percent" stroke="#22d3ee"
+              strokeWidth={2} strokeDasharray="4 2" strokeOpacity={0.7}
+              dot={false} activeDot={PERCENT_DOT} connectNulls={true}
+            />
+          )}
+        </ComposedChart>
+      </ChartContainer>
+    </div>
+  )
+}

--- a/src/features/analysis/time-series/time-series-chart.tsx
+++ b/src/features/analysis/time-series/time-series-chart.tsx
@@ -1,21 +1,18 @@
-import { useState, useMemo, useEffect } from 'react'
-import { Area, ComposedChart, Line, XAxis, YAxis, Tooltip } from 'recharts'
-import { ChartContainer, FormControl } from '@/components/ui'
+import { useMemo } from 'react'
+import { FormControl } from '@/components/ui'
 import { useData } from '@/shared/domain/use-data'
-import { prepareTimeSeriesData, getAvailableTimePeriods } from './chart-data'
 import type { TimePeriod, TimePeriodConfig } from './chart-types'
-import { formatLargeNumber, generateYAxisTicks } from '@/features/analysis/shared/formatting/chart-formatters'
+import { formatLargeNumber } from '@/features/analysis/shared/formatting/chart-formatters'
 import { filterRunsByType, type RunTypeFilter } from '@/features/analysis/shared/filtering/run-type-filter'
 import { RunType } from '@/shared/domain/run-types/types'
 import { RunTypeSelector } from '@/shared/domain/run-types/run-type-selector'
 import { TimeSeriesHeader } from './time-series-header'
 import { PeriodSelectorButton } from './period-selector-button'
 import { DataPointsCount } from './data-points-count'
-import { TimeSeriesChartTooltip } from './time-series-tooltip'
-import { MovingAverageSelector } from './moving-average/moving-average-selector'
-import { calculateMovingAverage } from './moving-average/moving-average-calculation'
-import type { MovingAveragePeriod } from './moving-average/moving-average-types'
-import { useMovingAverage } from './moving-average/use-moving-average'
+import { MovingAverageSelector, type MovingAveragePeriod } from './moving-average'
+import { PercentChangeToggle } from './percent-change'
+import { useTimeSeriesChartData } from './use-time-series-chart-data'
+import { TimeSeriesChartBody } from './time-series-chart-body'
 
 interface TimeSeriesChartProps {
   metric: string
@@ -31,11 +28,6 @@ interface TimeSeriesChartProps {
   valueFormatter?: (value: number) => string
 }
 
-const chartConfig = {
-  value: {
-    label: 'Value',
-  },
-}
 
 interface FilterControlsProps {
   availablePeriodConfigs: TimePeriodConfig[]
@@ -47,6 +39,8 @@ interface FilterControlsProps {
   dataPointCount: number
   averagePeriod: MovingAveragePeriod
   onAveragePeriodChange: (period: MovingAveragePeriod) => void
+  percentChangeEnabled: boolean
+  onPercentChangeToggle: (enabled: boolean) => void
 }
 
 function FilterControls({
@@ -59,6 +53,8 @@ function FilterControls({
   dataPointCount,
   averagePeriod,
   onAveragePeriodChange,
+  percentChangeEnabled,
+  onPercentChangeToggle,
 }: FilterControlsProps) {
   return (
     <div className="flex flex-wrap items-end justify-between gap-4">
@@ -76,7 +72,7 @@ function FilterControls({
         </div>
       </FormControl>
 
-      {/* Right side: Run type selector + SMA selector + Data points count */}
+      {/* Right side: Run type selector + SMA selector + % Change toggle + Data points count */}
       <div className="flex items-end gap-4">
         {showRunTypeSelector && onRunTypeChange && (
           <RunTypeSelector
@@ -88,6 +84,12 @@ function FilterControls({
 
         {/* Moving average trend line selector */}
         <MovingAverageSelector value={averagePeriod} onChange={onAveragePeriodChange} />
+
+        {/* Percentage change overlay toggle */}
+        <PercentChangeToggle
+          enabled={percentChangeEnabled}
+          onToggle={onPercentChangeToggle}
+        />
 
         {/* Data points indicator - aligned with controls */}
         <DataPointsCount count={dataPointCount} />
@@ -116,44 +118,21 @@ export function TimeSeriesChart({
   const filteredRuns = useMemo(() => {
     return filterRunsByType(runs, runTypeFilter)
   }, [runs, runTypeFilter])
-  const [selectedPeriod, setSelectedPeriod] = useState<TimePeriod>(defaultPeriod)
 
-  // Moving average state with localStorage persistence
-  const { averagePeriod, setAveragePeriod, isAverageEnabled } = useMovingAverage(metric)
-
-  // Get available periods based on data span
-  const availablePeriodConfigs = useMemo(() => {
-    return getAvailableTimePeriods(filteredRuns)
-  }, [filteredRuns])
-
-  // Reset period if current selection is not available
-  useEffect(() => {
-    const isCurrentPeriodAvailable = availablePeriodConfigs.some(config => config.period === selectedPeriod)
-    if (!isCurrentPeriodAvailable && availablePeriodConfigs.length > 0) {
-      setSelectedPeriod(availablePeriodConfigs[0].period)
-    }
-  }, [availablePeriodConfigs, selectedPeriod])
-
-  const currentConfig = availablePeriodConfigs.find(config => config.period === selectedPeriod) || availablePeriodConfigs[0]
-
-  const baseChartData = useMemo(() => {
-    return prepareTimeSeriesData(filteredRuns, selectedPeriod, metric)
-  }, [filteredRuns, selectedPeriod, metric])
-
-  // Apply moving average calculation if a period is selected
-  const chartData = useMemo(() => {
-    if (!isAverageEnabled) {
-      return baseChartData
-    }
-    // Type narrowing: isAverageEnabled guarantees averagePeriod is a number (3, 5, or 10)
-    return calculateMovingAverage(baseChartData, averagePeriod as number)
-  }, [baseChartData, averagePeriod, isAverageEnabled])
-
-  const yAxisTicks = useMemo(() => {
-    if (chartData.length === 0) return []
-    const maxValue = Math.max(...chartData.map(d => d.value))
-    return generateYAxisTicks(maxValue)
-  }, [chartData])
+  // Use custom hook for all chart data preparation
+  const {
+    chartData,
+    availablePeriodConfigs,
+    currentConfig,
+    selectedPeriod,
+    setSelectedPeriod,
+    yAxisTicks,
+    averagePeriod,
+    setAveragePeriod,
+    isAverageEnabled,
+    percentChangeEnabled,
+    setPercentChangeEnabled,
+  } = useTimeSeriesChartData(filteredRuns, metric, defaultPeriod)
 
   if (chartData.length === 0) {
     return (
@@ -188,92 +167,22 @@ export function TimeSeriesChart({
           dataPointCount={chartData.length}
           averagePeriod={averagePeriod}
           onAveragePeriodChange={setAveragePeriod}
+          percentChangeEnabled={percentChangeEnabled}
+          onPercentChangeToggle={setPercentChangeEnabled}
         />
       </div>
 
-      {/* Chart */}
-      <div className="transition-all duration-300 ease-in-out">
-        <ChartContainer config={chartConfig} className="h-[400px] w-full">
-          <ComposedChart
-            data={chartData}
-            margin={{ top: 20, right: 20, left: 20, bottom: 20 }}
-          >
-          <defs>
-            <linearGradient id={`gradient-${metric}`} x1="0" y1="0" x2="0" y2="1">
-              <stop offset="5%" stopColor={currentConfig.color} stopOpacity={0.3}/>
-              <stop offset="95%" stopColor={currentConfig.color} stopOpacity={0.05}/>
-            </linearGradient>
-          </defs>
-
-          <XAxis
-            dataKey="date"
-            axisLine={false}
-            tickLine={false}
-            tick={{ fontSize: 12, fill: '#94a3b8' }}
-            tickMargin={8}
-          />
-
-          <YAxis
-            axisLine={false}
-            tickLine={false}
-            tick={{ fontSize: 12, fill: '#94a3b8' }}
-            tickFormatter={formatter}
-            ticks={yAxisTicks}
-            domain={[0, 'dataMax']}
-            tickMargin={8}
-          />
-
-          <Tooltip
-            content={
-              <TimeSeriesChartTooltip
-                periodLabel={currentConfig.label}
-                metricLabel={tooltipLabel ?? title ?? ''}
-                formatter={formatter}
-                isHourlyPeriod={selectedPeriod === 'hourly'}
-                accentColor={currentConfig.color}
-                showTrendLine={isAverageEnabled}
-              />
-            }
-          />
-
-          <Area
-            type="monotone"
-            dataKey="value"
-            stroke={currentConfig.color}
-            fill={`url(#gradient-${metric})`}
-            strokeWidth={2}
-            dot={{ fill: currentConfig.color, strokeWidth: 0, r: 4 }}
-            activeDot={{
-              r: 6,
-              stroke: currentConfig.color,
-              strokeWidth: 2,
-              fill: '#1e293b',
-              filter: `drop-shadow(0 0 6px ${currentConfig.color}50)`
-            }}
-          />
-
-          {/* Moving average trend line - only rendered when enabled */}
-          {isAverageEnabled && (
-            <Line
-              type="monotone"
-              dataKey="movingAverage"
-              stroke="#f97316"
-              strokeWidth={2}
-              strokeDasharray="6 4"
-              strokeOpacity={0.7}
-              dot={false}
-              activeDot={{
-                r: 4,
-                stroke: '#f97316',
-                strokeWidth: 2,
-                fill: '#1e293b',
-              }}
-              connectNulls={false}
-            />
-          )}
-          </ComposedChart>
-        </ChartContainer>
-      </div>
+      <TimeSeriesChartBody
+        chartData={chartData}
+        metric={metric}
+        currentConfig={currentConfig}
+        yAxisTicks={yAxisTicks}
+        formatter={formatter}
+        selectedPeriod={selectedPeriod}
+        tooltipLabel={tooltipLabel ?? title ?? ''}
+        isAverageEnabled={isAverageEnabled}
+        percentChangeEnabled={percentChangeEnabled}
+      />
     </div>
   )
 }

--- a/src/features/analysis/time-series/time-series-tooltip.tsx
+++ b/src/features/analysis/time-series/time-series-tooltip.tsx
@@ -9,6 +9,10 @@
 
 import type { RunInfo, ChartDataPoint, PeriodInfo } from './chart-types'
 import { RunInfoHeader } from '@/features/analysis/shared/tooltips/run-info-header'
+import {
+  getPercentChangeColorClass,
+  formatPercentChangeDisplay,
+} from './percent-change/percent-change-display'
 
 interface TimeSeriesTooltipProps {
   /** Period label (e.g., "Per Run", "Daily") */
@@ -29,6 +33,8 @@ interface TimeSeriesTooltipProps {
   accentColor?: string
   /** Moving average value at this data point (null if insufficient data) */
   trendValue?: number | null
+  /** Percentage change value at this data point */
+  percentChangeValue?: number
 }
 
 function TimeSeriesTooltip({
@@ -41,6 +47,7 @@ function TimeSeriesTooltip({
   formatter,
   accentColor,
   trendValue,
+  percentChangeValue,
 }: TimeSeriesTooltipProps) {
   return (
     <div
@@ -77,11 +84,28 @@ function TimeSeriesTooltip({
       {trendValue !== undefined && trendValue !== null && formatter && (
         <div className="flex items-baseline justify-between gap-4 mt-2 pt-2 border-t border-slate-700/30">
           <span className="text-xs flex items-center gap-1.5">
-            <span className="inline-block w-3 h-0.5 bg-orange-500/70 rounded-full" style={{ borderStyle: 'dashed' }} />
+            <svg width="12" height="2" className="shrink-0">
+              <line x1="0" y1="1" x2="12" y2="1" stroke="rgb(249 115 22 / 0.7)" strokeWidth="2" strokeDasharray="3 2" />
+            </svg>
             <span className="text-slate-400">Moving Avg</span>
           </span>
           <span className="text-orange-400/80 text-xs tabular-nums font-medium">
             {formatter(trendValue)}
+          </span>
+        </div>
+      )}
+
+      {/* Percentage change row - only when enabled */}
+      {percentChangeValue !== undefined && (
+        <div className="flex items-baseline justify-between gap-4 mt-2 pt-2 border-t border-slate-700/30">
+          <span className="text-xs flex items-center gap-1.5">
+            <svg width="12" height="2" className="shrink-0">
+              <line x1="0" y1="1" x2="12" y2="1" stroke="rgb(34 211 238 / 0.7)" strokeWidth="2" strokeDasharray="2 1" />
+            </svg>
+            <span className="text-slate-400">% Change</span>
+          </span>
+          <span className={`text-xs tabular-nums font-medium ${getPercentChangeColorClass(percentChangeValue)}`}>
+            {formatPercentChangeDisplay(percentChangeValue)}
           </span>
         </div>
       )}
@@ -117,6 +141,8 @@ interface TimeSeriesChartTooltipProps {
   accentColor: string
   /** Whether to show moving average value in tooltip */
   showTrendLine?: boolean
+  /** Whether to show percentage change value in tooltip */
+  showPercentChange?: boolean
 }
 
 /**
@@ -133,6 +159,7 @@ export function TimeSeriesChartTooltip({
   isHourlyPeriod,
   accentColor,
   showTrendLine = false,
+  showPercentChange = false,
 }: TimeSeriesChartTooltipProps) {
   if (!active || !payload || !payload.length) return null
 
@@ -151,6 +178,7 @@ export function TimeSeriesChartTooltip({
       formatter={formatter}
       accentColor={accentColor}
       trendValue={showTrendLine ? dataPoint.movingAverage : undefined}
+      percentChangeValue={showPercentChange ? dataPoint.percentChange : undefined}
     />
   )
 }

--- a/src/features/analysis/time-series/use-time-series-chart-data.ts
+++ b/src/features/analysis/time-series/use-time-series-chart-data.ts
@@ -1,0 +1,101 @@
+import { useState, useMemo, useEffect } from 'react'
+import type { ParsedGameRun } from '@/shared/types/game-run.types'
+import { prepareTimeSeriesData, getAvailableTimePeriods } from './chart-data'
+import type { TimePeriod, ChartDataPoint, TimePeriodConfig } from './chart-types'
+import { generateYAxisTicks } from '@/features/analysis/shared/formatting/chart-formatters'
+import {
+  calculateMovingAverage,
+  useMovingAverage,
+  type MovingAveragePeriod,
+} from './moving-average'
+import { calculatePercentChange, usePercentChange } from './percent-change'
+
+interface UseTimeSeriesChartDataResult {
+  chartData: ChartDataPoint[]
+  availablePeriodConfigs: TimePeriodConfig[]
+  currentConfig: TimePeriodConfig
+  selectedPeriod: TimePeriod
+  setSelectedPeriod: (period: TimePeriod) => void
+  yAxisTicks: number[]
+  averagePeriod: MovingAveragePeriod
+  setAveragePeriod: (period: MovingAveragePeriod) => void
+  isAverageEnabled: boolean
+  percentChangeEnabled: boolean
+  setPercentChangeEnabled: (enabled: boolean) => void
+}
+
+/**
+ * Custom hook that encapsulates all chart data preparation logic.
+ * Handles period selection, moving average, and percent change calculations.
+ */
+export function useTimeSeriesChartData(
+  filteredRuns: ParsedGameRun[],
+  metric: string,
+  defaultPeriod: TimePeriod
+): UseTimeSeriesChartDataResult {
+  const [selectedPeriod, setSelectedPeriod] = useState<TimePeriod>(defaultPeriod)
+
+  // Moving average state with localStorage persistence
+  const { averagePeriod, setAveragePeriod, isAverageEnabled } = useMovingAverage(metric)
+
+  // Percentage change state with localStorage persistence
+  const { isEnabled: percentChangeEnabled, setEnabled: setPercentChangeEnabled } = usePercentChange(metric)
+
+  // Get available periods based on data span
+  const availablePeriodConfigs = useMemo(() => {
+    return getAvailableTimePeriods(filteredRuns)
+  }, [filteredRuns])
+
+  // Reset period if current selection is not available
+  useEffect(() => {
+    const isCurrentPeriodAvailable = availablePeriodConfigs.some(
+      (config) => config.period === selectedPeriod
+    )
+    if (!isCurrentPeriodAvailable && availablePeriodConfigs.length > 0) {
+      setSelectedPeriod(availablePeriodConfigs[0].period)
+    }
+  }, [availablePeriodConfigs, selectedPeriod])
+
+  const currentConfig =
+    availablePeriodConfigs.find((config) => config.period === selectedPeriod) ||
+    availablePeriodConfigs[0]
+
+  const baseChartData = useMemo(() => {
+    return prepareTimeSeriesData(filteredRuns, selectedPeriod, metric)
+  }, [filteredRuns, selectedPeriod, metric])
+
+  // Apply optional calculations: moving average and percent change
+  const chartData = useMemo(() => {
+    let data = baseChartData
+
+    if (isAverageEnabled) {
+      data = calculateMovingAverage(data, averagePeriod as number)
+    }
+
+    if (percentChangeEnabled) {
+      data = calculatePercentChange(data)
+    }
+
+    return data
+  }, [baseChartData, averagePeriod, isAverageEnabled, percentChangeEnabled])
+
+  const yAxisTicks = useMemo(() => {
+    if (chartData.length === 0) return []
+    const maxValue = Math.max(...chartData.map((d) => d.value))
+    return generateYAxisTicks(maxValue)
+  }, [chartData])
+
+  return {
+    chartData,
+    availablePeriodConfigs,
+    currentConfig,
+    selectedPeriod,
+    setSelectedPeriod,
+    yAxisTicks,
+    averagePeriod,
+    setAveragePeriod,
+    isAverageEnabled,
+    percentChangeEnabled,
+    setPercentChangeEnabled,
+  }
+}


### PR DESCRIPTION
## Summary
Users can now toggle a percentage change overlay on time series charts to see period-over-period differences. This displays a cyan dashed line showing how much each data point changed relative to the previous one, with color-coded values (green for gains, red for losses) in the tooltip. The toggle state persists per metric using localStorage.

## Technical Details
- Created `percent-change/` module with calculation, display, persistence, and toggle components
- Extracted chart rendering to `time-series-chart-body.tsx` to reduce parent component complexity
- Created `use-time-series-chart-data.ts` hook consolidating period selection, moving average, and percent change state
- Added secondary Y-axis (right side) for percentage scale when overlay is enabled
- Extended `ChartDataPoint` type with optional `percentChange` property
- Added barrel export (`index.ts`) for moving-average module for cleaner imports
- Removed eslint max-lines-per-function suppression for time-series-chart.tsx (no longer needed after extraction)

## Context
This follows the same pattern established by the moving average overlay feature, providing another analytical tool for identifying trends in run performance data.