### PR TITLE
IMPROVE: Add event chaining to spending planner for cross-currency dependencies

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -70,6 +70,7 @@ export default defineConfig([
   {
     files: ["**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/*.spec.tsx"],
     rules: {
+      "max-lines": "off",
       "max-nested-callbacks": ["error", { "max": 5 }],
       "max-lines-per-function": "off",
       "max-statements": "off",

--- a/src/features/analysis/source-analysis/calculations/period-grouping.test.ts
+++ b/src/features/analysis/source-analysis/calculations/period-grouping.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines */
 /**
  * Tests for Period Grouping Logic
  */

--- a/src/features/analysis/tier-stats/calculations/tier-stats-calculator.test.ts
+++ b/src/features/analysis/tier-stats/calculations/tier-stats-calculator.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines */
 // Test file covering multiple functions with comprehensive percentile aggregation tests
 import { describe, it, expect } from 'vitest'
 import type { ParsedGameRun } from '@/shared/types/game-run.types'

--- a/src/features/analysis/tier-trends/calculations/tier-trends-calculations.test.ts
+++ b/src/features/analysis/tier-trends/calculations/tier-trends-calculations.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines */
 import { describe, it, expect } from 'vitest';
 import { calculateTierTrends, getAvailableTiersForTrends, getDefaultAggregationType, getQuantityLabel } from './tier-trends-calculations';
 import type { TierTrendsFilters } from '../types';

--- a/src/features/game-runs/card-view/run-details/breakdown/breakdown-calculations.test.ts
+++ b/src/features/game-runs/card-view/run-details/breakdown/breakdown-calculations.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines */
 /**
  * Breakdown Calculations Tests
  *

--- a/src/features/spending-planner/events/chain-icon.tsx
+++ b/src/features/spending-planner/events/chain-icon.tsx
@@ -1,0 +1,32 @@
+/**
+ * Chain Icon Component
+ *
+ * Chain link icon for indicating chained events.
+ * Uses lucide-react Link icon with custom styling for active/inactive states.
+ */
+
+import { Link } from 'lucide-react'
+import { cn } from '@/shared/lib/utils'
+
+interface ChainIconProps {
+  className?: string
+  /** Whether the chain is active (orange) or inactive (gray) */
+  active?: boolean
+  /** Size variant for the icon */
+  size?: 'sm' | 'default'
+}
+
+export function ChainIcon({ className, active = true, size = 'default' }: ChainIconProps) {
+  const sizeValue = size === 'sm' ? 14 : 16
+
+  return (
+    <Link
+      size={sizeValue}
+      className={cn(
+        'transition-colors duration-150',
+        active ? 'text-orange-500' : 'text-slate-500',
+        className
+      )}
+    />
+  )
+}

--- a/src/features/spending-planner/events/event-chain-helpers.ts
+++ b/src/features/spending-planner/events/event-chain-helpers.ts
@@ -1,0 +1,163 @@
+/**
+ * Event Chain Helper Functions
+ *
+ * Pure functions for managing event chains in the spending planner.
+ * Events can be chained together, meaning they must wait for their predecessor.
+ */
+
+import type { SpendingEvent } from '../types'
+import { sortByPriority } from './event-reorder'
+
+/**
+ * Check if an event is chained to another event.
+ */
+export function isChainedEvent(event: SpendingEvent): boolean {
+  return event.lockedToEventId !== null
+}
+
+/**
+ * Check if an event is a chain head (has dependents but is not itself chained).
+ */
+export function isChainHead(events: SpendingEvent[], eventId: string): boolean {
+  const event = events.find((e) => e.id === eventId)
+  if (!event) return false
+
+  // Must not be chained itself
+  if (event.lockedToEventId !== null) return false
+
+  // Must have at least one dependent
+  return events.some((e) => e.lockedToEventId === eventId)
+}
+
+/**
+ * Get all events in a chain starting from the head.
+ * Returns events in priority order.
+ */
+export function getChainFromHead(events: SpendingEvent[], headId: string): SpendingEvent[] {
+  const chain: SpendingEvent[] = []
+  const head = events.find((e) => e.id === headId)
+  if (!head) return chain
+
+  chain.push(head)
+
+  // Sort once before walking the chain (O(n log n) instead of O(n^2 log n))
+  const sorted = sortByPriority(events)
+
+  // Walk down the chain following dependencies
+  let currentId = headId
+  let foundNext = true
+  while (foundNext) {
+    foundNext = false
+    // Find the next event in priority order that is chained to current
+    for (const event of sorted) {
+      if (event.lockedToEventId === currentId) {
+        chain.push(event)
+        currentId = event.id
+        foundNext = true
+        break
+      }
+    }
+  }
+
+  return chain
+}
+
+/**
+ * Walk up the chain to find the head event.
+ * Returns the event itself if it's not chained.
+ */
+export function getChainHead(events: SpendingEvent[], eventId: string): SpendingEvent | null {
+  const event = events.find((e) => e.id === eventId)
+  if (!event) return null
+
+  // If not chained, this is the head
+  if (event.lockedToEventId === null) return event
+
+  // Walk up the chain
+  return getChainHead(events, event.lockedToEventId)
+}
+
+/**
+ * Toggle the chain state of an event.
+ * - If currently free-floating: chain to the event immediately before it
+ * - If currently chained: make it free-floating
+ * Returns null if the event cannot be toggled (e.g., first event).
+ */
+export function toggleEventChain(
+  events: SpendingEvent[],
+  eventId: string
+): SpendingEvent[] | null {
+  const sorted = sortByPriority(events)
+  const eventIndex = sorted.findIndex((e) => e.id === eventId)
+
+  if (eventIndex === -1) return null
+
+  const event = sorted[eventIndex]
+
+  // First event cannot be chained (nothing to chain to)
+  if (eventIndex === 0) return null
+
+  const previousEvent = sorted[eventIndex - 1]
+
+  // Toggle chain state
+  const newLockedToEventId = event.lockedToEventId === null
+    ? previousEvent.id  // Chain to previous
+    : null              // Make free-floating
+
+  return events.map((e) =>
+    e.id === eventId
+      ? { ...e, lockedToEventId: newLockedToEventId }
+      : e
+  )
+}
+
+/**
+ * Check if an event can be chained (not the first event).
+ */
+export function canChainEvent(events: SpendingEvent[], eventId: string): boolean {
+  const sorted = sortByPriority(events)
+  const eventIndex = sorted.findIndex((e) => e.id === eventId)
+  return eventIndex > 0
+}
+
+/**
+ * A group of events for rendering - either a single free-floating event
+ * or a chain head with its dependents.
+ */
+interface EventGroup {
+  /** Events in this group, in priority order */
+  events: SpendingEvent[]
+  /** Whether this group is a chain (has more than one event) */
+  isChain: boolean
+}
+
+/**
+ * Group events into chains for rendering.
+ * Each chain head starts a new group containing itself and all dependents.
+ * Free-floating events (not chained and no dependents) are their own group.
+ * Returns groups in priority order.
+ */
+export function groupEventsIntoChains(events: SpendingEvent[]): EventGroup[] {
+  const sorted = sortByPriority(events)
+  const groups: EventGroup[] = []
+  const processedIds = new Set<string>()
+
+  for (const event of sorted) {
+    // Skip if already processed as part of a chain
+    if (processedIds.has(event.id)) continue
+
+    // Skip chained events - they'll be included with their head
+    if (event.lockedToEventId !== null) continue
+
+    // This is either a chain head or a free-floating event
+    const chain = getChainFromHead(events, event.id)
+    chain.forEach((e) => processedIds.add(e.id))
+
+    groups.push({
+      events: chain,
+      isChain: chain.length > 1,
+    })
+  }
+
+  return groups
+}

--- a/src/features/spending-planner/events/event-pill.tsx
+++ b/src/features/spending-planner/events/event-pill.tsx
@@ -2,6 +2,7 @@
  * Event Pill Component
  *
  * Draggable pill displaying a spending event in the queue.
+ * Supports event chaining with visual snapping.
  */
 
 import { cn } from '@/shared/lib/utils'
@@ -10,18 +11,108 @@ import type { SpendingEvent } from '../types'
 import { getCurrencyConfig, getCurrencyVisualStyles } from '../currencies/currency-config'
 import { EventPillActions } from './event-pill-actions'
 import { createEventDragHandlers, createEventActionHandlers } from './event-pill-handlers'
+import { ChainIcon } from './chain-icon'
+
+interface DragHandleIconProps {
+  className?: string
+}
+
+/** Drag handle SVG icon */
+function DragHandleIcon({ className }: DragHandleIconProps) {
+  return (
+    <svg className={cn('w-4 h-4', className)} fill="currentColor" viewBox="0 0 20 20">
+      <path d="M7 2a2 2 0 1 0 .001 4.001A2 2 0 0 0 7 2zm0 6a2 2 0 1 0 .001 4.001A2 2 0 0 0 7 8zm0 6a2 2 0 1 0 .001 4.001A2 2 0 0 0 7 14zm6-8a2 2 0 1 0-.001-4.001A2 2 0 0 0 13 6zm0 2a2 2 0 1 0 .001 4.001A2 2 0 0 0 13 8zm0 6a2 2 0 1 0 .001 4.001A2 2 0 0 0 13 14z" />
+    </svg>
+  )
+}
+
+interface EventPillHandleProps {
+  isChained: boolean
+  canChain: boolean
+  onChainClick: () => void
+}
+
+/** Handle/chain icon for the left side of the pill */
+function EventPillHandle({ isChained, canChain, onChainClick }: EventPillHandleProps) {
+  // Shared base styles for the handle area
+  const baseStyles = cn(
+    'flex items-center justify-center w-8',
+    'border-r border-slate-600/30',
+    'transition-all duration-150'
+  )
+
+  if (isChained) {
+    return (
+      <button
+        type="button"
+        onClick={onChainClick}
+        className={cn(
+          baseStyles,
+          'cursor-pointer',
+          'hover:bg-orange-500/10',
+          'group'
+        )}
+        title="Click to unchain this event"
+      >
+        <ChainIcon active className="group-hover:text-orange-400" />
+      </button>
+    )
+  }
+
+  if (canChain) {
+    return (
+      <button
+        type="button"
+        onClick={onChainClick}
+        className={cn(
+          baseStyles,
+          'cursor-pointer',
+          'text-slate-500',
+          'hover:bg-slate-700/50 hover:text-slate-400',
+          'group'
+        )}
+        title="Click to chain to previous event"
+      >
+        {/* Show chain icon on hover to hint at chaining capability */}
+        <DragHandleIcon className="group-hover:hidden" />
+        <ChainIcon active={false} className="hidden group-hover:block" />
+      </button>
+    )
+  }
+
+  // First event: cannot chain, only drag
+  return (
+    <div
+      className={cn(
+        baseStyles,
+        'cursor-grab active:cursor-grabbing',
+        'text-slate-500 hover:text-slate-400'
+      )}
+      title="Drag to reorder"
+    >
+      <DragHandleIcon />
+    </div>
+  )
+}
 
 interface EventPillProps {
   event: SpendingEvent
   index: number
   isDragging: boolean
   isDraggedOver: boolean
+  /** Whether this event is chained to the previous event */
+  isChained: boolean
+  /** Whether this event can be chained (not the first event) */
+  canChain: boolean
+  /** Whether this event has a dependent chained to it (chain head with followers) */
+  hasChainedDependent: boolean
   onDragStart: (index: number) => void
   onDragEnter: (index: number) => void
   onDragEnd: () => void
   onRemove: (eventId: string) => void
   onEdit: (event: SpendingEvent) => void
   onClone: (eventId: string) => void
+  onToggleChain: (eventId: string) => void
 }
 
 export function EventPill({
@@ -29,12 +120,16 @@ export function EventPill({
   index,
   isDragging,
   isDraggedOver,
+  isChained,
+  canChain,
+  hasChainedDependent,
   onDragStart,
   onDragEnter,
   onDragEnd,
   onRemove,
   onEdit,
   onClone,
+  onToggleChain,
 }: EventPillProps) {
   const config = getCurrencyConfig(event.currencyId)
   const visualStyles = getCurrencyVisualStyles(event.currencyId)
@@ -43,10 +138,17 @@ export function EventPill({
   const dragHandlers = createEventDragHandlers(index, onDragStart, onDragEnter)
   const actionHandlers = createEventActionHandlers(event, onEdit, onClone, onRemove)
 
+  // Chained events cannot be dragged individually
+  const isDraggable = !isChained
+
+  const handleChainClick = () => {
+    onToggleChain(event.id)
+  }
+
   return (
     <div
-      draggable
-      onDragStart={dragHandlers.onDragStart}
+      draggable={isDraggable}
+      onDragStart={isDraggable ? dragHandlers.onDragStart : undefined}
       onDragEnter={dragHandlers.onDragEnter}
       onDragOver={dragHandlers.onDragOver}
       onDrop={dragHandlers.onDrop}
@@ -58,15 +160,19 @@ export function EventPill({
         'transition-all duration-150',
         'min-w-[160px] max-w-[200px]',
         isDragging && 'opacity-50',
-        isDraggedOver && 'border-orange-500/70 bg-slate-700/70'
+        isDraggedOver && 'border-orange-500/70 bg-slate-700/70',
+        // Horizontal snapping for chained events: remove left border/rounded corners, add top accent
+        isChained && 'border-l-0 rounded-l-none -ml-px border-t-orange-500/50',
+        // Chain heads with dependents: square right border for continuous chain appearance
+        hasChainedDependent && 'rounded-r-none'
       )}
     >
-      {/* Drag handle on left */}
-      <div className="flex items-center justify-center px-1.5 border-r border-slate-600/30 cursor-grab active:cursor-grabbing text-slate-500 hover:text-slate-400">
-        <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
-          <path d="M7 2a2 2 0 1 0 .001 4.001A2 2 0 0 0 7 2zm0 6a2 2 0 1 0 .001 4.001A2 2 0 0 0 7 8zm0 6a2 2 0 1 0 .001 4.001A2 2 0 0 0 7 14zm6-8a2 2 0 1 0-.001-4.001A2 2 0 0 0 13 6zm0 2a2 2 0 1 0 .001 4.001A2 2 0 0 0 13 8zm0 6a2 2 0 1 0 .001 4.001A2 2 0 0 0 13 14z" />
-        </svg>
-      </div>
+      {/* Left side: Chain icon, chain toggle, or drag handle */}
+      <EventPillHandle
+        isChained={isChained}
+        canChain={canChain}
+        onChainClick={handleChainClick}
+      />
 
       {/* Content area with subtle currency color gradient */}
       <div className={cn(

--- a/src/features/spending-planner/events/event-reorder.test.ts
+++ b/src/features/spending-planner/events/event-reorder.test.ts
@@ -6,15 +6,21 @@ import {
   updateEvent,
   sortByPriority,
   generateEventId,
+  isChainedEvent,
+  isChainHead,
+  getChainFromHead,
+  getChainHead,
+  toggleEventChain,
+  canChainEvent,
 } from './event-reorder'
 import { CurrencyId } from '../types'
 import type { SpendingEvent } from '../types'
 
 describe('event-reorder', () => {
   const createTestEvents = (): SpendingEvent[] => [
-    { id: '1', name: 'Event A', currencyId: CurrencyId.Coins, amount: 100, priority: 0 },
-    { id: '2', name: 'Event B', currencyId: CurrencyId.Stones, amount: 200, priority: 1 },
-    { id: '3', name: 'Event C', currencyId: CurrencyId.Coins, amount: 300, priority: 2 },
+    { id: '1', name: 'Event A', currencyId: CurrencyId.Coins, amount: 100, priority: 0, lockedToEventId: null },
+    { id: '2', name: 'Event B', currencyId: CurrencyId.Stones, amount: 200, priority: 1, lockedToEventId: null },
+    { id: '3', name: 'Event C', currencyId: CurrencyId.Coins, amount: 300, priority: 2, lockedToEventId: null },
   ]
 
   describe('reorderEvents', () => {
@@ -182,9 +188,9 @@ describe('event-reorder', () => {
   describe('sortByPriority', () => {
     it('should sort events by priority', () => {
       const events: SpendingEvent[] = [
-        { id: '3', name: 'Event C', currencyId: CurrencyId.Coins, amount: 300, priority: 2 },
-        { id: '1', name: 'Event A', currencyId: CurrencyId.Coins, amount: 100, priority: 0 },
-        { id: '2', name: 'Event B', currencyId: CurrencyId.Stones, amount: 200, priority: 1 },
+        { id: '3', name: 'Event C', currencyId: CurrencyId.Coins, amount: 300, priority: 2, lockedToEventId: null },
+        { id: '1', name: 'Event A', currencyId: CurrencyId.Coins, amount: 100, priority: 0, lockedToEventId: null },
+        { id: '2', name: 'Event B', currencyId: CurrencyId.Stones, amount: 200, priority: 1, lockedToEventId: null },
       ]
       const result = sortByPriority(events)
 
@@ -195,8 +201,8 @@ describe('event-reorder', () => {
 
     it('should not mutate original array', () => {
       const events: SpendingEvent[] = [
-        { id: '3', name: 'Event C', currencyId: CurrencyId.Coins, amount: 300, priority: 2 },
-        { id: '1', name: 'Event A', currencyId: CurrencyId.Coins, amount: 100, priority: 0 },
+        { id: '3', name: 'Event C', currencyId: CurrencyId.Coins, amount: 300, priority: 2, lockedToEventId: null },
+        { id: '1', name: 'Event A', currencyId: CurrencyId.Coins, amount: 100, priority: 0, lockedToEventId: null },
       ]
       sortByPriority(events)
 
@@ -216,6 +222,212 @@ describe('event-reorder', () => {
     it('should start with event- prefix', () => {
       const id = generateEventId()
       expect(id.startsWith('event-')).toBe(true)
+    })
+  })
+
+  // =============================================================================
+  // Chain Helper Functions
+  // =============================================================================
+
+  describe('isChainedEvent', () => {
+    it('should return false for free-floating events', () => {
+      const event: SpendingEvent = {
+        id: '1', name: 'Event A', currencyId: CurrencyId.Coins, amount: 100, priority: 0, lockedToEventId: null,
+      }
+      expect(isChainedEvent(event)).toBe(false)
+    })
+
+    it('should return true for chained events', () => {
+      const event: SpendingEvent = {
+        id: '2', name: 'Event B', currencyId: CurrencyId.Coins, amount: 100, priority: 1, lockedToEventId: '1',
+      }
+      expect(isChainedEvent(event)).toBe(true)
+    })
+  })
+
+  describe('isChainHead', () => {
+    it('should return false for event with no dependents', () => {
+      const events = createTestEvents()
+      expect(isChainHead(events, '1')).toBe(false)
+    })
+
+    it('should return true for event with dependents', () => {
+      const events: SpendingEvent[] = [
+        { id: '1', name: 'Event A', currencyId: CurrencyId.Coins, amount: 100, priority: 0, lockedToEventId: null },
+        { id: '2', name: 'Event B', currencyId: CurrencyId.Coins, amount: 200, priority: 1, lockedToEventId: '1' },
+      ]
+      expect(isChainHead(events, '1')).toBe(true)
+    })
+
+    it('should return false for chained event even if it has dependents', () => {
+      const events: SpendingEvent[] = [
+        { id: '1', name: 'Event A', currencyId: CurrencyId.Coins, amount: 100, priority: 0, lockedToEventId: null },
+        { id: '2', name: 'Event B', currencyId: CurrencyId.Coins, amount: 200, priority: 1, lockedToEventId: '1' },
+        { id: '3', name: 'Event C', currencyId: CurrencyId.Coins, amount: 300, priority: 2, lockedToEventId: '2' },
+      ]
+      expect(isChainHead(events, '2')).toBe(false)
+    })
+
+    it('should return false for non-existent event', () => {
+      const events = createTestEvents()
+      expect(isChainHead(events, 'non-existent')).toBe(false)
+    })
+  })
+
+  describe('getChainFromHead', () => {
+    it('should return single event for event with no dependents', () => {
+      const events = createTestEvents()
+      const chain = getChainFromHead(events, '1')
+      expect(chain).toHaveLength(1)
+      expect(chain[0].id).toBe('1')
+    })
+
+    it('should return all events in a chain', () => {
+      const events: SpendingEvent[] = [
+        { id: '1', name: 'Event A', currencyId: CurrencyId.Coins, amount: 100, priority: 0, lockedToEventId: null },
+        { id: '2', name: 'Event B', currencyId: CurrencyId.Coins, amount: 200, priority: 1, lockedToEventId: '1' },
+        { id: '3', name: 'Event C', currencyId: CurrencyId.Coins, amount: 300, priority: 2, lockedToEventId: '2' },
+      ]
+      const chain = getChainFromHead(events, '1')
+      expect(chain).toHaveLength(3)
+      expect(chain[0].id).toBe('1')
+      expect(chain[1].id).toBe('2')
+      expect(chain[2].id).toBe('3')
+    })
+
+    it('should return empty array for non-existent event', () => {
+      const events = createTestEvents()
+      const chain = getChainFromHead(events, 'non-existent')
+      expect(chain).toHaveLength(0)
+    })
+  })
+
+  describe('getChainHead', () => {
+    it('should return the event itself if not chained', () => {
+      const events = createTestEvents()
+      const head = getChainHead(events, '1')
+      expect(head?.id).toBe('1')
+    })
+
+    it('should walk up to find the head of a chain', () => {
+      const events: SpendingEvent[] = [
+        { id: '1', name: 'Event A', currencyId: CurrencyId.Coins, amount: 100, priority: 0, lockedToEventId: null },
+        { id: '2', name: 'Event B', currencyId: CurrencyId.Coins, amount: 200, priority: 1, lockedToEventId: '1' },
+        { id: '3', name: 'Event C', currencyId: CurrencyId.Coins, amount: 300, priority: 2, lockedToEventId: '2' },
+      ]
+      const head = getChainHead(events, '3')
+      expect(head?.id).toBe('1')
+    })
+
+    it('should return null for non-existent event', () => {
+      const events = createTestEvents()
+      const head = getChainHead(events, 'non-existent')
+      expect(head).toBeNull()
+    })
+  })
+
+  describe('toggleEventChain', () => {
+    it('should chain event to previous when free-floating', () => {
+      const events = createTestEvents()
+      const result = toggleEventChain(events, '2')
+
+      expect(result).not.toBeNull()
+      expect(result!.find((e) => e.id === '2')?.lockedToEventId).toBe('1')
+    })
+
+    it('should make event free-floating when chained', () => {
+      const events: SpendingEvent[] = [
+        { id: '1', name: 'Event A', currencyId: CurrencyId.Coins, amount: 100, priority: 0, lockedToEventId: null },
+        { id: '2', name: 'Event B', currencyId: CurrencyId.Coins, amount: 200, priority: 1, lockedToEventId: '1' },
+      ]
+      const result = toggleEventChain(events, '2')
+
+      expect(result).not.toBeNull()
+      expect(result!.find((e) => e.id === '2')?.lockedToEventId).toBeNull()
+    })
+
+    it('should return null for first event (cannot chain)', () => {
+      const events = createTestEvents()
+      const result = toggleEventChain(events, '1')
+      expect(result).toBeNull()
+    })
+
+    it('should return null for non-existent event', () => {
+      const events = createTestEvents()
+      const result = toggleEventChain(events, 'non-existent')
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('canChainEvent', () => {
+    it('should return false for first event', () => {
+      const events = createTestEvents()
+      expect(canChainEvent(events, '1')).toBe(false)
+    })
+
+    it('should return true for non-first events', () => {
+      const events = createTestEvents()
+      expect(canChainEvent(events, '2')).toBe(true)
+      expect(canChainEvent(events, '3')).toBe(true)
+    })
+  })
+
+  describe('reorderEvents with chains', () => {
+    it('should prevent chained events from being dragged individually', () => {
+      const events: SpendingEvent[] = [
+        { id: '1', name: 'Event A', currencyId: CurrencyId.Coins, amount: 100, priority: 0, lockedToEventId: null },
+        { id: '2', name: 'Event B', currencyId: CurrencyId.Coins, amount: 200, priority: 1, lockedToEventId: '1' },
+        { id: '3', name: 'Event C', currencyId: CurrencyId.Coins, amount: 300, priority: 2, lockedToEventId: null },
+      ]
+      // Try to drag chained event (index 1) - should be prevented
+      const result = reorderEvents(events, 1, 2)
+
+      // Should return original array unchanged
+      expect(result[0].id).toBe('1')
+      expect(result[1].id).toBe('2')
+      expect(result[2].id).toBe('3')
+    })
+
+    it('should move chain head with its entire chain', () => {
+      const events: SpendingEvent[] = [
+        { id: '1', name: 'Event A', currencyId: CurrencyId.Coins, amount: 100, priority: 0, lockedToEventId: null },
+        { id: '2', name: 'Event B', currencyId: CurrencyId.Coins, amount: 200, priority: 1, lockedToEventId: '1' },
+        { id: '3', name: 'Event C', currencyId: CurrencyId.Coins, amount: 300, priority: 2, lockedToEventId: null },
+      ]
+      // Drag chain head (index 0) to after free event (index 2)
+      const result = reorderEvents(events, 0, 2)
+
+      // Chain (1, 2) should move together after event 3
+      expect(result[0].id).toBe('3')
+      expect(result[1].id).toBe('1')
+      expect(result[2].id).toBe('2')
+    })
+  })
+
+  describe('removeEvent with chains', () => {
+    it('should make dependents free-floating when anchor is deleted', () => {
+      const events: SpendingEvent[] = [
+        { id: '1', name: 'Event A', currencyId: CurrencyId.Coins, amount: 100, priority: 0, lockedToEventId: null },
+        { id: '2', name: 'Event B', currencyId: CurrencyId.Coins, amount: 200, priority: 1, lockedToEventId: '1' },
+        { id: '3', name: 'Event C', currencyId: CurrencyId.Coins, amount: 300, priority: 2, lockedToEventId: '2' },
+      ]
+      const result = removeEvent(events, '1')
+
+      expect(result).toHaveLength(2)
+      // Event 2 should now be free-floating
+      expect(result[0].lockedToEventId).toBeNull()
+      // Event 3 should still be chained to event 2
+      expect(result[1].lockedToEventId).toBe('2')
+    })
+  })
+
+  describe('addEvent with chains', () => {
+    it('should add new event as free-floating', () => {
+      const events = createTestEvents()
+      const newEvent = { id: '4', name: 'Event D', currencyId: CurrencyId.Coins, amount: 400 }
+      const result = addEvent(events, newEvent)
+
+      expect(result[3].lockedToEventId).toBeNull()
     })
   })
 })

--- a/src/features/spending-planner/events/event-reorder.ts
+++ b/src/features/spending-planner/events/event-reorder.ts
@@ -9,7 +9,13 @@ import type { SpendingEvent } from '../types'
 /**
  * Reorder events by moving an item from one index to another.
  * Also updates priority values to match the new order.
+ *
+ * Chain behavior:
+ * - Chained events cannot be dragged individually
+ * - Chain heads move their entire chain as a unit
+ * - Dropping into the middle of a chain redirects to chain head position
  */
+/* eslint-disable-next-line complexity, max-statements */
 export function reorderEvents(
   events: SpendingEvent[],
   fromIndex: number,
@@ -30,10 +36,61 @@ export function reorderEvents(
     return events
   }
 
-  // Create new array with reordered items
-  const result = [...events]
-  const [removed] = result.splice(fromIndex, 1)
-  result.splice(toIndex, 0, removed)
+  const draggedEvent = events[fromIndex]
+
+  // Chained events cannot be dragged individually
+  if (draggedEvent.lockedToEventId !== null) {
+    return events
+  }
+
+  // Get the chain for the dragged event (if it's a head)
+  const chainIds = new Set<string>()
+  const collectChain = (eventId: string) => {
+    chainIds.add(eventId)
+    for (const e of events) {
+      if (e.lockedToEventId === eventId) {
+        collectChain(e.id)
+      }
+    }
+  }
+  collectChain(draggedEvent.id)
+
+  // If dropping into a chain, find the chain head position
+  let adjustedToIndex = toIndex
+  const targetEvent = events[toIndex]
+  if (targetEvent.lockedToEventId !== null) {
+    // Find the chain head's index
+    let headEvent = targetEvent
+    while (headEvent.lockedToEventId !== null) {
+      const parent = events.find((e) => e.id === headEvent.lockedToEventId)
+      if (!parent) break
+      headEvent = parent
+    }
+    adjustedToIndex = events.findIndex((e) => e.id === headEvent.id)
+  }
+
+  // Separate chain members from other events
+  const chainEvents = events.filter((e) => chainIds.has(e.id))
+  const otherEvents = events.filter((e) => !chainIds.has(e.id))
+
+  // Calculate insertion position in the filtered array
+  // For forward moves (fromIndex < toIndex), we insert AFTER the target, so count up to and including toIndex
+  // For backward moves (fromIndex > toIndex), we insert AT the target, so count up to (not including) toIndex
+  let insertPosition = 0
+  const isMovingForward = fromIndex < adjustedToIndex
+  const countLimit = isMovingForward ? adjustedToIndex + 1 : adjustedToIndex
+  for (let i = 0; i < countLimit; i++) {
+    if (!chainIds.has(events[i].id)) {
+      insertPosition++
+    }
+  }
+
+  // Insert chain at the new position
+  const result = [
+    ...otherEvents.slice(0, insertPosition),
+    ...chainEvents,
+    ...otherEvents.slice(insertPosition),
+  ]
 
   // Update priorities to match new order
   return result.map((event, index) => ({
@@ -44,14 +101,16 @@ export function reorderEvents(
 
 /**
  * Add a new event to the queue at the end.
+ * New events are always free-floating (not chained).
  */
 export function addEvent(
   events: SpendingEvent[],
-  newEvent: Omit<SpendingEvent, 'priority'>
+  newEvent: Omit<SpendingEvent, 'priority' | 'lockedToEventId'>
 ): SpendingEvent[] {
   const eventWithPriority: SpendingEvent = {
     ...newEvent,
     priority: events.length,
+    lockedToEventId: null,
   }
   return [...events, eventWithPriority]
 }
@@ -59,16 +118,18 @@ export function addEvent(
 /**
  * Remove an event from the queue by ID.
  * Updates priorities of remaining events.
+ * Makes any events chained to the removed event free-floating.
  */
 export function removeEvent(
   events: SpendingEvent[],
   eventId: string
 ): SpendingEvent[] {
   const filtered = events.filter((e) => e.id !== eventId)
-  // Re-index priorities
+  // Re-index priorities and unchain any events that were chained to the removed event
   return filtered.map((event, index) => ({
     ...event,
     priority: index,
+    lockedToEventId: event.lockedToEventId === eventId ? null : event.lockedToEventId,
   }))
 }
 
@@ -95,6 +156,7 @@ export function sortByPriority(events: SpendingEvent[]): SpendingEvent[] {
 /**
  * Clone an existing event with a new ID.
  * The cloned event is inserted right after the original.
+ * Clones are always free-floating (not chained).
  */
 export function cloneEvent(
   events: SpendingEvent[],
@@ -109,6 +171,7 @@ export function cloneEvent(
     id: generateEventId(),
     name: `${source.name} (copy)`,
     priority: source.priority + 1,
+    lockedToEventId: null, // Clones are always free-floating
   }
 
   // Insert after the source and re-index priorities
@@ -130,3 +193,14 @@ export function cloneEvent(
 export function generateEventId(): string {
   return `event-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`
 }
+
+// Re-export chain helper functions for backward compatibility
+export {
+  isChainedEvent,
+  isChainHead,
+  getChainFromHead,
+  getChainHead,
+  toggleEventChain,
+  canChainEvent,
+  groupEventsIntoChains,
+} from './event-chain-helpers'

--- a/src/features/spending-planner/events/use-event-queue.ts
+++ b/src/features/spending-planner/events/use-event-queue.ts
@@ -13,6 +13,7 @@ import {
   updateEvent as updateEventFn,
   cloneEvent as cloneEventFn,
   generateEventId,
+  toggleEventChain as toggleEventChainFn,
 } from './event-reorder'
 
 /** Input for adding a new event */
@@ -46,6 +47,7 @@ interface UseEventQueueReturn {
   removeEvent: (events: SpendingEvent[], eventId: string) => SpendingEvent[]
   updateEvent: (events: SpendingEvent[], eventId: string, input: UpdateEventInput) => SpendingEvent[]
   cloneEvent: (events: SpendingEvent[], eventId: string) => SpendingEvent[]
+  toggleEventChain: (events: SpendingEvent[], eventId: string) => SpendingEvent[] | null
 }
 
 /**
@@ -118,6 +120,13 @@ export function useEventQueue(): UseEventQueueReturn {
     []
   )
 
+  const toggleEventChain = useCallback(
+    (events: SpendingEvent[], eventId: string): SpendingEvent[] | null => {
+      return toggleEventChainFn(events, eventId)
+    },
+    []
+  )
+
   const isDragging = draggedIndex !== null
 
   return {
@@ -132,5 +141,6 @@ export function useEventQueue(): UseEventQueueReturn {
     removeEvent,
     updateEvent,
     cloneEvent,
+    toggleEventChain,
   }
 }

--- a/src/features/spending-planner/income/derived-income-calculation.test.ts
+++ b/src/features/spending-planner/income/derived-income-calculation.test.ts
@@ -2,7 +2,6 @@
  * Derived Income Calculation Tests
  */
 
-/* eslint-disable max-lines */
 import { describe, it, expect } from 'vitest'
 import type { ParsedGameRun, GameRunField } from '@/shared/types/game-run.types'
 import { CurrencyId } from '../types'

--- a/src/features/spending-planner/spending-planner.tsx
+++ b/src/features/spending-planner/spending-planner.tsx
@@ -26,6 +26,7 @@ export function SpendingPlanner() {
     handleCloneEvent,
     handleDrop,
     handleLookbackPeriodChange,
+    handleToggleChain,
   } = useSpendingPlannerState()
 
   return (
@@ -74,6 +75,7 @@ export function SpendingPlanner() {
         onRemoveEvent={handleRemoveEvent}
         onEditEvent={handleEditEvent}
         onCloneEvent={handleCloneEvent}
+        onToggleChain={handleToggleChain}
       />
 
       {/* Timeline Visualization */}

--- a/src/features/spending-planner/types.ts
+++ b/src/features/spending-planner/types.ts
@@ -149,6 +149,8 @@ export interface SpendingEvent {
   durationDays?: number
   /** Priority order (lower = higher priority) */
   priority: number
+  /** ID of event this is chained to (null = free-floating) */
+  lockedToEventId: string | null
 }
 
 // =============================================================================

--- a/src/features/spending-planner/use-spending-planner-state.ts
+++ b/src/features/spending-planner/use-spending-planner-state.ts
@@ -58,6 +58,8 @@ interface UseSpendingPlannerStateReturn {
   handleDrop: () => void
   /** Update lookback period for derived income calculation */
   handleLookbackPeriodChange: (period: LookbackPeriod) => void
+  /** Toggle event chain state */
+  handleToggleChain: (eventId: string) => void
 }
 
 /**
@@ -229,6 +231,17 @@ export function useSpendingPlannerState(): UseSpendingPlannerStateReturn {
     eventQueue.handleDragEnd()
   }, [eventQueue, state.events])
 
+  // Toggle event chain state
+  const handleToggleChain = useCallback(
+    (eventId: string) => {
+      const newEvents = eventQueue.toggleEventChain(state.events, eventId)
+      if (newEvents) {
+        setState((prev) => ({ ...prev, events: newEvents }))
+      }
+    },
+    [eventQueue, state.events]
+  )
+
   // Calculate timeline with proration for week 0
   const timelineData = useMemo(() => {
     return calculateTimeline(state.incomes, state.events, state.timelineConfig.weeks, {
@@ -252,5 +265,6 @@ export function useSpendingPlannerState(): UseSpendingPlannerStateReturn {
     handleCloneEvent,
     handleDrop,
     handleLookbackPeriodChange,
+    handleToggleChain,
   }
 }

--- a/src/features/tools/module-calculator/manual-mode/manual-mode-logic.test.ts
+++ b/src/features/tools/module-calculator/manual-mode/manual-mode-logic.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines */
 import { describe, it, expect } from 'vitest';
 import type { CalculatorConfig, SlotTarget } from '../types';
 import type { ManualModeConfig } from './types';

--- a/src/features/tools/module-calculator/manual-mode/roll-log/roll-log-logic.test.ts
+++ b/src/features/tools/module-calculator/manual-mode/roll-log/roll-log-logic.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines */
 import { describe, it, expect } from 'vitest';
 import type { ManualSlot, RollLogEntry, RollLogEffect } from '../types';
 import {

--- a/src/shared/domain/data-migrations.test.ts
+++ b/src/shared/domain/data-migrations.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines */
 // Comprehensive test suite for data migration system requires extensive test cases
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {


### PR DESCRIPTION
## Summary
Users can now chain spending events together, creating sequential dependencies that work across different currencies. Chained events wait for their predecessor to complete before triggering, while unchained (free-floating) events execute as soon as their currency balance allows. This solves the problem where a coin purchase had to wait for a slow-accumulating stone purchase simply due to queue order.

## Technical Details
- Added `lockedToEventId: string | null` field to `SpendingEvent` interface for chain relationships
- Refactored `calculateTimeline()` to compute per-event `minTriggerWeek` based on chain status instead of strict queue order
- Created `event-chain-helpers.ts` with pure functions: `toggleEventChain`, `groupEventsIntoChains`, `getChainFromHead`, `isChainedEvent`
- Added `ChainIcon` component using lucide-react Link icon with active/inactive states
- Updated `EventPill` with chain toggle button and visual snapping (borderless left edge for chained events)
- Modified `reorderEvents()` to move entire chains as units when dragging chain heads
- Added comprehensive test coverage for chain logic and timeline calculations
- ESLint: disabled `max-lines` rule for test files globally (removes inline suppressions)

## Context
The previous queue model forced strict sequential execution regardless of currency type, preventing optimal resource allocation when multiple currencies accumulate at different rates.
