### PR TITLE
BUG: Fix spending planner to allow mid-week event purchases

### DIFF
--- a/src/features/spending-planner/timeline/layouts/calculate-week-balance.test.ts
+++ b/src/features/spending-planner/timeline/layouts/calculate-week-balance.test.ts
@@ -23,10 +23,19 @@ describe('calculateProrationAdjustment', () => {
 })
 
 describe('calculateWeekBalance', () => {
+  /**
+   * NEW SEMANTICS (Mid-Week Spending Model):
+   * - rawEndingBalance = balances[weekIndex + 1] = starting balance + income - spending
+   * - priorBalance = balance at START of week = endingBalance - displayedIncome + expenditure
+   * - endingBalance = rawEndingBalance (with proration adjustment)
+   */
+
   describe('week 0 (current week)', () => {
-    it('should apply proration to income only', () => {
+    it('should apply proration to income and calculate correct prior balance', () => {
+      // Starting balance: 255, Full income: 500, Expenditure: 0
+      // rawEndingBalance = 255 + 500 - 0 = 755
       const result = calculateWeekBalance({
-        rawBalance: 255,
+        rawEndingBalance: 755,
         income: 500,
         expenditure: 0,
         weekIndex: 0,
@@ -34,6 +43,10 @@ describe('calculateWeekBalance', () => {
         week0FullIncome: 500,
       })
 
+      // proratedIncome = 500 * 0.26 = 130
+      // incomeAdjustment = 130 - 500 = -370
+      // endingBalance = 755 + (-370) = 385
+      // priorBalance = 385 - 130 + 0 = 255
       expect(result.priorBalance).toBe(255)
       expect(result.income).toBeCloseTo(130, 0)
       expect(result.expenditure).toBe(0)
@@ -41,8 +54,10 @@ describe('calculateWeekBalance', () => {
     })
 
     it('should handle expenditure in week 0', () => {
+      // Starting balance: 300, Full income: 500, Expenditure: 200
+      // rawEndingBalance = 300 + 500 - 200 = 600
       const result = calculateWeekBalance({
-        rawBalance: 100,
+        rawEndingBalance: 600,
         income: 500,
         expenditure: 200,
         weekIndex: 0,
@@ -50,14 +65,21 @@ describe('calculateWeekBalance', () => {
         week0FullIncome: 500,
       })
 
+      // proratedIncome = 500 * 0.5 = 250
+      // incomeAdjustment = 250 - 500 = -250
+      // endingBalance = 600 + (-250) = 350
+      // priorBalance = 350 - 250 + 200 = 300
       expect(result.priorBalance).toBe(300)
       expect(result.income).toBe(250)
+      expect(result.expenditure).toBe(200)
       expect(result.balance).toBe(350)
     })
 
     it('should work with full week (factor 1)', () => {
+      // Starting balance: 255, Full income: 500, Expenditure: 0
+      // rawEndingBalance = 255 + 500 = 755
       const result = calculateWeekBalance({
-        rawBalance: 255,
+        rawEndingBalance: 755,
         income: 500,
         expenditure: 0,
         weekIndex: 0,
@@ -65,14 +87,19 @@ describe('calculateWeekBalance', () => {
         week0FullIncome: 500,
       })
 
+      // No proration adjustment needed
+      expect(result.priorBalance).toBe(255)
       expect(result.balance).toBe(755)
     })
   })
 
   describe('week N > 0 (future weeks)', () => {
     it('should apply proration adjustment from week 0', () => {
+      // Starting balance: 385, Income: 500.5, Expenditure: 0
+      // rawEndingBalance (before adjustment) = 385 + 500.5 = 885.5
+      // But calculator assumes full week 0 income, so raw = 885.5 + 370 = 1255.5
       const result = calculateWeekBalance({
-        rawBalance: 755,
+        rawEndingBalance: 1255.5,
         income: 500.5,
         expenditure: 0,
         weekIndex: 1,
@@ -80,14 +107,19 @@ describe('calculateWeekBalance', () => {
         week0FullIncome: 500,
       })
 
-      const adjustment = (0.26 - 1) * 500
-      expect(result.priorBalance).toBeCloseTo(755 + adjustment, 0)
-      expect(result.balance).toBeCloseTo(755 + 500.5 + adjustment, 0)
+      // adjustment = (0.26 - 1) * 500 = -370
+      // endingBalance = 1255.5 + (-370) = 885.5
+      // priorBalance = 885.5 - 500.5 + 0 = 385
+      expect(result.priorBalance).toBeCloseTo(385, 0)
+      expect(result.balance).toBeCloseTo(885.5, 0)
     })
 
     it('should handle expenditure in future week', () => {
+      // Starting balance: 385, Income: 500.5, Expenditure: 672
+      // Displayed ending balance = 385 + 500.5 - 672 = 213.5
+      // rawEndingBalance (before adjustment) = 213.5 - (-370) = 583.5
       const result = calculateWeekBalance({
-        rawBalance: 83,
+        rawEndingBalance: 583.5,
         income: 500.5,
         expenditure: 672,
         weekIndex: 1,
@@ -95,14 +127,17 @@ describe('calculateWeekBalance', () => {
         week0FullIncome: 500,
       })
 
-      const adjustment = (0.26 - 1) * 500
-      expect(result.priorBalance).toBeCloseTo(83 + 672 + adjustment, 0)
-      expect(result.balance).toBeCloseTo(83 + 500.5 + adjustment, 0)
+      // endingBalance = 583.5 + (-370) = 213.5
+      // priorBalance = 213.5 - 500.5 + 672 = 385
+      expect(result.priorBalance).toBeCloseTo(385, 0)
+      expect(result.balance).toBeCloseTo(213.5, 0)
     })
 
     it('should work with full week 0 (no adjustment needed)', () => {
+      // Starting balance: 755, Income: 500, Expenditure: 0
+      // rawEndingBalance = 755 + 500 = 1255
       const result = calculateWeekBalance({
-        rawBalance: 755,
+        rawEndingBalance: 1255,
         income: 500,
         expenditure: 0,
         weekIndex: 1,
@@ -110,18 +145,21 @@ describe('calculateWeekBalance', () => {
         week0FullIncome: 500,
       })
 
+      // No proration adjustment
       expect(result.priorBalance).toBe(755)
       expect(result.balance).toBe(1255)
     })
   })
 
   describe('user-reported scenario', () => {
-    // Starting balance: 255T, Week 0: +130T prorated -> 385T
-    // Week 1: prior 385T, +500.5T income, -672T spending -> ~213.5T
+    // Starting balance: 255T, Week 0: +130T prorated -> 385T ending balance
+    // Week 1: prior 385T, +500.5T income, -672T spending -> ~213.5T ending balance
 
     it('should calculate week 0 correctly', () => {
+      // Starting: 255T, Full income: 500T, Expenditure: 0
+      // rawEndingBalance = 255T + 500T = 755T
       const result = calculateWeekBalance({
-        rawBalance: 255e12,
+        rawEndingBalance: 755e12,
         income: 500e12,
         expenditure: 0,
         weekIndex: 0,
@@ -135,10 +173,14 @@ describe('calculateWeekBalance', () => {
     })
 
     it('should calculate week 1 correctly with proration adjustment', () => {
-      const rawBalance = 255e12 + 500e12 - 672e12
+      // Prior (starting): 385T, Income: 500.5T, Expenditure: 672T
+      // Displayed ending = 385T + 500.5T - 672T = 213.5T
+      // Proration adjustment = (0.26 - 1) * 500T = -370T
+      // rawEndingBalance = 213.5T - (-370T) = 583.5T
+      const rawEndingBalance = 583.5e12
 
       const result = calculateWeekBalance({
-        rawBalance,
+        rawEndingBalance,
         income: 500.5e12,
         expenditure: 672e12,
         weekIndex: 1,

--- a/src/features/spending-planner/timeline/layouts/timeline-layout-columns.tsx
+++ b/src/features/spending-planner/timeline/layouts/timeline-layout-columns.tsx
@@ -214,14 +214,16 @@ function CurrencyRow({ currencyId, weekIndex, timelineData, currentWeekProration
     const expenditures = timelineData.expenditureByWeek.get(currencyId) ?? []
     const balances = timelineData.balancesByWeek.get(currencyId) ?? []
 
-    const rawBalance = balances[weekIndex] ?? 0
+    // Use balances[weekIndex + 1] as the raw ending balance for this week
+    // (mid-week spending model: spending deducted from ending balance, not starting)
+    const rawEndingBalance = balances[weekIndex + 1] ?? 0
     const income = incomes[weekIndex] ?? 0
     const expenditure = expenditures[weekIndex] ?? 0
     const week0FullIncome = incomes[0] ?? 0
 
     // Use single source of truth for balance calculation
     return calculateWeekBalance({
-      rawBalance,
+      rawEndingBalance,
       income,
       expenditure,
       weekIndex,

--- a/src/features/spending-planner/timeline/layouts/timeline-layout-rows.tsx
+++ b/src/features/spending-planner/timeline/layouts/timeline-layout-rows.tsx
@@ -225,14 +225,16 @@ function CurrencyCell({
     const expenditures = timelineData.expenditureByWeek.get(currencyId) ?? []
     const balances = timelineData.balancesByWeek.get(currencyId) ?? []
 
-    const rawBalance = balances[weekIndex] ?? 0
+    // Use balances[weekIndex + 1] as the raw ending balance for this week
+    // (mid-week spending model: spending deducted from ending balance, not starting)
+    const rawEndingBalance = balances[weekIndex + 1] ?? 0
     const income = incomes[weekIndex] ?? 0
     const expenditure = expenditures[weekIndex] ?? 0
     const week0FullIncome = incomes[0] ?? 0
 
     // Use single source of truth for balance calculation
     return calculateWeekBalance({
-      rawBalance,
+      rawEndingBalance,
       income,
       expenditure,
       weekIndex,


### PR DESCRIPTION
## Summary
Fixed spending planner event scheduling to allow purchases mid-week after income is received. Previously, events could only trigger when the starting balance was sufficient, forcing users to wait an extra week even when that week's income would cover the cost. Now events schedule in the same week they become affordable.

## Technical Details
- Updated `findTriggerWeek` to check `balances[week + 1]` (ending balance) instead of `balances[week]` (starting balance)
- Updated `subtractFromBalances` to deduct from ending balance forward, not starting balance
- Fixed `calculateWeekBalance` to derive prior/ending balances from new array semantics where `balances[N+1]` represents week N's ending balance
- Updated layout components to pass `balances[weekIndex + 1]` as raw ending balance
- Updated all test expectations to reflect earlier trigger weeks

## Context
The balance array semantics changed: `balances[N]` is now starting balance for week N, and `balances[N+1]` is ending balance after income and spending. This enables the intuitive behavior where you can buy something the same week you earn enough for it.