### PR TITLE
IMPROVE: Add calendar-aware trend windows with period-specific options

### DIFF
--- a/src/features/analysis/time-series/moving-average/index.ts
+++ b/src/features/analysis/time-series/moving-average/index.ts
@@ -2,4 +2,7 @@ export { calculateMovingAverage } from './moving-average-calculation'
 export { useMovingAverage } from './use-moving-average'
 export { MovingAverageSelector } from './moving-average-selector'
 
-export type { MovingAveragePeriod } from './moving-average-types'
+export type { TrendWindowValue,  } from './moving-average-types'
+
+
+

--- a/src/features/analysis/time-series/moving-average/moving-average-persistence.test.ts
+++ b/src/features/analysis/time-series/moving-average/moving-average-persistence.test.ts
@@ -1,154 +1,234 @@
 import { describe, it, expect, beforeEach } from 'vitest'
-import { loadMovingAveragePeriod, saveMovingAveragePeriod, clearMovingAverageConfig } from './moving-average-persistence'
+import {
+  loadTrendWindow,
+  saveTrendWindow,
+  clearTrendWindowConfig,
+  buildCompoundKey,
+} from './moving-average-persistence'
 
 describe('moving-average-persistence', () => {
   beforeEach(() => {
-    // Clear localStorage before each test
     localStorage.clear()
   })
 
-  describe('loadMovingAveragePeriod', () => {
+  describe('buildCompoundKey', () => {
+    it('creates compound key from metric and period', () => {
+      expect(buildCompoundKey('coinsEarned', 'daily')).toBe('coinsEarned:daily')
+      expect(buildCompoundKey('totalDamage', 'weekly')).toBe('totalDamage:weekly')
+      expect(buildCompoundKey('cellsEarned', 'run')).toBe('cellsEarned:run')
+    })
+  })
+
+  describe('loadTrendWindow', () => {
     it('returns "none" when no stored value exists', () => {
-      const result = loadMovingAveragePeriod('coinsEarned')
+      const result = loadTrendWindow('coinsEarned', 'daily')
       expect(result).toBe('none')
     })
 
-    it('returns stored numeric value when present', () => {
-      localStorage.setItem('tower-tracking-moving-average-config', JSON.stringify({
-        coinsEarned: 5,
-      }))
+    it('returns stored value when present', () => {
+      localStorage.setItem(
+        'tower-tracking-moving-average-config',
+        JSON.stringify({
+          'coinsEarned:daily': '7d',
+        })
+      )
 
-      const result = loadMovingAveragePeriod('coinsEarned')
-      expect(result).toBe(5)
+      const result = loadTrendWindow('coinsEarned', 'daily')
+      expect(result).toBe('7d')
     })
 
     it('returns stored "none" value when present', () => {
-      localStorage.setItem('tower-tracking-moving-average-config', JSON.stringify({
-        coinsEarned: 'none',
-      }))
+      localStorage.setItem(
+        'tower-tracking-moving-average-config',
+        JSON.stringify({
+          'coinsEarned:daily': 'none',
+        })
+      )
 
-      const result = loadMovingAveragePeriod('coinsEarned')
+      const result = loadTrendWindow('coinsEarned', 'daily')
       expect(result).toBe('none')
     })
 
-    it('returns different values for different metrics', () => {
-      localStorage.setItem('tower-tracking-moving-average-config', JSON.stringify({
-        coinsEarned: 3,
-        cellsEarned: 10,
-        totalDamage: 'none',
-      }))
+    it('returns different values for different metric+period combinations', () => {
+      localStorage.setItem(
+        'tower-tracking-moving-average-config',
+        JSON.stringify({
+          'coinsEarned:daily': '7d',
+          'coinsEarned:weekly': '2w',
+          'totalDamage:daily': '14d',
+        })
+      )
 
-      expect(loadMovingAveragePeriod('coinsEarned')).toBe(3)
-      expect(loadMovingAveragePeriod('cellsEarned')).toBe(10)
-      expect(loadMovingAveragePeriod('totalDamage')).toBe('none')
+      expect(loadTrendWindow('coinsEarned', 'daily')).toBe('7d')
+      expect(loadTrendWindow('coinsEarned', 'weekly')).toBe('2w')
+      expect(loadTrendWindow('totalDamage', 'daily')).toBe('14d')
     })
 
-    it('returns "none" for unknown metric key', () => {
-      localStorage.setItem('tower-tracking-moving-average-config', JSON.stringify({
-        coinsEarned: 5,
-      }))
+    it('returns "none" for unknown metric+period combination', () => {
+      localStorage.setItem(
+        'tower-tracking-moving-average-config',
+        JSON.stringify({
+          'coinsEarned:daily': '7d',
+        })
+      )
 
-      const result = loadMovingAveragePeriod('unknownMetric')
+      const result = loadTrendWindow('unknownMetric', 'daily')
       expect(result).toBe('none')
     })
 
     it('returns "none" for invalid stored value', () => {
-      localStorage.setItem('tower-tracking-moving-average-config', JSON.stringify({
-        coinsEarned: 7, // Invalid moving average period
-      }))
+      localStorage.setItem(
+        'tower-tracking-moving-average-config',
+        JSON.stringify({
+          'coinsEarned:daily': 'invalidValue',
+        })
+      )
 
-      const result = loadMovingAveragePeriod('coinsEarned')
+      const result = loadTrendWindow('coinsEarned', 'daily')
       expect(result).toBe('none')
     })
 
     it('returns "none" when stored JSON is malformed', () => {
       localStorage.setItem('tower-tracking-moving-average-config', 'not valid json')
 
-      const result = loadMovingAveragePeriod('coinsEarned')
+      const result = loadTrendWindow('coinsEarned', 'daily')
       expect(result).toBe('none')
     })
   })
 
-  describe('saveMovingAveragePeriod', () => {
-    it('saves value to localStorage', () => {
-      saveMovingAveragePeriod('coinsEarned', 5)
+  describe('saveTrendWindow', () => {
+    it('saves value to localStorage with compound key', () => {
+      saveTrendWindow('coinsEarned', 'daily', '7d')
 
       const stored = localStorage.getItem('tower-tracking-moving-average-config')
       expect(stored).toBeTruthy()
-      expect(JSON.parse(stored!)).toEqual({ coinsEarned: 5 })
+      expect(JSON.parse(stored!)).toEqual({ 'coinsEarned:daily': '7d' })
     })
 
     it('merges with existing config', () => {
-      localStorage.setItem('tower-tracking-moving-average-config', JSON.stringify({
-        cellsEarned: 10,
-      }))
+      localStorage.setItem(
+        'tower-tracking-moving-average-config',
+        JSON.stringify({
+          'cellsEarned:weekly': '2w',
+        })
+      )
 
-      saveMovingAveragePeriod('coinsEarned', 5)
+      saveTrendWindow('coinsEarned', 'daily', '7d')
 
       const stored = localStorage.getItem('tower-tracking-moving-average-config')
       expect(JSON.parse(stored!)).toEqual({
-        cellsEarned: 10,
-        coinsEarned: 5,
+        'cellsEarned:weekly': '2w',
+        'coinsEarned:daily': '7d',
       })
     })
 
-    it('overwrites existing value for same metric', () => {
-      localStorage.setItem('tower-tracking-moving-average-config', JSON.stringify({
-        coinsEarned: 3,
-      }))
+    it('overwrites existing value for same metric+period', () => {
+      localStorage.setItem(
+        'tower-tracking-moving-average-config',
+        JSON.stringify({
+          'coinsEarned:daily': '3d',
+        })
+      )
 
-      saveMovingAveragePeriod('coinsEarned', 10)
+      saveTrendWindow('coinsEarned', 'daily', '14d')
 
       const stored = localStorage.getItem('tower-tracking-moving-average-config')
-      expect(JSON.parse(stored!)).toEqual({ coinsEarned: 10 })
+      expect(JSON.parse(stored!)).toEqual({ 'coinsEarned:daily': '14d' })
     })
 
     it('handles "none" value', () => {
-      saveMovingAveragePeriod('coinsEarned', 'none')
+      saveTrendWindow('coinsEarned', 'daily', 'none')
 
       const stored = localStorage.getItem('tower-tracking-moving-average-config')
-      expect(JSON.parse(stored!)).toEqual({ coinsEarned: 'none' })
+      expect(JSON.parse(stored!)).toEqual({ 'coinsEarned:daily': 'none' })
+    })
+
+    it('stores independent values for same metric with different periods', () => {
+      saveTrendWindow('coinsEarned', 'daily', '7d')
+      saveTrendWindow('coinsEarned', 'weekly', '2w')
+      saveTrendWindow('coinsEarned', 'monthly', '3m')
+
+      const stored = localStorage.getItem('tower-tracking-moving-average-config')
+      expect(JSON.parse(stored!)).toEqual({
+        'coinsEarned:daily': '7d',
+        'coinsEarned:weekly': '2w',
+        'coinsEarned:monthly': '3m',
+      })
     })
   })
 
-  describe('clearMovingAverageConfig', () => {
+  describe('clearTrendWindowConfig', () => {
     it('removes config from localStorage', () => {
-      localStorage.setItem('tower-tracking-moving-average-config', JSON.stringify({
-        coinsEarned: 5,
-      }))
+      localStorage.setItem(
+        'tower-tracking-moving-average-config',
+        JSON.stringify({
+          'coinsEarned:daily': '7d',
+        })
+      )
 
-      clearMovingAverageConfig()
+      clearTrendWindowConfig()
 
       expect(localStorage.getItem('tower-tracking-moving-average-config')).toBeNull()
     })
 
     it('does not throw when no config exists', () => {
-      expect(() => clearMovingAverageConfig()).not.toThrow()
+      expect(() => clearTrendWindowConfig()).not.toThrow()
+    })
+  })
+
+  describe('legacy format migration', () => {
+    it('clears legacy format (bare numbers) and returns default', () => {
+      // Legacy format: { "coinsEarned": 5, "totalDamage": 3 }
+      localStorage.setItem(
+        'tower-tracking-moving-average-config',
+        JSON.stringify({
+          coinsEarned: 5,
+          totalDamage: 3,
+        })
+      )
+
+      // Loading should detect legacy format and clear it
+      const result = loadTrendWindow('coinsEarned', 'daily')
+      expect(result).toBe('none')
+
+      // Storage should be cleared
+      expect(localStorage.getItem('tower-tracking-moving-average-config')).toBeNull()
+    })
+
+    it('handles mixed legacy and new format by treating as legacy', () => {
+      localStorage.setItem(
+        'tower-tracking-moving-average-config',
+        JSON.stringify({
+          coinsEarned: 5, // Legacy numeric value
+          'totalDamage:daily': '7d', // New format
+        })
+      )
+
+      // Should detect legacy format and clear all
+      const result = loadTrendWindow('coinsEarned', 'daily')
+      expect(result).toBe('none')
+      expect(localStorage.getItem('tower-tracking-moving-average-config')).toBeNull()
     })
   })
 
   describe('SSR safety', () => {
-    it('loadMovingAveragePeriod handles SSR environment', () => {
-      // Mock window being undefined
+    it('loadTrendWindow handles SSR environment', () => {
       const originalWindow = global.window
       // @ts-expect-error - Testing SSR behavior
       delete global.window
 
-      // This should not throw and return default
-      const result = loadMovingAveragePeriod('coinsEarned')
+      const result = loadTrendWindow('coinsEarned', 'daily')
       expect(result).toBe('none')
 
-      // Restore window
       global.window = originalWindow
     })
 
-    it('saveMovingAveragePeriod handles SSR environment silently', () => {
+    it('saveTrendWindow handles SSR environment silently', () => {
       const originalWindow = global.window
       // @ts-expect-error - Testing SSR behavior
       delete global.window
 
-      // This should not throw
-      expect(() => saveMovingAveragePeriod('coinsEarned', 5)).not.toThrow()
+      expect(() => saveTrendWindow('coinsEarned', 'daily', '7d')).not.toThrow()
 
       global.window = originalWindow
     })

--- a/src/features/analysis/time-series/moving-average/moving-average-persistence.ts
+++ b/src/features/analysis/time-series/moving-average/moving-average-persistence.ts
@@ -1,62 +1,120 @@
-import { isValidMovingAveragePeriod, type MovingAveragePeriod } from './moving-average-types'
+import type { TimePeriod } from '../chart-types'
+import {
+  isValidTrendWindowValue,
+  getDefaultTrendWindow,
+  type TrendWindowValue,
+} from './moving-average-types'
 
 const STORAGE_KEY = 'tower-tracking-moving-average-config'
 
-interface MovingAverageConfig {
-  [metricKey: string]: MovingAveragePeriod
+interface TrendWindowConfig {
+  [compoundKey: string]: TrendWindowValue
 }
 
 /**
- * Load moving average period for a specific metric from localStorage
- * Returns 'none' as default if no stored value or on SSR
+ * Build compound key from metric and period.
+ * Format: "metricKey:period" (e.g., "coinsEarned:daily")
  */
-export function loadMovingAveragePeriod(metricKey: string): MovingAveragePeriod {
-  if (typeof window === 'undefined') return 'none'
+export function buildCompoundKey(metricKey: string, period: TimePeriod): string {
+  return `${metricKey}:${period}`
+}
+
+/**
+ * Check if stored config is in legacy format (bare numbers like 3, 5, 10).
+ * Legacy format: { "coinsEarned": 5, "totalDamage": 3 }
+ * New format: { "coinsEarned:daily": "7d", "totalDamage:weekly": "2w" }
+ */
+function isLegacyFormat(config: unknown): boolean {
+  if (!config || typeof config !== 'object') return false
+
+  return Object.values(config).some(
+    (value) => typeof value === 'number' && [3, 5, 10].includes(value)
+  )
+}
+
+/**
+ * Load stored config, migrating from legacy format if needed.
+ * Returns empty object if legacy format detected (migration clears old data).
+ */
+function loadConfig(): TrendWindowConfig {
+  if (typeof window === 'undefined') return {}
 
   try {
     const stored = localStorage.getItem(STORAGE_KEY)
-    if (!stored) return 'none'
+    if (!stored) return {}
 
-    const config: MovingAverageConfig = JSON.parse(stored)
-    const value = config[metricKey]
+    const config = JSON.parse(stored)
 
-    // Validate stored value is a valid MovingAveragePeriod
-    if (isValidMovingAveragePeriod(value)) {
-      return value
+    // Detect and clear legacy format
+    if (isLegacyFormat(config)) {
+      localStorage.removeItem(STORAGE_KEY)
+      return {}
     }
-    return 'none'
+
+    return config as TrendWindowConfig
   } catch {
-    return 'none'
+    return {}
   }
 }
 
 /**
- * Save moving average period for a specific metric to localStorage
- * Merges with existing config, SSR-safe
+ * Save config to localStorage
  */
-export function saveMovingAveragePeriod(metricKey: string, period: MovingAveragePeriod): void {
+function saveConfig(config: TrendWindowConfig): void {
   if (typeof window === 'undefined') return
 
   try {
-    const stored = localStorage.getItem(STORAGE_KEY)
-    const config: MovingAverageConfig = stored ? JSON.parse(stored) : {}
-    config[metricKey] = period
     localStorage.setItem(STORAGE_KEY, JSON.stringify(config))
   } catch (error) {
-    console.error('Failed to save moving average config:', error)
+    console.error('Failed to save trend window config:', error)
   }
 }
 
 /**
- * Clear all moving average configurations from localStorage
- * Useful for testing or reset functionality
+ * Load trend window value for a specific metric and period from localStorage.
+ * Returns 'none' as default if no stored value or on SSR.
  */
-export function clearMovingAverageConfig(): void {
+export function loadTrendWindow(metricKey: string, period: TimePeriod): TrendWindowValue {
+  const config = loadConfig()
+  const compoundKey = buildCompoundKey(metricKey, period)
+  const value = config[compoundKey]
+
+  // Validate stored value is a valid TrendWindowValue
+  if (isValidTrendWindowValue(value)) {
+    return value
+  }
+
+  return getDefaultTrendWindow()
+}
+
+/**
+ * Save trend window value for a specific metric and period to localStorage.
+ * Merges with existing config, SSR-safe.
+ */
+export function saveTrendWindow(
+  metricKey: string,
+  period: TimePeriod,
+  value: TrendWindowValue
+): void {
+  if (typeof window === 'undefined') return
+
+  const config = loadConfig()
+  const compoundKey = buildCompoundKey(metricKey, period)
+  config[compoundKey] = value
+  saveConfig(config)
+}
+
+/**
+ * Clear all trend window configurations from localStorage.
+ * Useful for testing or reset functionality.
+ */
+export function clearTrendWindowConfig(): void {
   if (typeof window === 'undefined') return
 
   try {
     localStorage.removeItem(STORAGE_KEY)
   } catch (error) {
-    console.error('Failed to clear moving average config:', error)
+    console.error('Failed to clear trend window config:', error)
   }
 }
+

--- a/src/features/analysis/time-series/moving-average/moving-average-selector.tsx
+++ b/src/features/analysis/time-series/moving-average/moving-average-selector.tsx
@@ -1,39 +1,44 @@
 import { FormControl, Select } from '@/components/ui'
-import { MovingAveragePeriod, MOVING_AVERAGE_OPTIONS } from './moving-average-types'
+import type { TimePeriod } from '../chart-types'
+import { getTrendWindowOptions, type TrendWindowValue } from './moving-average-types'
 import { cn } from '@/shared/lib/utils'
 
 interface MovingAverageSelectorProps {
-  value: MovingAveragePeriod
-  onChange: (period: MovingAveragePeriod) => void
+  value: TrendWindowValue
+  period: TimePeriod
+  onChange: (value: TrendWindowValue) => void
 }
 
 /**
- * Dropdown selector for moving average window size
- * Renders next to the Data Points indicator in time series charts
+ * Dropdown selector for trend window size.
+ * Renders next to the Data Points indicator in time series charts.
+ * Options are context-aware based on the selected time period.
  *
- * When a moving average period is selected (not 'none'), the selector shows a subtle
+ * When a trend window is selected (not 'none'), the selector shows a subtle
  * orange accent to indicate the trend line is active on the chart.
  */
-export function MovingAverageSelector({ value, onChange }: MovingAverageSelectorProps) {
+export function MovingAverageSelector({
+  value,
+  period,
+  onChange,
+}: MovingAverageSelectorProps) {
   const isActive = value !== 'none'
+  const options = getTrendWindowOptions(period)
 
   return (
     <FormControl label="Trend" layout="vertical">
       <Select
-        value={String(value)}
-        onChange={(e) => {
-          const val = e.target.value
-          onChange(val === 'none' ? 'none' : (Number(val) as 3 | 5 | 10))
-        }}
+        value={value}
+        onChange={(e) => onChange(e.target.value as TrendWindowValue)}
         size="compact"
         data-testid="moving-average-selector"
         className={cn(
-          "transition-colors duration-200",
-          isActive && "border-orange-500/50 text-orange-100"
+          'transition-colors duration-200',
+          isActive && 'bg-orange-950/30 border-orange-500/50 text-orange-100'
         )}
       >
-        {MOVING_AVERAGE_OPTIONS.map((opt) => (
-          <option key={String(opt.value)} value={String(opt.value)}>
+        {options.map((opt) => (
+          <option key={opt.value} value={opt.value}>
             {opt.label}
           </option>
         ))}

--- a/src/features/analysis/time-series/moving-average/moving-average-types.test.ts
+++ b/src/features/analysis/time-series/moving-average/moving-average-types.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect } from 'vitest'
+import {
+  getWindowSize,
+  getTrendWindowOptions,
+  getDefaultTrendWindow,
+  isValidTrendWindowValue,
+  isValidForPeriod,
+  type TrendWindowValue,
+} from './moving-average-types'
+
+describe('moving-average-types', () => {
+  describe('getWindowSize', () => {
+    it('returns null for "none"', () => {
+      expect(getWindowSize('none')).toBeNull()
+    })
+
+    it('returns numeric value for hourly options', () => {
+      expect(getWindowSize('6h')).toBe(6)
+      expect(getWindowSize('12h')).toBe(12)
+      expect(getWindowSize('24h')).toBe(24)
+      expect(getWindowSize('48h')).toBe(48)
+    })
+
+    it('returns numeric value for run options', () => {
+      expect(getWindowSize('3r')).toBe(3)
+      expect(getWindowSize('5r')).toBe(5)
+      expect(getWindowSize('10r')).toBe(10)
+    })
+
+    it('returns numeric value for daily options', () => {
+      expect(getWindowSize('3d')).toBe(3)
+      expect(getWindowSize('7d')).toBe(7)
+      expect(getWindowSize('14d')).toBe(14)
+      expect(getWindowSize('21d')).toBe(21)
+    })
+
+    it('returns numeric value for weekly options', () => {
+      expect(getWindowSize('2w')).toBe(2)
+      expect(getWindowSize('3w')).toBe(3)
+      expect(getWindowSize('4w')).toBe(4)
+    })
+
+    it('returns numeric value for monthly options', () => {
+      expect(getWindowSize('2m')).toBe(2)
+      expect(getWindowSize('3m')).toBe(3)
+      expect(getWindowSize('4m')).toBe(4)
+    })
+  })
+
+  describe('getTrendWindowOptions', () => {
+    it('returns hourly options for hourly period', () => {
+      const options = getTrendWindowOptions('hourly')
+      expect(options).toHaveLength(5)
+      expect(options[0]).toEqual({ value: 'none', label: 'No Trend' })
+      expect(options[1]).toEqual({ value: '6h', label: '6 hours' })
+      expect(options[4]).toEqual({ value: '48h', label: '48 hours' })
+    })
+
+    it('returns run options for run period', () => {
+      const options = getTrendWindowOptions('run')
+      expect(options).toHaveLength(4)
+      expect(options[0]).toEqual({ value: 'none', label: 'No Trend' })
+      expect(options[1]).toEqual({ value: '3r', label: '3 runs' })
+      expect(options[3]).toEqual({ value: '10r', label: '10 runs' })
+    })
+
+    it('returns daily options for daily period', () => {
+      const options = getTrendWindowOptions('daily')
+      expect(options).toHaveLength(5)
+      expect(options[0]).toEqual({ value: 'none', label: 'No Trend' })
+      expect(options[1]).toEqual({ value: '3d', label: '3 days' })
+      expect(options[2]).toEqual({ value: '7d', label: '7 days' })
+    })
+
+    it('returns weekly options for weekly period', () => {
+      const options = getTrendWindowOptions('weekly')
+      expect(options).toHaveLength(4)
+      expect(options[0]).toEqual({ value: 'none', label: 'No Trend' })
+      expect(options[1]).toEqual({ value: '2w', label: '2 weeks' })
+      expect(options[2]).toEqual({ value: '3w', label: '3 weeks' })
+    })
+
+    it('returns monthly options for monthly period', () => {
+      const options = getTrendWindowOptions('monthly')
+      expect(options).toHaveLength(4)
+      expect(options[0]).toEqual({ value: 'none', label: 'No Trend' })
+      expect(options[1]).toEqual({ value: '2m', label: '2 months' })
+      expect(options[2]).toEqual({ value: '3m', label: '3 months' })
+    })
+
+    it('returns only "none" for yearly period', () => {
+      const options = getTrendWindowOptions('yearly')
+      expect(options).toHaveLength(1)
+      expect(options[0]).toEqual({ value: 'none', label: 'No Trend' })
+    })
+  })
+
+  describe('getDefaultTrendWindow', () => {
+    it('returns "none"', () => {
+      expect(getDefaultTrendWindow()).toBe('none')
+    })
+  })
+
+  describe('isValidTrendWindowValue', () => {
+    it('returns true for "none"', () => {
+      expect(isValidTrendWindowValue('none')).toBe(true)
+    })
+
+    it('returns true for valid hourly values', () => {
+      expect(isValidTrendWindowValue('6h')).toBe(true)
+      expect(isValidTrendWindowValue('12h')).toBe(true)
+      expect(isValidTrendWindowValue('24h')).toBe(true)
+      expect(isValidTrendWindowValue('48h')).toBe(true)
+    })
+
+    it('returns true for valid run values', () => {
+      expect(isValidTrendWindowValue('3r')).toBe(true)
+      expect(isValidTrendWindowValue('5r')).toBe(true)
+      expect(isValidTrendWindowValue('10r')).toBe(true)
+    })
+
+    it('returns true for valid daily values', () => {
+      expect(isValidTrendWindowValue('3d')).toBe(true)
+      expect(isValidTrendWindowValue('7d')).toBe(true)
+      expect(isValidTrendWindowValue('14d')).toBe(true)
+      expect(isValidTrendWindowValue('21d')).toBe(true)
+    })
+
+    it('returns true for valid weekly values', () => {
+      expect(isValidTrendWindowValue('2w')).toBe(true)
+      expect(isValidTrendWindowValue('3w')).toBe(true)
+      expect(isValidTrendWindowValue('4w')).toBe(true)
+    })
+
+    it('returns true for valid monthly values', () => {
+      expect(isValidTrendWindowValue('2m')).toBe(true)
+      expect(isValidTrendWindowValue('3m')).toBe(true)
+      expect(isValidTrendWindowValue('4m')).toBe(true)
+    })
+
+    it('returns false for invalid values', () => {
+      expect(isValidTrendWindowValue('invalid')).toBe(false)
+      expect(isValidTrendWindowValue('5d')).toBe(false) // Not a valid option
+      expect(isValidTrendWindowValue('100h')).toBe(false)
+      expect(isValidTrendWindowValue(5)).toBe(false) // Number instead of string
+      expect(isValidTrendWindowValue(null)).toBe(false)
+      expect(isValidTrendWindowValue(undefined)).toBe(false)
+    })
+  })
+
+  describe('isValidForPeriod', () => {
+    it('returns true for "none" with any period', () => {
+      expect(isValidForPeriod('none', 'hourly')).toBe(true)
+      expect(isValidForPeriod('none', 'run')).toBe(true)
+      expect(isValidForPeriod('none', 'daily')).toBe(true)
+      expect(isValidForPeriod('none', 'weekly')).toBe(true)
+      expect(isValidForPeriod('none', 'monthly')).toBe(true)
+      expect(isValidForPeriod('none', 'yearly')).toBe(true)
+    })
+
+    it('returns true for hourly values with hourly period', () => {
+      expect(isValidForPeriod('6h', 'hourly')).toBe(true)
+      expect(isValidForPeriod('12h', 'hourly')).toBe(true)
+      expect(isValidForPeriod('24h', 'hourly')).toBe(true)
+    })
+
+    it('returns false for hourly values with non-hourly period', () => {
+      expect(isValidForPeriod('6h', 'daily')).toBe(false)
+      expect(isValidForPeriod('12h', 'weekly')).toBe(false)
+    })
+
+    it('returns true for run values with run period', () => {
+      expect(isValidForPeriod('3r', 'run')).toBe(true)
+      expect(isValidForPeriod('5r', 'run')).toBe(true)
+      expect(isValidForPeriod('10r', 'run')).toBe(true)
+    })
+
+    it('returns false for run values with non-run period', () => {
+      expect(isValidForPeriod('3r', 'daily')).toBe(false)
+      expect(isValidForPeriod('5r', 'hourly')).toBe(false)
+    })
+
+    it('returns true for daily values with daily period', () => {
+      expect(isValidForPeriod('7d', 'daily')).toBe(true)
+      expect(isValidForPeriod('14d', 'daily')).toBe(true)
+    })
+
+    it('returns false for daily values with non-daily period', () => {
+      expect(isValidForPeriod('7d', 'weekly')).toBe(false)
+      expect(isValidForPeriod('14d', 'monthly')).toBe(false)
+    })
+
+    it('returns true for weekly values with weekly period', () => {
+      expect(isValidForPeriod('2w', 'weekly')).toBe(true)
+      expect(isValidForPeriod('4w', 'weekly')).toBe(true)
+    })
+
+    it('returns true for monthly values with monthly period', () => {
+      expect(isValidForPeriod('3m', 'monthly')).toBe(true)
+      expect(isValidForPeriod('4m', 'monthly')).toBe(true)
+    })
+
+    it('returns false for all non-none values with yearly period', () => {
+      const values: TrendWindowValue[] = ['7d', '2w', '3m', '10r', '12h']
+      values.forEach((value) => {
+        expect(isValidForPeriod(value, 'yearly')).toBe(false)
+      })
+    })
+  })
+})

--- a/src/features/analysis/time-series/moving-average/moving-average-types.ts
+++ b/src/features/analysis/time-series/moving-average/moving-average-types.ts
@@ -1,21 +1,120 @@
-/**
- * Moving average dropdown option values
- * - 'none': No moving average line displayed
- * - 3, 5, 10: Moving average window size (number of data points to average)
- */
-export type MovingAveragePeriod = 'none' | 3 | 5 | 10
-
-
-export const MOVING_AVERAGE_OPTIONS = [
-  { value: 'none' as const, label: 'No Average' },
-  { value: 3 as const, label: 'Average (3)' },
-  { value: 5 as const, label: 'Average (5)' },
-  { value: 10 as const, label: 'Average (10)' },
-]
+import type { TimePeriod } from '../chart-types'
 
 /**
- * Type guard to check if a value is a valid MovingAveragePeriod
+ * Period-specific trend window options.
+ * Each array is the single source of truth for that period's valid values.
  */
-export function isValidMovingAveragePeriod(value: unknown): value is MovingAveragePeriod {
-  return value === 'none' || value === 3 || value === 5 || value === 10
+const HOURLY_OPTIONS = [
+  { value: 'none', label: 'No Trend' },
+  { value: '6h', label: '6 hours' },
+  { value: '12h', label: '12 hours' },
+  { value: '24h', label: '24 hours' },
+  { value: '48h', label: '48 hours' },
+] as const
+
+const RUN_OPTIONS = [
+  { value: 'none', label: 'No Trend' },
+  { value: '3r', label: '3 runs' },
+  { value: '5r', label: '5 runs' },
+  { value: '10r', label: '10 runs' },
+] as const
+
+const DAILY_OPTIONS = [
+  { value: 'none', label: 'No Trend' },
+  { value: '3d', label: '3 days' },
+  { value: '7d', label: '7 days' },
+  { value: '14d', label: '14 days' },
+  { value: '21d', label: '21 days' },
+] as const
+
+const WEEKLY_OPTIONS = [
+  { value: 'none', label: 'No Trend' },
+  { value: '2w', label: '2 weeks' },
+  { value: '3w', label: '3 weeks' },
+  { value: '4w', label: '4 weeks' },
+] as const
+
+const MONTHLY_OPTIONS = [
+  { value: 'none', label: 'No Trend' },
+  { value: '2m', label: '2 months' },
+  { value: '3m', label: '3 months' },
+  { value: '4m', label: '4 months' },
+] as const
+
+const YEARLY_OPTIONS = [{ value: 'none', label: 'No Trend' }] as const
+
+/**
+ * Maps time periods to their trend window options.
+ */
+const OPTIONS_BY_PERIOD = {
+  hourly: HOURLY_OPTIONS,
+  run: RUN_OPTIONS,
+  daily: DAILY_OPTIONS,
+  weekly: WEEKLY_OPTIONS,
+  monthly: MONTHLY_OPTIONS,
+  yearly: YEARLY_OPTIONS,
+} as const
+
+/**
+ * All valid trend window values derived from the option definitions.
+ */
+type HourlyValue = (typeof HOURLY_OPTIONS)[number]['value']
+type RunValue = (typeof RUN_OPTIONS)[number]['value']
+type DailyValue = (typeof DAILY_OPTIONS)[number]['value']
+type WeeklyValue = (typeof WEEKLY_OPTIONS)[number]['value']
+type MonthlyValue = (typeof MONTHLY_OPTIONS)[number]['value']
+
+export type TrendWindowValue =
+  | HourlyValue
+  | RunValue
+  | DailyValue
+  | WeeklyValue
+  | MonthlyValue
+
+interface TrendWindowOption {
+  readonly value: TrendWindowValue
+  readonly label: string
+}
+
+/**
+ * Get trend window options for a specific time period.
+ */
+export function getTrendWindowOptions(period: TimePeriod): readonly TrendWindowOption[] {
+  return OPTIONS_BY_PERIOD[period]
+}
+
+/**
+ * Get the default trend window value.
+ */
+export function getDefaultTrendWindow(): TrendWindowValue {
+  return 'none'
+}
+
+/**
+ * Maps TrendWindowValue to numeric window size for calculation.
+ * Returns null for 'none' (no trend line).
+ */
+export function getWindowSize(value: TrendWindowValue): number | null {
+  if (value === 'none') return null
+  return parseInt(value.slice(0, -1), 10)
+}
+
+/**
+ * Type guard to check if a value is a valid TrendWindowValue.
+ * Validates against all period option definitions.
+ */
+export function isValidTrendWindowValue(value: unknown): value is TrendWindowValue {
+  if (typeof value !== 'string') return false
+
+  return Object.values(OPTIONS_BY_PERIOD).some((options) =>
+    options.some((opt) => opt.value === value)
+  )
+}
+
+/**
+ * Check if a trend window value is valid for a given period.
+ */
+export function isValidForPeriod(value: TrendWindowValue, period: TimePeriod): boolean {
+  const options = OPTIONS_BY_PERIOD[period]
+  return options.some((opt) => opt.value === value)
 }

--- a/src/features/analysis/time-series/moving-average/use-moving-average.test.tsx
+++ b/src/features/analysis/time-series/moving-average/use-moving-average.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import { useMovingAverage } from './use-moving-average'
+import type { TimePeriod } from '../chart-types'
 
 describe('useMovingAverage', () => {
   beforeEach(() => {
@@ -9,112 +10,227 @@ describe('useMovingAverage', () => {
 
   describe('initial state', () => {
     it('returns "none" as default when no stored value exists', () => {
-      const { result } = renderHook(() => useMovingAverage('testMetric'))
+      const { result } = renderHook(() => useMovingAverage('testMetric', 'daily'))
 
-      expect(result.current.averagePeriod).toBe('none')
-      expect(result.current.isAverageEnabled).toBe(false)
+      expect(result.current.trendWindow).toBe('none')
+      expect(result.current.isEnabled).toBe(false)
+      expect(result.current.windowSize).toBeNull()
     })
 
     it('loads persisted value on mount', () => {
-      localStorage.setItem('tower-tracking-moving-average-config', JSON.stringify({
-        coinsEarned: 5,
-      }))
+      localStorage.setItem(
+        'tower-tracking-moving-average-config',
+        JSON.stringify({
+          'coinsEarned:daily': '7d',
+        })
+      )
 
-      const { result } = renderHook(() => useMovingAverage('coinsEarned'))
+      const { result } = renderHook(() => useMovingAverage('coinsEarned', 'daily'))
 
-      expect(result.current.averagePeriod).toBe(5)
-      expect(result.current.isAverageEnabled).toBe(true)
+      expect(result.current.trendWindow).toBe('7d')
+      expect(result.current.isEnabled).toBe(true)
+      expect(result.current.windowSize).toBe(7)
     })
 
-    it('returns "none" for different metric key', () => {
-      localStorage.setItem('tower-tracking-moving-average-config', JSON.stringify({
-        coinsEarned: 5,
-      }))
+    it('returns "none" for different metric+period combination', () => {
+      localStorage.setItem(
+        'tower-tracking-moving-average-config',
+        JSON.stringify({
+          'coinsEarned:daily': '7d',
+        })
+      )
 
-      const { result } = renderHook(() => useMovingAverage('totalDamage'))
+      const { result } = renderHook(() => useMovingAverage('totalDamage', 'daily'))
 
-      expect(result.current.averagePeriod).toBe('none')
-      expect(result.current.isAverageEnabled).toBe(false)
+      expect(result.current.trendWindow).toBe('none')
+      expect(result.current.isEnabled).toBe(false)
+    })
+
+    it('returns correct value for same metric but different period', () => {
+      localStorage.setItem(
+        'tower-tracking-moving-average-config',
+        JSON.stringify({
+          'coinsEarned:daily': '7d',
+          'coinsEarned:weekly': '2w',
+        })
+      )
+
+      const { result: dailyResult } = renderHook(() =>
+        useMovingAverage('coinsEarned', 'daily')
+      )
+      const { result: weeklyResult } = renderHook(() =>
+        useMovingAverage('coinsEarned', 'weekly')
+      )
+
+      expect(dailyResult.current.trendWindow).toBe('7d')
+      expect(weeklyResult.current.trendWindow).toBe('2w')
     })
   })
 
-  describe('setAveragePeriod', () => {
-    it('updates averagePeriod state', () => {
-      const { result } = renderHook(() => useMovingAverage('testMetric'))
+  describe('setTrendWindow', () => {
+    it('updates trendWindow state', () => {
+      const { result } = renderHook(() => useMovingAverage('testMetric', 'daily'))
 
       act(() => {
-        result.current.setAveragePeriod(10)
+        result.current.setTrendWindow('14d')
       })
 
-      expect(result.current.averagePeriod).toBe(10)
-      expect(result.current.isAverageEnabled).toBe(true)
+      expect(result.current.trendWindow).toBe('14d')
+      expect(result.current.isEnabled).toBe(true)
+      expect(result.current.windowSize).toBe(14)
     })
 
-    it('persists value to localStorage', () => {
-      const { result } = renderHook(() => useMovingAverage('testMetric'))
+    it('persists value to localStorage with compound key', () => {
+      const { result } = renderHook(() => useMovingAverage('testMetric', 'daily'))
 
       act(() => {
-        result.current.setAveragePeriod(3)
+        result.current.setTrendWindow('3d')
       })
 
       const stored = localStorage.getItem('tower-tracking-moving-average-config')
       expect(stored).toBeTruthy()
-      expect(JSON.parse(stored!)).toEqual({ testMetric: 3 })
+      expect(JSON.parse(stored!)).toEqual({ 'testMetric:daily': '3d' })
     })
 
     it('can set value back to "none"', () => {
-      const { result } = renderHook(() => useMovingAverage('testMetric'))
+      const { result } = renderHook(() => useMovingAverage('testMetric', 'daily'))
 
       act(() => {
-        result.current.setAveragePeriod(5)
+        result.current.setTrendWindow('7d')
       })
 
-      expect(result.current.isAverageEnabled).toBe(true)
+      expect(result.current.isEnabled).toBe(true)
 
       act(() => {
-        result.current.setAveragePeriod('none')
+        result.current.setTrendWindow('none')
       })
 
-      expect(result.current.averagePeriod).toBe('none')
-      expect(result.current.isAverageEnabled).toBe(false)
+      expect(result.current.trendWindow).toBe('none')
+      expect(result.current.isEnabled).toBe(false)
+      expect(result.current.windowSize).toBeNull()
     })
   })
 
-  describe('isAverageEnabled', () => {
-    it('is false when averagePeriod is "none"', () => {
-      const { result } = renderHook(() => useMovingAverage('testMetric'))
+  describe('windowSize', () => {
+    it('returns null when trendWindow is "none"', () => {
+      const { result } = renderHook(() => useMovingAverage('testMetric', 'daily'))
 
-      expect(result.current.isAverageEnabled).toBe(false)
+      expect(result.current.windowSize).toBeNull()
     })
 
-    it('is true when averagePeriod is a number', () => {
-      const { result } = renderHook(() => useMovingAverage('testMetric'))
+    it('returns numeric value for daily options', () => {
+      const { result } = renderHook(() => useMovingAverage('testMetric', 'daily'))
 
       act(() => {
-        result.current.setAveragePeriod(3)
+        result.current.setTrendWindow('7d')
+      })
+      expect(result.current.windowSize).toBe(7)
+
+      act(() => {
+        result.current.setTrendWindow('14d')
+      })
+      expect(result.current.windowSize).toBe(14)
+    })
+
+    it('returns numeric value for weekly options', () => {
+      const { result } = renderHook(() => useMovingAverage('testMetric', 'weekly'))
+
+      act(() => {
+        result.current.setTrendWindow('2w')
+      })
+      expect(result.current.windowSize).toBe(2)
+
+      act(() => {
+        result.current.setTrendWindow('4w')
+      })
+      expect(result.current.windowSize).toBe(4)
+    })
+  })
+
+  describe('isEnabled', () => {
+    it('is false when trendWindow is "none"', () => {
+      const { result } = renderHook(() => useMovingAverage('testMetric', 'daily'))
+
+      expect(result.current.isEnabled).toBe(false)
+    })
+
+    it('is true when trendWindow is not "none"', () => {
+      const { result } = renderHook(() => useMovingAverage('testMetric', 'daily'))
+
+      act(() => {
+        result.current.setTrendWindow('3d')
       })
 
-      expect(result.current.isAverageEnabled).toBe(true)
+      expect(result.current.isEnabled).toBe(true)
     })
   })
 
   describe('metric key changes', () => {
     it('reloads persisted value when metricKey changes', () => {
-      localStorage.setItem('tower-tracking-moving-average-config', JSON.stringify({
-        coinsEarned: 5,
-        totalDamage: 10,
-      }))
-
-      const { result, rerender } = renderHook(
-        ({ metricKey }) => useMovingAverage(metricKey),
-        { initialProps: { metricKey: 'coinsEarned' } }
+      localStorage.setItem(
+        'tower-tracking-moving-average-config',
+        JSON.stringify({
+          'coinsEarned:daily': '7d',
+          'totalDamage:daily': '14d',
+        })
       )
 
-      expect(result.current.averagePeriod).toBe(5)
+      const { result, rerender } = renderHook(
+        ({ metricKey, period }: { metricKey: string; period: TimePeriod }) =>
+          useMovingAverage(metricKey, period),
+        { initialProps: { metricKey: 'coinsEarned', period: 'daily' as TimePeriod } }
+      )
 
-      rerender({ metricKey: 'totalDamage' })
+      expect(result.current.trendWindow).toBe('7d')
 
-      expect(result.current.averagePeriod).toBe(10)
+      rerender({ metricKey: 'totalDamage', period: 'daily' as TimePeriod })
+
+      expect(result.current.trendWindow).toBe('14d')
+    })
+  })
+
+  describe('period changes', () => {
+    it('reloads persisted value when period changes', () => {
+      localStorage.setItem(
+        'tower-tracking-moving-average-config',
+        JSON.stringify({
+          'coinsEarned:daily': '7d',
+          'coinsEarned:weekly': '2w',
+        })
+      )
+
+      const { result, rerender } = renderHook(
+        ({ metricKey, period }: { metricKey: string; period: TimePeriod }) =>
+          useMovingAverage(metricKey, period),
+        { initialProps: { metricKey: 'coinsEarned', period: 'daily' as TimePeriod } }
+      )
+
+      expect(result.current.trendWindow).toBe('7d')
+
+      rerender({ metricKey: 'coinsEarned', period: 'weekly' as TimePeriod })
+
+      expect(result.current.trendWindow).toBe('2w')
+    })
+
+    it('returns "none" when switching to a period without stored value', () => {
+      localStorage.setItem(
+        'tower-tracking-moving-average-config',
+        JSON.stringify({
+          'coinsEarned:daily': '7d',
+        })
+      )
+
+      const { result, rerender } = renderHook(
+        ({ metricKey, period }: { metricKey: string; period: TimePeriod }) =>
+          useMovingAverage(metricKey, period),
+        { initialProps: { metricKey: 'coinsEarned', period: 'daily' as TimePeriod } }
+      )
+
+      expect(result.current.trendWindow).toBe('7d')
+
+      rerender({ metricKey: 'coinsEarned', period: 'weekly' as TimePeriod })
+
+      expect(result.current.trendWindow).toBe('none')
     })
   })
 })

--- a/src/features/analysis/time-series/time-series-chart.tsx
+++ b/src/features/analysis/time-series/time-series-chart.tsx
@@ -9,7 +9,7 @@ import { RunTypeSelector } from '@/shared/domain/run-types/run-type-selector'
 import { TimeSeriesHeader } from './time-series-header'
 import { PeriodSelectorButton } from './period-selector-button'
 import { DataPointsCount } from './data-points-count'
-import { MovingAverageSelector, type MovingAveragePeriod } from './moving-average'
+import { MovingAverageSelector, type TrendWindowValue } from './moving-average'
 import { PercentChangeToggle } from './percent-change'
 import { useTimeSeriesChartData } from './use-time-series-chart-data'
 import { TimeSeriesChartBody } from './time-series-chart-body'
@@ -37,8 +37,8 @@ interface FilterControlsProps {
   runTypeFilter: RunTypeFilter
   onRunTypeChange?: (runType: RunTypeFilter) => void
   dataPointCount: number
-  averagePeriod: MovingAveragePeriod
-  onAveragePeriodChange: (period: MovingAveragePeriod) => void
+  trendWindow: TrendWindowValue
+  onTrendWindowChange: (value: TrendWindowValue) => void
   percentChangeEnabled: boolean
   onPercentChangeToggle: (enabled: boolean) => void
 }
@@ -51,11 +51,14 @@ function FilterControls({
   runTypeFilter,
   onRunTypeChange,
   dataPointCount,
-  averagePeriod,
-  onAveragePeriodChange,
+  trendWindow,
+  onTrendWindowChange,
   percentChangeEnabled,
   onPercentChangeToggle,
 }: FilterControlsProps) {
+  // Hide trend selector for yearly view (not enough data points for meaningful trends)
+  const showTrendSelector = selectedPeriod !== 'yearly'
+
   return (
     <div className="flex flex-wrap items-end justify-between gap-4">
       {/* Left side: Duration selector */}
@@ -82,8 +85,14 @@ function FilterControls({
           />
         )}
 
-        {/* Moving average trend line selector */}
-        <MovingAverageSelector value={averagePeriod} onChange={onAveragePeriodChange} />
+        {/* Moving average trend line selector - hidden for yearly view */}
+        {showTrendSelector && (
+          <MovingAverageSelector
+            value={trendWindow}
+            period={selectedPeriod}
+            onChange={onTrendWindowChange}
+          />
+        )}
 
         {/* Percentage change overlay toggle */}
         <PercentChangeToggle
@@ -127,8 +136,8 @@ export function TimeSeriesChart({
     selectedPeriod,
     setSelectedPeriod,
     yAxisTicks,
-    averagePeriod,
-    setAveragePeriod,
+    trendWindow,
+    setTrendWindow,
     isAverageEnabled,
     percentChangeEnabled,
     setPercentChangeEnabled,
@@ -165,8 +174,8 @@ export function TimeSeriesChart({
           runTypeFilter={runTypeFilter}
           onRunTypeChange={onRunTypeChange}
           dataPointCount={chartData.length}
-          averagePeriod={averagePeriod}
-          onAveragePeriodChange={setAveragePeriod}
+          trendWindow={trendWindow}
+          onTrendWindowChange={setTrendWindow}
           percentChangeEnabled={percentChangeEnabled}
           onPercentChangeToggle={setPercentChangeEnabled}
         />

--- a/src/styles.css
+++ b/src/styles.css
@@ -75,6 +75,17 @@
     border-color: theme('colors.border');
   }
 
+  /* Native select option styling for dark theme */
+  select option {
+    background-color: #1e293b;
+    color: #e2e8f0;
+  }
+
+  select option:checked {
+    background-color: #334155;
+    color: #e2e8f0;
+  }
+
   body {
     background-color: theme('colors.background');
     color: theme('colors.foreground');


### PR DESCRIPTION
## Summary
Trend window selection now shows contextually appropriate options based on the selected time period. Instead of generic numbers (3, 5, 10), users see meaningful units like "7 days", "2 weeks", or "3 months". Each metric+period combination maintains its own preference, so switching periods no longer loses your trend settings.

## Technical Details
- Added `TrendWindowValue` type with period-specific strings (e.g., `'7d'`, `'2w'`, `'3m'`)
- Implemented compound localStorage keys (`metric:period`) for independent preferences
- Added legacy format migration that clears old numeric values on first load
- Made selector period-aware with `getTrendWindowOptions(period)` function
- Hidden trend selector for yearly view (insufficient data points)
- Removed 1-week and 1-month options (now start at 2 for meaningful trends)
- Fixed washed-out dropdown styling with dark theme option styles

## Files Changed
- `moving-average-types.ts` - New type system with period-specific options
- `moving-average-persistence.ts` - Compound key storage with legacy migration
- `moving-average-selector.tsx` - Period-aware dropdown with updated styling
- `use-moving-average.ts` - Hook updated for metric+period keys
- `time-series-chart.tsx` - Passes period to selector, hides for yearly
- `styles.css` - Dark theme dropdown option styling