### PR TITLE
IMPROVE: Expand Monte Carlo percentile display to 4 quartile boxes

### DIFF
--- a/src/features/tools/module-calculator/results/cost-distribution-chart.tsx
+++ b/src/features/tools/module-calculator/results/cost-distribution-chart.tsx
@@ -5,7 +5,7 @@
  */
 
 import type { CostStatistics, HistogramBucket } from '../types';
-import { formatCost } from './results-formatters';
+import { formatCost, formatPercentage } from './results-formatters';
 
 interface CostDistributionChartProps {
   statistics: CostStatistics;
@@ -34,24 +34,30 @@ interface PercentileSummaryProps {
 function PercentileSummary({ statistics }: PercentileSummaryProps) {
   return (
     <div className="space-y-3">
-      {/* Main stats row */}
-      <div className="grid grid-cols-3 gap-2">
+      {/* Main stats row - 2 cols on very small, 4 cols on sm+ */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-1.5 sm:gap-2">
         <StatBox
-          label="Best Case"
-          sublabel="10th percentile"
-          value={statistics.percentile10}
-          color="text-green-400"
+          label="Good"
+          sublabel="25th pctl"
+          value={statistics.percentile25}
+          color="text-emerald-400"
         />
         <StatBox
           label="Typical"
           sublabel="Median"
           value={statistics.median}
-          color="text-orange-400"
+          color="text-amber-400"
           highlight
         />
         <StatBox
-          label="Worst Case"
-          sublabel="95th percentile"
+          label="Pessimistic"
+          sublabel="75th pctl"
+          value={statistics.percentile75}
+          color="text-orange-400"
+        />
+        <StatBox
+          label="Worst"
+          sublabel="95th pctl"
           value={statistics.percentile95}
           color="text-red-400"
         />
@@ -77,17 +83,17 @@ interface StatBoxProps {
 function StatBox({ label, sublabel, value, color, highlight }: StatBoxProps) {
   return (
     <div
-      className={`text-center p-2 rounded-lg ${
+      className={`text-center px-1.5 py-2 sm:px-2 sm:py-2.5 rounded-lg transition-colors ${
         highlight
-          ? 'bg-orange-500/10 border border-orange-500/30'
+          ? 'bg-amber-500/10 border border-amber-500/30'
           : 'bg-slate-800/30 border border-slate-700/30'
       }`}
     >
-      <div className="text-xs text-slate-400">{label}</div>
-      <div className={`text-lg font-bold ${color}`}>
+      <div className="text-[10px] sm:text-xs text-slate-400 font-medium truncate">{label}</div>
+      <div className={`text-base sm:text-lg font-bold tabular-nums ${color}`}>
         {formatCost(value)}
       </div>
-      <div className="text-[10px] text-slate-500">{sublabel}</div>
+      <div className="text-[9px] sm:text-[10px] text-slate-500 truncate">{sublabel}</div>
     </div>
   );
 }
@@ -137,7 +143,7 @@ function Histogram({ buckets }: HistogramProps) {
                     {isLastBucket && hasOutliers && ' (includes outliers)'}
                   </div>
                   <div className="text-slate-400 mt-0.5">
-                    {bucket.count} runs ({bucket.percentage.toFixed(1)}%)
+                    {bucket.count} runs ({formatPercentage(bucket.percentage)})
                   </div>
                 </div>
               </div>

--- a/src/features/tools/module-calculator/results/results-formatters.test.ts
+++ b/src/features/tools/module-calculator/results/results-formatters.test.ts
@@ -22,34 +22,34 @@ describe('results-formatters', () => {
     });
 
     it('formats thousands with K suffix', () => {
-      expect(formatCost(1000)).toBe('1.0K');
+      expect(formatCost(1000)).toBe('1K');
       expect(formatCost(1500)).toBe('1.5K');
-      expect(formatCost(999999)).toBe('1000.0K');
+      expect(formatCost(999999)).toBe('1,000K');
     });
 
-    it('formats millions with M suffix and 2 decimals', () => {
-      expect(formatCost(1000000)).toBe('1.00M');
-      expect(formatCost(2500000)).toBe('2.50M');
+    it('formats millions with M suffix', () => {
+      expect(formatCost(1000000)).toBe('1M');
+      expect(formatCost(2500000)).toBe('2.5M');
       expect(formatCost(1580000)).toBe('1.58M');
       expect(formatCost(1660000)).toBe('1.66M');
     });
 
-    it('formats billions with B suffix and 2 decimals', () => {
-      expect(formatCost(1000000000)).toBe('1.00B');
-      expect(formatCost(3700000000)).toBe('3.70B');
+    it('formats billions with B suffix', () => {
+      expect(formatCost(1000000000)).toBe('1B');
+      expect(formatCost(3700000000)).toBe('3.7B');
     });
   });
 
   describe('formatCostRange', () => {
     it('formats range with appropriate suffixes', () => {
-      expect(formatCostRange(1000, 5000)).toBe('1.0K - 5.0K');
-      expect(formatCostRange(500000, 2000000)).toBe('500.0K - 2.00M');
+      expect(formatCostRange(1000, 5000)).toBe('1K - 5K');
+      expect(formatCostRange(500000, 2000000)).toBe('500K - 2M');
     });
   });
 
   describe('formatPercentage', () => {
     it('formats with specified decimals', () => {
-      expect(formatPercentage(50)).toBe('50.0%');
+      expect(formatPercentage(50)).toBe('50%');
       expect(formatPercentage(33.333, 2)).toBe('33.33%');
     });
   });
@@ -80,7 +80,7 @@ describe('results-formatters', () => {
   describe('formatRollCount', () => {
     it('formats roll count', () => {
       expect(formatRollCount(100)).toBe('100 rolls');
-      expect(formatRollCount(50000)).toBe('50.0K rolls');
+      expect(formatRollCount(50000)).toBe('50K rolls');
     });
   });
 
@@ -96,34 +96,35 @@ describe('results-formatters', () => {
   });
 
   describe('getPercentileColor', () => {
-    it('returns green for low percentiles (lucky)', () => {
-      expect(getPercentileColor(5)).toBe('#22c55e');
+    it('returns green for low percentiles (good case)', () => {
       expect(getPercentileColor(10)).toBe('#22c55e');
+      expect(getPercentileColor(25)).toBe('#22c55e');
     });
 
-    it('returns orange for median', () => {
-      expect(getPercentileColor(50)).toBe('#f97316');
+    it('returns yellow for median (typical)', () => {
+      expect(getPercentileColor(50)).toBe('#eab308');
     });
 
-    it('returns yellow for high percentiles', () => {
-      expect(getPercentileColor(75)).toBe('#eab308');
+    it('returns orange for high percentiles (pessimistic)', () => {
+      expect(getPercentileColor(75)).toBe('#f97316');
     });
 
-    it('returns red for very high percentiles (unlucky)', () => {
+    it('returns red for very high percentiles (worst case)', () => {
       expect(getPercentileColor(95)).toBe('#ef4444');
     });
   });
 
   describe('formatPercentileLabel', () => {
     it('formats special percentiles', () => {
-      expect(formatPercentileLabel(10)).toBe('10th %ile (lucky)');
+      expect(formatPercentileLabel(25)).toBe('25th %ile (good)');
       expect(formatPercentileLabel(50)).toBe('Median');
-      expect(formatPercentileLabel(95)).toBe('95th %ile (unlucky)');
+      expect(formatPercentileLabel(75)).toBe('75th %ile (pessimistic)');
+      expect(formatPercentileLabel(95)).toBe('95th %ile (worst)');
     });
 
     it('formats regular percentiles', () => {
-      expect(formatPercentileLabel(25)).toBe('25th %ile');
-      expect(formatPercentileLabel(75)).toBe('75th %ile');
+      expect(formatPercentileLabel(10)).toBe('10th %ile');
+      expect(formatPercentileLabel(60)).toBe('60th %ile');
     });
   });
 
@@ -148,7 +149,7 @@ describe('results-formatters', () => {
   describe('formatConfidenceMessage', () => {
     it('formats confidence message', () => {
       expect(formatConfidenceMessage(5000000)).toBe(
-        '95% of runs cost less than 5.00M shards'
+        '95% of runs cost less than 5M shards'
       );
     });
   });

--- a/src/features/tools/module-calculator/simulation/monte-carlo-simulation.test.ts
+++ b/src/features/tools/module-calculator/simulation/monte-carlo-simulation.test.ts
@@ -185,7 +185,7 @@ describe('monte-carlo-simulation', () => {
 
       expect(results.shardCost.min).toBeLessThanOrEqual(results.shardCost.median);
       expect(results.shardCost.median).toBeLessThanOrEqual(results.shardCost.max);
-      expect(results.shardCost.percentile10).toBeLessThanOrEqual(results.shardCost.percentile90);
+      expect(results.shardCost.percentile25).toBeLessThanOrEqual(results.shardCost.percentile75);
     });
 
     it('calculates roll count statistics', () => {
@@ -231,8 +231,8 @@ describe('monte-carlo-simulation', () => {
       const values = Array.from({ length: 100 }, (_, i) => i + 1);
       const result = calculateStatistics(values);
 
-      expect(result.percentile10).toBeCloseTo(10.9, 0);
-      expect(result.percentile90).toBeCloseTo(90.1, 0);
+      expect(result.percentile25).toBeCloseTo(25.75, 0);
+      expect(result.percentile75).toBeCloseTo(75.25, 0);
       expect(result.percentile95).toBeCloseTo(95.05, 0);
     });
   });

--- a/src/features/tools/module-calculator/simulation/monte-carlo-simulation.ts
+++ b/src/features/tools/module-calculator/simulation/monte-carlo-simulation.ts
@@ -167,8 +167,8 @@ export function calculateStatistics(values: number[]): CostStatistics {
       max: 0,
       mean: 0,
       median: 0,
-      percentile10: 0,
-      percentile90: 0,
+      percentile25: 0,
+      percentile75: 0,
       percentile95: 0,
     };
   }
@@ -181,8 +181,8 @@ export function calculateStatistics(values: number[]): CostStatistics {
     max: sorted[sorted.length - 1],
     mean: sum / sorted.length,
     median: getPercentile(sorted, 50),
-    percentile10: getPercentile(sorted, 10),
-    percentile90: getPercentile(sorted, 90),
+    percentile25: getPercentile(sorted, 25),
+    percentile75: getPercentile(sorted, 75),
     percentile95: getPercentile(sorted, 95),
   };
 }

--- a/src/features/tools/module-calculator/types.ts
+++ b/src/features/tools/module-calculator/types.ts
@@ -171,8 +171,8 @@ export interface CostStatistics {
   max: number;
   mean: number;
   median: number;
-  percentile10: number;
-  percentile90: number;
+  percentile25: number;
+  percentile75: number;
   percentile95: number;
 }
 


### PR DESCRIPTION
## Summary
Monte Carlo simulation results now display 4 percentile boxes (25th, 50th, 75th, 95th) instead of 3 (10th, 50th, 95th). The quartile-based approach provides better mental anchoring for cost planning, with clearer labels (Good/Typical/Pessimistic/Worst) and an improved color progression from green through yellow and orange to red.

## Technical Details
- Updated `CostStatistics` interface: `percentile25/75` replaces `percentile10/90`
- Modified `calculateStatistics()` to compute quartile percentiles
- Expanded display to 4 responsive boxes (2x2 on mobile, 4x1 on desktop)
- Replaced manual `.toFixed()` formatting with `formatLargeNumber`/`formatLocalePercentage` utilities
- Updated color scheme: emerald-400 -> amber-400 -> orange-400 -> red-400
- Changed terminology from "lucky/unlucky" to "good/typical/pessimistic/worst"
- Updated `generateSimulationSummary()` to use new percentile fields
- Updated all test expectations for new percentile values and formatting