### PR TITLE
IMPROVE: Add time series interval selector for data point control

### DIFF
--- a/src/features/analysis/time-series/chart-data.test.ts
+++ b/src/features/analysis/time-series/chart-data.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { prepareTimeSeriesData, getAvailableTimePeriods } from './chart-data'
 import { ParsedGameRun } from '@/shared/types/game-run.types'
+import { Duration } from '@/shared/domain/filters/types'
 
 describe('Chart Data Utils', () => {
   describe('getAvailableTimePeriods', () => {
@@ -33,12 +34,12 @@ describe('Chart Data Utils', () => {
       const periods = getAvailableTimePeriods(runs)
       const periodTypes = periods.map(p => p.period)
 
-      expect(periodTypes).toContain('hourly')
-      expect(periodTypes).toContain('run')
-      expect(periodTypes).toContain('daily')
-      expect(periodTypes).toContain('weekly')
-      expect(periodTypes).toContain('monthly')
-      expect(periodTypes).not.toContain('yearly') // Only one year of data
+      expect(periodTypes).toContain(Duration.HOURLY)
+      expect(periodTypes).toContain(Duration.PER_RUN)
+      expect(periodTypes).toContain(Duration.DAILY)
+      expect(periodTypes).toContain(Duration.WEEKLY)
+      expect(periodTypes).toContain(Duration.MONTHLY)
+      expect(periodTypes).not.toContain(Duration.YEARLY) // Only one year of data
     })
 
     it('should show yearly view only when data spans multiple years', () => {
@@ -70,7 +71,7 @@ describe('Chart Data Utils', () => {
       const periods = getAvailableTimePeriods(runs)
       const periodTypes = periods.map(p => p.period)
 
-      expect(periodTypes).toContain('yearly')
+      expect(periodTypes).toContain(Duration.YEARLY)
     })
 
     it('should only show hourly and run views when no data', () => {
@@ -79,7 +80,7 @@ describe('Chart Data Utils', () => {
       const periods = getAvailableTimePeriods(runs)
       const periodTypes = periods.map(p => p.period)
 
-      expect(periodTypes).toEqual(['hourly', 'run'])
+      expect(periodTypes).toEqual([Duration.HOURLY, Duration.PER_RUN])
     })
   })
 
@@ -100,8 +101,8 @@ describe('Chart Data Utils', () => {
         }
       ]
 
-      const dailyData = prepareTimeSeriesData(runs, 'daily', 'coinsEarned')
-      
+      const dailyData = prepareTimeSeriesData(runs, Duration.DAILY, 'coinsEarned')
+
       expect(dailyData).toHaveLength(1)
       expect(dailyData[0].value).toBe(1000000)
       expect(dailyData[0].date).toBe('Aug 31')
@@ -124,7 +125,7 @@ describe('Chart Data Utils', () => {
         }
       ]
 
-      const weeklyData = prepareTimeSeriesData(runs, 'weekly', 'coinsEarned')
+      const weeklyData = prepareTimeSeriesData(runs, Duration.WEEKLY, 'coinsEarned')
       
       expect(weeklyData).toHaveLength(1)
       expect(weeklyData[0].value).toBe(1000000)
@@ -148,7 +149,7 @@ describe('Chart Data Utils', () => {
         }
       ]
 
-      const monthlyData = prepareTimeSeriesData(runs, 'monthly', 'coinsEarned')
+      const monthlyData = prepareTimeSeriesData(runs, Duration.MONTHLY, 'coinsEarned')
       
       expect(monthlyData).toHaveLength(1)
       expect(monthlyData[0].value).toBe(1000000)
@@ -181,7 +182,7 @@ describe('Chart Data Utils', () => {
         }
       ]
 
-      const dailyData = prepareTimeSeriesData(runs, 'daily', 'coinsEarned')
+      const dailyData = prepareTimeSeriesData(runs, Duration.DAILY, 'coinsEarned')
       
       expect(dailyData).toHaveLength(1)
       expect(dailyData[0].value).toBe(2200000) // Sum of both runs
@@ -203,7 +204,7 @@ describe('Chart Data Utils', () => {
         }
       ]
 
-      const cellsData = prepareTimeSeriesData(runs, 'daily', 'cellsEarned')
+      const cellsData = prepareTimeSeriesData(runs, Duration.DAILY, 'cellsEarned')
       
       expect(cellsData).toHaveLength(1)
       expect(cellsData[0].value).toBe(50000)
@@ -237,7 +238,7 @@ describe('Chart Data Utils', () => {
         }
       ]
 
-      const weeklyData = prepareTimeSeriesData(runs, 'weekly', 'coinsEarned')
+      const weeklyData = prepareTimeSeriesData(runs, Duration.WEEKLY, 'coinsEarned')
       
       expect(weeklyData).toHaveLength(2) // Two different weeks
       expect(weeklyData[0].value).toBe(1000000) // First week (Saturday Aug 30)

--- a/src/features/analysis/time-series/chart-data.ts
+++ b/src/features/analysis/time-series/chart-data.ts
@@ -2,10 +2,10 @@ import { format, startOfDay, startOfWeek, startOfMonth, startOfYear } from 'date
 import { ParsedGameRun } from '@/shared/types/game-run.types'
 import {
   ChartDataPoint,
-  TimePeriod,
   TimePeriodConfig,
   TIME_PERIOD_CONFIGS
 } from './chart-types'
+import { Duration } from '@/shared/domain/filters/types'
 import {
   prepareFieldPerRunData,
   prepareFieldPerHourData,
@@ -21,21 +21,21 @@ import {
  */
 export function prepareTimeSeriesData(
   runs: ParsedGameRun[],
-  period: TimePeriod,
+  period: Duration,
   metric: string
 ): ChartDataPoint[] {
   switch (period) {
-    case 'hourly':
+    case Duration.HOURLY:
       return prepareFieldPerHourData(runs, metric)
-    case 'run':
+    case Duration.PER_RUN:
       return prepareFieldPerRunData(runs, metric)
-    case 'daily':
+    case Duration.DAILY:
       return prepareFieldPerDayData(runs, metric)
-    case 'weekly':
+    case Duration.WEEKLY:
       return prepareFieldPerWeekData(runs, metric)
-    case 'monthly':
+    case Duration.MONTHLY:
       return prepareFieldPerMonthData(runs, metric)
-    case 'yearly':
+    case Duration.YEARLY:
       return prepareFieldPerYearData(runs, metric)
     default:
       return []
@@ -50,7 +50,7 @@ export function getAvailableTimePeriods(runs: ParsedGameRun[]): TimePeriodConfig
   if (runs.length === 0) {
     // Always show hourly and per run when no data
     return TIME_PERIOD_CONFIGS.filter(config =>
-      config.period === 'hourly' || config.period === 'run'
+      config.period === Duration.HOURLY || config.period === Duration.PER_RUN
     )
   }
 
@@ -69,26 +69,26 @@ export function getAvailableTimePeriods(runs: ParsedGameRun[]): TimePeriodConfig
   })
 
   // Always include hourly and per run
-  const availablePeriods: TimePeriod[] = ['hourly', 'run']
+  const availablePeriods: Duration[] = [Duration.HOURLY, Duration.PER_RUN]
 
   // Always show daily view if we have any data
   if (uniqueDays.size >= 1) {
-    availablePeriods.push('daily')
+    availablePeriods.push(Duration.DAILY)
   }
 
   // Always show weekly view if we have any data
   if (uniqueWeeks.size >= 1) {
-    availablePeriods.push('weekly')
+    availablePeriods.push(Duration.WEEKLY)
   }
 
   // Always show monthly view if we have any data
   if (uniqueMonths.size >= 1) {
-    availablePeriods.push('monthly')
+    availablePeriods.push(Duration.MONTHLY)
   }
 
   // Only show yearly view if we have data spanning multiple years
   if (uniqueYears.size > 1) {
-    availablePeriods.push('yearly')
+    availablePeriods.push(Duration.YEARLY)
   }
 
   // Return configurations for available periods in original order

--- a/src/features/analysis/time-series/chart-types.ts
+++ b/src/features/analysis/time-series/chart-types.ts
@@ -3,6 +3,7 @@
 // Re-export shared RunInfo type for consumers of this module
 export type { RunInfo } from '@/features/analysis/shared/tooltips/run-info-header'
 import type { RunInfo } from '@/features/analysis/shared/tooltips/run-info-header'
+import { Duration } from '@/shared/domain/filters/types'
 
 export interface PeriodInfo {
   /** Daily average for this period */
@@ -26,7 +27,7 @@ export interface ChartDataPoint {
 }
 
 
-export type TimePeriod = 'hourly' | 'run' | 'daily' | 'weekly' | 'monthly' | 'yearly'
+export type TimePeriod = Duration
 
 export interface TimePeriodConfig {
   period: TimePeriod
@@ -49,10 +50,10 @@ export interface TierKilledByData {
 
 // Time period configurations - Enhanced color palette for better visual harmony
 export const TIME_PERIOD_CONFIGS: TimePeriodConfig[] = [
-  { period: 'hourly', label: 'Per Hour', color: '#ec4899', dateFormat: 'MMM dd' }, // Pink for granular data
-  { period: 'run', label: 'Per Run', color: '#8b5cf6', dateFormat: 'MMM dd' }, // Purple for individual runs
-  { period: 'daily', label: 'Daily', color: '#06d6a0', dateFormat: 'MMM dd' }, // Mint green for daily aggregation
-  { period: 'weekly', label: 'Weekly', color: '#ffbe0b', dateFormat: 'MMM dd' }, // Golden yellow for weekly
-  { period: 'monthly', label: 'Monthly', color: '#f72585', dateFormat: 'MMM yyyy' }, // Hot pink for monthly
-  { period: 'yearly', label: 'Yearly', color: '#3a86ff', dateFormat: 'yyyy' } // Electric blue for yearly
+  { period: Duration.HOURLY, label: 'Per Hour', color: '#ec4899', dateFormat: 'MMM dd' }, // Pink for granular data
+  { period: Duration.PER_RUN, label: 'Per Run', color: '#8b5cf6', dateFormat: 'MMM dd' }, // Purple for individual runs
+  { period: Duration.DAILY, label: 'Daily', color: '#06d6a0', dateFormat: 'MMM dd' }, // Mint green for daily aggregation
+  { period: Duration.WEEKLY, label: 'Weekly', color: '#ffbe0b', dateFormat: 'MMM dd' }, // Golden yellow for weekly
+  { period: Duration.MONTHLY, label: 'Monthly', color: '#f72585', dateFormat: 'MMM yyyy' }, // Hot pink for monthly
+  { period: Duration.YEARLY, label: 'Yearly', color: '#3a86ff', dateFormat: 'yyyy' } // Electric blue for yearly
 ]

--- a/src/features/analysis/time-series/interval-selector/index.ts
+++ b/src/features/analysis/time-series/interval-selector/index.ts
@@ -1,0 +1,3 @@
+export { sliceToInterval } from './interval-data-logic'
+export { useIntervalSelector } from './use-interval-selector'
+export { useDurationSelector } from './use-duration-selector'

--- a/src/features/analysis/time-series/interval-selector/interval-data-logic.test.ts
+++ b/src/features/analysis/time-series/interval-selector/interval-data-logic.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { sliceToInterval } from './interval-data-logic'
+
+describe('sliceToInterval', () => {
+  const data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+
+  it('returns full array when interval is "all"', () => {
+    expect(sliceToInterval(data, 'all')).toEqual(data)
+  })
+
+  it('returns last N items when interval is a number', () => {
+    expect(sliceToInterval(data, 3)).toEqual([8, 9, 10])
+    expect(sliceToInterval(data, 5)).toEqual([6, 7, 8, 9, 10])
+    expect(sliceToInterval(data, 1)).toEqual([10])
+  })
+
+  it('returns full array when interval exceeds data length', () => {
+    expect(sliceToInterval(data, 20)).toEqual(data)
+  })
+
+  it('returns full array when interval equals data length', () => {
+    expect(sliceToInterval(data, 10)).toEqual(data)
+  })
+
+  it('handles empty array', () => {
+    expect(sliceToInterval([], 5)).toEqual([])
+    expect(sliceToInterval([], 'all')).toEqual([])
+  })
+
+  it('works with object arrays', () => {
+    const objects = [{ id: 1 }, { id: 2 }, { id: 3 }]
+    expect(sliceToInterval(objects, 2)).toEqual([{ id: 2 }, { id: 3 }])
+  })
+})

--- a/src/features/analysis/time-series/interval-selector/interval-data-logic.ts
+++ b/src/features/analysis/time-series/interval-selector/interval-data-logic.ts
@@ -1,0 +1,13 @@
+import type { PeriodCountFilter } from '@/shared/domain/filters/types'
+
+/**
+ * Slice data array to the most recent N items based on interval selection.
+ * Returns full array when interval is 'all'.
+ */
+export function sliceToInterval<T>(data: T[], interval: PeriodCountFilter): T[] {
+  if (interval === 'all' || data.length <= interval) {
+    return data
+  }
+
+  return data.slice(-interval)
+}

--- a/src/features/analysis/time-series/interval-selector/interval-persistence.test.ts
+++ b/src/features/analysis/time-series/interval-selector/interval-persistence.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { Duration } from '@/shared/domain/filters/types'
+import {
+  loadPersistedDuration,
+  savePersistedDuration,
+  loadPersistedIntervalCount,
+  savePersistedIntervalCount,
+  clearTimeSeriesFilterConfig,
+} from './interval-persistence'
+
+const STORAGE_KEY = 'tower-tracking-time-series-filters'
+
+describe('interval-persistence', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  describe('loadPersistedDuration', () => {
+    it('returns null when no stored value exists', () => {
+      expect(loadPersistedDuration()).toBeNull()
+    })
+
+    it('returns stored duration value', () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ duration: 'daily' }))
+      expect(loadPersistedDuration()).toBe(Duration.DAILY)
+    })
+
+    it('returns null for invalid duration value', () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ duration: 'invalid' }))
+      expect(loadPersistedDuration()).toBeNull()
+    })
+
+    it('returns null for malformed JSON', () => {
+      localStorage.setItem(STORAGE_KEY, 'not valid json')
+      expect(loadPersistedDuration()).toBeNull()
+    })
+  })
+
+  describe('savePersistedDuration', () => {
+    it('saves duration to localStorage', () => {
+      savePersistedDuration(Duration.DAILY)
+
+      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!)
+      expect(stored.duration).toBe('daily')
+    })
+
+    it('merges with existing config', () => {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({ periodCounts: { daily: 14 } })
+      )
+
+      savePersistedDuration(Duration.WEEKLY)
+
+      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!)
+      expect(stored.duration).toBe('weekly')
+      expect(stored.periodCounts).toEqual({ daily: 14 })
+    })
+  })
+
+  describe('loadPersistedIntervalCount', () => {
+    it('returns null when no stored value exists', () => {
+      expect(loadPersistedIntervalCount(Duration.DAILY)).toBeNull()
+    })
+
+    it('returns stored numeric count', () => {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({ periodCounts: { daily: 14 } })
+      )
+      expect(loadPersistedIntervalCount(Duration.DAILY)).toBe(14)
+    })
+
+    it('returns "all" when stored as "all"', () => {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({ periodCounts: { daily: 'all' } })
+      )
+      expect(loadPersistedIntervalCount(Duration.DAILY)).toBe('all')
+    })
+
+    it('returns null for duration without stored count', () => {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({ periodCounts: { daily: 14 } })
+      )
+      expect(loadPersistedIntervalCount(Duration.WEEKLY)).toBeNull()
+    })
+
+    it('returns null for invalid stored value', () => {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({ periodCounts: { daily: -1 } })
+      )
+      expect(loadPersistedIntervalCount(Duration.DAILY)).toBeNull()
+    })
+  })
+
+  describe('savePersistedIntervalCount', () => {
+    it('saves interval count for a duration', () => {
+      savePersistedIntervalCount(Duration.DAILY, 14)
+
+      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!)
+      expect(stored.periodCounts.daily).toBe(14)
+    })
+
+    it('saves "all" for a duration', () => {
+      savePersistedIntervalCount(Duration.DAILY, 'all')
+
+      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!)
+      expect(stored.periodCounts.daily).toBe('all')
+    })
+
+    it('merges with existing period counts', () => {
+      savePersistedIntervalCount(Duration.DAILY, 14)
+      savePersistedIntervalCount(Duration.WEEKLY, 10)
+
+      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!)
+      expect(stored.periodCounts).toEqual({ daily: 14, weekly: 10 })
+    })
+
+    it('overwrites existing value for same duration', () => {
+      savePersistedIntervalCount(Duration.DAILY, 14)
+      savePersistedIntervalCount(Duration.DAILY, 7)
+
+      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!)
+      expect(stored.periodCounts.daily).toBe(7)
+    })
+  })
+
+  describe('clearTimeSeriesFilterConfig', () => {
+    it('removes config from localStorage', () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ duration: 'daily' }))
+      clearTimeSeriesFilterConfig()
+      expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
+    })
+
+    it('does not throw when no config exists', () => {
+      expect(() => clearTimeSeriesFilterConfig()).not.toThrow()
+    })
+  })
+
+  describe('SSR safety', () => {
+    it('loadPersistedDuration handles SSR environment', () => {
+      const originalWindow = global.window
+      // @ts-expect-error - Testing SSR behavior
+      delete global.window
+
+      expect(loadPersistedDuration()).toBeNull()
+
+      global.window = originalWindow
+    })
+
+    it('savePersistedDuration handles SSR environment silently', () => {
+      const originalWindow = global.window
+      // @ts-expect-error - Testing SSR behavior
+      delete global.window
+
+      expect(() => savePersistedDuration(Duration.DAILY)).not.toThrow()
+
+      global.window = originalWindow
+    })
+  })
+})

--- a/src/features/analysis/time-series/interval-selector/interval-persistence.ts
+++ b/src/features/analysis/time-series/interval-selector/interval-persistence.ts
@@ -1,0 +1,104 @@
+import { Duration, type PeriodCountFilter } from '@/shared/domain/filters/types'
+
+const STORAGE_KEY = 'tower-tracking-time-series-filters'
+
+interface TimeSeriesFilterConfig {
+  duration?: string
+  periodCounts?: Record<string, number | 'all'>
+}
+
+function loadConfig(): TimeSeriesFilterConfig {
+  if (typeof window === 'undefined') return {}
+
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (!stored) return {}
+    return JSON.parse(stored) as TimeSeriesFilterConfig
+  } catch {
+    return {}
+  }
+}
+
+function saveConfig(config: TimeSeriesFilterConfig): void {
+  if (typeof window === 'undefined') return
+
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(config))
+  } catch {
+    // Silently fail on storage errors
+  }
+}
+
+/**
+ * Load persisted duration from localStorage.
+ * Returns null if no stored value or on SSR.
+ */
+export function loadPersistedDuration(): Duration | null {
+  const config = loadConfig()
+  const value = config.duration
+
+  if (value && Object.values(Duration).includes(value as Duration)) {
+    return value as Duration
+  }
+
+  return null
+}
+
+/**
+ * Save duration selection to localStorage.
+ */
+export function savePersistedDuration(duration: Duration): void {
+  if (typeof window === 'undefined') return
+
+  const config = loadConfig()
+  config.duration = duration
+  saveConfig(config)
+}
+
+/**
+ * Load persisted interval count for a specific duration.
+ * Returns null if no stored value.
+ */
+export function loadPersistedIntervalCount(duration: Duration): PeriodCountFilter | null {
+  const config = loadConfig()
+  const counts = config.periodCounts
+
+  if (!counts || !(duration in counts)) return null
+
+  const value = counts[duration]
+  if (value === 'all' || (typeof value === 'number' && value > 0)) {
+    return value
+  }
+
+  return null
+}
+
+/**
+ * Save interval count for a specific duration to localStorage.
+ */
+export function savePersistedIntervalCount(
+  duration: Duration,
+  count: PeriodCountFilter
+): void {
+  if (typeof window === 'undefined') return
+
+  const config = loadConfig()
+  if (!config.periodCounts) {
+    config.periodCounts = {}
+  }
+  config.periodCounts[duration] = count
+  saveConfig(config)
+}
+
+/**
+ * Clear all time series filter config from localStorage.
+ */
+export function clearTimeSeriesFilterConfig(): void {
+  if (typeof window === 'undefined') return
+
+  try {
+    localStorage.removeItem(STORAGE_KEY)
+  } catch {
+    // Silently fail
+  }
+}

--- a/src/features/analysis/time-series/interval-selector/use-duration-selector.test.tsx
+++ b/src/features/analysis/time-series/interval-selector/use-duration-selector.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { Duration } from '@/shared/domain/filters/types'
+import { TIME_PERIOD_CONFIGS } from '../chart-types'
+import { useDurationSelector } from './use-duration-selector'
+
+const STORAGE_KEY = 'tower-tracking-time-series-filters'
+
+/** All configs except yearly */
+const standardConfigs = TIME_PERIOD_CONFIGS.filter(
+  (c) => c.period !== Duration.YEARLY
+)
+
+describe('useDurationSelector', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  describe('initial state', () => {
+    it('defaults to the provided default period', () => {
+      const { result } = renderHook(() =>
+        useDurationSelector(Duration.PER_RUN, standardConfigs)
+      )
+
+      expect(result.current.selectedPeriod).toBe(Duration.PER_RUN)
+    })
+
+    it('hydrates from localStorage on mount', () => {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({ duration: 'daily' })
+      )
+
+      const { result } = renderHook(() =>
+        useDurationSelector(Duration.PER_RUN, standardConfigs)
+      )
+
+      expect(result.current.selectedPeriod).toBe(Duration.DAILY)
+    })
+
+    it('ignores invalid persisted value', () => {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({ duration: 'invalid' })
+      )
+
+      const { result } = renderHook(() =>
+        useDurationSelector(Duration.PER_RUN, standardConfigs)
+      )
+
+      expect(result.current.selectedPeriod).toBe(Duration.PER_RUN)
+    })
+  })
+
+  describe('setSelectedPeriod', () => {
+    it('updates state', () => {
+      const { result } = renderHook(() =>
+        useDurationSelector(Duration.PER_RUN, standardConfigs)
+      )
+
+      act(() => {
+        result.current.setSelectedPeriod(Duration.WEEKLY)
+      })
+
+      expect(result.current.selectedPeriod).toBe(Duration.WEEKLY)
+    })
+
+    it('persists to localStorage', () => {
+      const { result } = renderHook(() =>
+        useDurationSelector(Duration.PER_RUN, standardConfigs)
+      )
+
+      act(() => {
+        result.current.setSelectedPeriod(Duration.WEEKLY)
+      })
+
+      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!)
+      expect(stored.duration).toBe('weekly')
+    })
+  })
+
+  describe('auto-reset when period unavailable', () => {
+    it('resets to first available when selected period is removed', () => {
+      const allConfigs = TIME_PERIOD_CONFIGS
+      const { result, rerender } = renderHook(
+        ({ configs }) => useDurationSelector(Duration.YEARLY, configs),
+        { initialProps: { configs: allConfigs } }
+      )
+
+      // Yearly is available initially
+      expect(result.current.selectedPeriod).toBe(Duration.YEARLY)
+
+      // Remove yearly from available configs
+      rerender({ configs: standardConfigs })
+
+      // Should reset to first available (HOURLY)
+      expect(result.current.selectedPeriod).toBe(Duration.HOURLY)
+    })
+
+    it('keeps selection when period remains available', () => {
+      const { result, rerender } = renderHook(
+        ({ configs }) => useDurationSelector(Duration.DAILY, configs),
+        { initialProps: { configs: standardConfigs } }
+      )
+
+      expect(result.current.selectedPeriod).toBe(Duration.DAILY)
+
+      // Re-render with same configs
+      rerender({ configs: standardConfigs })
+
+      expect(result.current.selectedPeriod).toBe(Duration.DAILY)
+    })
+  })
+})

--- a/src/features/analysis/time-series/interval-selector/use-duration-selector.ts
+++ b/src/features/analysis/time-series/interval-selector/use-duration-selector.ts
@@ -1,0 +1,52 @@
+import { useState, useEffect, useCallback } from 'react'
+import type { TimePeriod, TimePeriodConfig } from '../chart-types'
+import {
+  loadPersistedDuration,
+  savePersistedDuration,
+} from './interval-persistence'
+
+interface UseDurationSelectorResult {
+  selectedPeriod: TimePeriod
+  setSelectedPeriod: (period: TimePeriod) => void
+}
+
+/**
+ * Hook to manage duration/period selection with localStorage persistence.
+ * Hydrates from localStorage on mount and auto-resets when the selected
+ * period is no longer available in the provided configs.
+ */
+export function useDurationSelector(
+  defaultPeriod: TimePeriod,
+  availablePeriodConfigs: TimePeriodConfig[]
+): UseDurationSelectorResult {
+  const [selectedPeriod, setSelectedPeriodState] = useState<TimePeriod>(defaultPeriod)
+
+  // Hydrate duration from localStorage on mount
+  useEffect(() => {
+    const persisted = loadPersistedDuration()
+    if (persisted) {
+      setSelectedPeriodState(persisted)
+    }
+  }, [])
+
+  // Reset period if current selection is not available
+  useEffect(() => {
+    const isCurrentPeriodAvailable = availablePeriodConfigs.some(
+      (config) => config.period === selectedPeriod
+    )
+    if (!isCurrentPeriodAvailable && availablePeriodConfigs.length > 0) {
+      setSelectedPeriodState(availablePeriodConfigs[0].period)
+    }
+  }, [availablePeriodConfigs, selectedPeriod])
+
+  // Wrap setter to also persist
+  const setSelectedPeriod = useCallback((period: TimePeriod) => {
+    setSelectedPeriodState(period)
+    savePersistedDuration(period)
+  }, [])
+
+  return {
+    selectedPeriod,
+    setSelectedPeriod,
+  }
+}

--- a/src/features/analysis/time-series/interval-selector/use-interval-selector.test.tsx
+++ b/src/features/analysis/time-series/interval-selector/use-interval-selector.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { Duration } from '@/shared/domain/filters/types'
+import { useIntervalSelector } from './use-interval-selector'
+
+describe('useIntervalSelector', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  describe('initial state', () => {
+    it('defaults to "all" when no persisted value exists', () => {
+      const { result } = renderHook(() => useIntervalSelector(Duration.DAILY))
+
+      expect(result.current.intervalCount).toBe('all')
+    })
+
+    it('loads persisted value on mount', () => {
+      localStorage.setItem(
+        'tower-tracking-time-series-filters',
+        JSON.stringify({ periodCounts: { daily: 14 } })
+      )
+
+      const { result } = renderHook(() => useIntervalSelector(Duration.DAILY))
+
+      expect(result.current.intervalCount).toBe(14)
+    })
+
+    it('returns correct count options for duration', () => {
+      const { result } = renderHook(() => useIntervalSelector(Duration.DAILY))
+
+      expect(result.current.countOptions).toEqual([7, 14, 21, 28, 35, 42])
+    })
+
+    it('returns correct label for duration', () => {
+      const { result } = renderHook(() => useIntervalSelector(Duration.DAILY))
+
+      expect(result.current.label).toBe('Last Days')
+    })
+  })
+
+  describe('setIntervalCount', () => {
+    it('updates state', () => {
+      const { result } = renderHook(() => useIntervalSelector(Duration.DAILY))
+
+      act(() => {
+        result.current.setIntervalCount(14)
+      })
+
+      expect(result.current.intervalCount).toBe(14)
+    })
+
+    it('persists to localStorage', () => {
+      const { result } = renderHook(() => useIntervalSelector(Duration.DAILY))
+
+      act(() => {
+        result.current.setIntervalCount(14)
+      })
+
+      const stored = JSON.parse(localStorage.getItem('tower-tracking-time-series-filters')!)
+      expect(stored.periodCounts.daily).toBe(14)
+    })
+
+    it('can set to "all"', () => {
+      const { result } = renderHook(() => useIntervalSelector(Duration.DAILY))
+
+      act(() => {
+        result.current.setIntervalCount(14)
+      })
+      act(() => {
+        result.current.setIntervalCount('all')
+      })
+
+      expect(result.current.intervalCount).toBe('all')
+    })
+  })
+
+  describe('duration changes', () => {
+    it('loads persisted value for new duration', () => {
+      localStorage.setItem(
+        'tower-tracking-time-series-filters',
+        JSON.stringify({ periodCounts: { daily: 14, weekly: 10 } })
+      )
+
+      const { result, rerender } = renderHook(
+        ({ duration }) => useIntervalSelector(duration),
+        { initialProps: { duration: Duration.DAILY } }
+      )
+
+      expect(result.current.intervalCount).toBe(14)
+
+      rerender({ duration: Duration.WEEKLY })
+
+      expect(result.current.intervalCount).toBe(10)
+    })
+
+    it('falls back to "all" for duration without persisted value', () => {
+      localStorage.setItem(
+        'tower-tracking-time-series-filters',
+        JSON.stringify({ periodCounts: { daily: 14 } })
+      )
+
+      const { result, rerender } = renderHook(
+        ({ duration }) => useIntervalSelector(duration),
+        { initialProps: { duration: Duration.DAILY } }
+      )
+
+      expect(result.current.intervalCount).toBe(14)
+
+      rerender({ duration: Duration.WEEKLY })
+
+      expect(result.current.intervalCount).toBe('all')
+    })
+
+    it('updates options and label for new duration', () => {
+      const { result, rerender } = renderHook(
+        ({ duration }) => useIntervalSelector(duration),
+        { initialProps: { duration: Duration.DAILY } }
+      )
+
+      expect(result.current.countOptions).toEqual([7, 14, 21, 28, 35, 42])
+      expect(result.current.label).toBe('Last Days')
+
+      rerender({ duration: Duration.HOURLY })
+
+      expect(result.current.countOptions).toEqual([6, 12, 18, 24, 30, 36])
+      expect(result.current.label).toBe('Last Hours')
+    })
+  })
+})

--- a/src/features/analysis/time-series/interval-selector/use-interval-selector.ts
+++ b/src/features/analysis/time-series/interval-selector/use-interval-selector.ts
@@ -1,0 +1,43 @@
+import { useState, useEffect, useCallback } from 'react'
+import { Duration, type PeriodCountFilter } from '@/shared/domain/filters/types'
+import { getPeriodCountOptions, getPeriodCountLabel } from '@/shared/domain/filters/period-count/period-count-logic'
+import {
+  loadPersistedIntervalCount,
+  savePersistedIntervalCount,
+} from './interval-persistence'
+
+interface UseIntervalSelectorResult {
+  intervalCount: PeriodCountFilter
+  setIntervalCount: (count: PeriodCountFilter) => void
+  countOptions: number[]
+  label: string
+}
+
+/**
+ * Hook to manage interval count state with localStorage persistence.
+ * Loads persisted value on duration change, falls back to 'all'.
+ */
+export function useIntervalSelector(duration: Duration): UseIntervalSelectorResult {
+  const [intervalCount, setIntervalCountState] = useState<PeriodCountFilter>('all')
+
+  // Load persisted interval when duration changes
+  useEffect(() => {
+    const persisted = loadPersistedIntervalCount(duration)
+    setIntervalCountState(persisted ?? 'all')
+  }, [duration])
+
+  const setIntervalCount = useCallback(
+    (count: PeriodCountFilter) => {
+      setIntervalCountState(count)
+      savePersistedIntervalCount(duration, count)
+    },
+    [duration]
+  )
+
+  return {
+    intervalCount,
+    setIntervalCount,
+    countOptions: getPeriodCountOptions(duration),
+    label: getPeriodCountLabel(duration),
+  }
+}

--- a/src/features/analysis/time-series/moving-average/moving-average-persistence.test.ts
+++ b/src/features/analysis/time-series/moving-average/moving-average-persistence.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest'
+import { Duration } from '@/shared/domain/filters/types'
 import {
   loadTrendWindow,
   saveTrendWindow,
@@ -13,15 +14,15 @@ describe('moving-average-persistence', () => {
 
   describe('buildCompoundKey', () => {
     it('creates compound key from metric and period', () => {
-      expect(buildCompoundKey('coinsEarned', 'daily')).toBe('coinsEarned:daily')
-      expect(buildCompoundKey('totalDamage', 'weekly')).toBe('totalDamage:weekly')
-      expect(buildCompoundKey('cellsEarned', 'run')).toBe('cellsEarned:run')
+      expect(buildCompoundKey('coinsEarned', Duration.DAILY)).toBe('coinsEarned:daily')
+      expect(buildCompoundKey('totalDamage', Duration.WEEKLY)).toBe('totalDamage:weekly')
+      expect(buildCompoundKey('cellsEarned', Duration.PER_RUN)).toBe('cellsEarned:per-run')
     })
   })
 
   describe('loadTrendWindow', () => {
     it('returns "none" when no stored value exists', () => {
-      const result = loadTrendWindow('coinsEarned', 'daily')
+      const result = loadTrendWindow('coinsEarned', Duration.DAILY)
       expect(result).toBe('none')
     })
 
@@ -33,7 +34,7 @@ describe('moving-average-persistence', () => {
         })
       )
 
-      const result = loadTrendWindow('coinsEarned', 'daily')
+      const result = loadTrendWindow('coinsEarned', Duration.DAILY)
       expect(result).toBe('7d')
     })
 
@@ -45,7 +46,7 @@ describe('moving-average-persistence', () => {
         })
       )
 
-      const result = loadTrendWindow('coinsEarned', 'daily')
+      const result = loadTrendWindow('coinsEarned', Duration.DAILY)
       expect(result).toBe('none')
     })
 
@@ -59,9 +60,9 @@ describe('moving-average-persistence', () => {
         })
       )
 
-      expect(loadTrendWindow('coinsEarned', 'daily')).toBe('7d')
-      expect(loadTrendWindow('coinsEarned', 'weekly')).toBe('2w')
-      expect(loadTrendWindow('totalDamage', 'daily')).toBe('14d')
+      expect(loadTrendWindow('coinsEarned', Duration.DAILY)).toBe('7d')
+      expect(loadTrendWindow('coinsEarned', Duration.WEEKLY)).toBe('2w')
+      expect(loadTrendWindow('totalDamage', Duration.DAILY)).toBe('14d')
     })
 
     it('returns "none" for unknown metric+period combination', () => {
@@ -72,7 +73,7 @@ describe('moving-average-persistence', () => {
         })
       )
 
-      const result = loadTrendWindow('unknownMetric', 'daily')
+      const result = loadTrendWindow('unknownMetric', Duration.DAILY)
       expect(result).toBe('none')
     })
 
@@ -84,21 +85,21 @@ describe('moving-average-persistence', () => {
         })
       )
 
-      const result = loadTrendWindow('coinsEarned', 'daily')
+      const result = loadTrendWindow('coinsEarned', Duration.DAILY)
       expect(result).toBe('none')
     })
 
     it('returns "none" when stored JSON is malformed', () => {
       localStorage.setItem('tower-tracking-moving-average-config', 'not valid json')
 
-      const result = loadTrendWindow('coinsEarned', 'daily')
+      const result = loadTrendWindow('coinsEarned', Duration.DAILY)
       expect(result).toBe('none')
     })
   })
 
   describe('saveTrendWindow', () => {
     it('saves value to localStorage with compound key', () => {
-      saveTrendWindow('coinsEarned', 'daily', '7d')
+      saveTrendWindow('coinsEarned', Duration.DAILY, '7d')
 
       const stored = localStorage.getItem('tower-tracking-moving-average-config')
       expect(stored).toBeTruthy()
@@ -113,7 +114,7 @@ describe('moving-average-persistence', () => {
         })
       )
 
-      saveTrendWindow('coinsEarned', 'daily', '7d')
+      saveTrendWindow('coinsEarned', Duration.DAILY, '7d')
 
       const stored = localStorage.getItem('tower-tracking-moving-average-config')
       expect(JSON.parse(stored!)).toEqual({
@@ -130,23 +131,23 @@ describe('moving-average-persistence', () => {
         })
       )
 
-      saveTrendWindow('coinsEarned', 'daily', '14d')
+      saveTrendWindow('coinsEarned', Duration.DAILY, '14d')
 
       const stored = localStorage.getItem('tower-tracking-moving-average-config')
       expect(JSON.parse(stored!)).toEqual({ 'coinsEarned:daily': '14d' })
     })
 
     it('handles "none" value', () => {
-      saveTrendWindow('coinsEarned', 'daily', 'none')
+      saveTrendWindow('coinsEarned', Duration.DAILY, 'none')
 
       const stored = localStorage.getItem('tower-tracking-moving-average-config')
       expect(JSON.parse(stored!)).toEqual({ 'coinsEarned:daily': 'none' })
     })
 
     it('stores independent values for same metric with different periods', () => {
-      saveTrendWindow('coinsEarned', 'daily', '7d')
-      saveTrendWindow('coinsEarned', 'weekly', '2w')
-      saveTrendWindow('coinsEarned', 'monthly', '3m')
+      saveTrendWindow('coinsEarned', Duration.DAILY, '7d')
+      saveTrendWindow('coinsEarned', Duration.WEEKLY, '2w')
+      saveTrendWindow('coinsEarned', Duration.MONTHLY, '3m')
 
       const stored = localStorage.getItem('tower-tracking-moving-average-config')
       expect(JSON.parse(stored!)).toEqual({
@@ -188,7 +189,7 @@ describe('moving-average-persistence', () => {
       )
 
       // Loading should detect legacy format and clear it
-      const result = loadTrendWindow('coinsEarned', 'daily')
+      const result = loadTrendWindow('coinsEarned', Duration.DAILY)
       expect(result).toBe('none')
 
       // Storage should be cleared
@@ -205,7 +206,7 @@ describe('moving-average-persistence', () => {
       )
 
       // Should detect legacy format and clear all
-      const result = loadTrendWindow('coinsEarned', 'daily')
+      const result = loadTrendWindow('coinsEarned', Duration.DAILY)
       expect(result).toBe('none')
       expect(localStorage.getItem('tower-tracking-moving-average-config')).toBeNull()
     })
@@ -217,7 +218,7 @@ describe('moving-average-persistence', () => {
       // @ts-expect-error - Testing SSR behavior
       delete global.window
 
-      const result = loadTrendWindow('coinsEarned', 'daily')
+      const result = loadTrendWindow('coinsEarned', Duration.DAILY)
       expect(result).toBe('none')
 
       global.window = originalWindow
@@ -228,7 +229,7 @@ describe('moving-average-persistence', () => {
       // @ts-expect-error - Testing SSR behavior
       delete global.window
 
-      expect(() => saveTrendWindow('coinsEarned', 'daily', '7d')).not.toThrow()
+      expect(() => saveTrendWindow('coinsEarned', Duration.DAILY, '7d')).not.toThrow()
 
       global.window = originalWindow
     })

--- a/src/features/analysis/time-series/moving-average/moving-average-types.test.ts
+++ b/src/features/analysis/time-series/moving-average/moving-average-types.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest'
+import { Duration } from '@/shared/domain/filters/types'
 import {
   getWindowSize,
   getTrendWindowOptions,
@@ -49,7 +50,7 @@ describe('moving-average-types', () => {
 
   describe('getTrendWindowOptions', () => {
     it('returns hourly options for hourly period', () => {
-      const options = getTrendWindowOptions('hourly')
+      const options = getTrendWindowOptions(Duration.HOURLY)
       expect(options).toHaveLength(5)
       expect(options[0]).toEqual({ value: 'none', label: 'No Trend' })
       expect(options[1]).toEqual({ value: '6h', label: '6 hours' })
@@ -57,7 +58,7 @@ describe('moving-average-types', () => {
     })
 
     it('returns run options for run period', () => {
-      const options = getTrendWindowOptions('run')
+      const options = getTrendWindowOptions(Duration.PER_RUN)
       expect(options).toHaveLength(4)
       expect(options[0]).toEqual({ value: 'none', label: 'No Trend' })
       expect(options[1]).toEqual({ value: '3r', label: '3 runs' })
@@ -65,7 +66,7 @@ describe('moving-average-types', () => {
     })
 
     it('returns daily options for daily period', () => {
-      const options = getTrendWindowOptions('daily')
+      const options = getTrendWindowOptions(Duration.DAILY)
       expect(options).toHaveLength(5)
       expect(options[0]).toEqual({ value: 'none', label: 'No Trend' })
       expect(options[1]).toEqual({ value: '3d', label: '3 days' })
@@ -73,7 +74,7 @@ describe('moving-average-types', () => {
     })
 
     it('returns weekly options for weekly period', () => {
-      const options = getTrendWindowOptions('weekly')
+      const options = getTrendWindowOptions(Duration.WEEKLY)
       expect(options).toHaveLength(4)
       expect(options[0]).toEqual({ value: 'none', label: 'No Trend' })
       expect(options[1]).toEqual({ value: '2w', label: '2 weeks' })
@@ -81,7 +82,7 @@ describe('moving-average-types', () => {
     })
 
     it('returns monthly options for monthly period', () => {
-      const options = getTrendWindowOptions('monthly')
+      const options = getTrendWindowOptions(Duration.MONTHLY)
       expect(options).toHaveLength(4)
       expect(options[0]).toEqual({ value: 'none', label: 'No Trend' })
       expect(options[1]).toEqual({ value: '2m', label: '2 months' })
@@ -89,7 +90,7 @@ describe('moving-average-types', () => {
     })
 
     it('returns only "none" for yearly period', () => {
-      const options = getTrendWindowOptions('yearly')
+      const options = getTrendWindowOptions(Duration.YEARLY)
       expect(options).toHaveLength(1)
       expect(options[0]).toEqual({ value: 'none', label: 'No Trend' })
     })
@@ -150,60 +151,60 @@ describe('moving-average-types', () => {
 
   describe('isValidForPeriod', () => {
     it('returns true for "none" with any period', () => {
-      expect(isValidForPeriod('none', 'hourly')).toBe(true)
-      expect(isValidForPeriod('none', 'run')).toBe(true)
-      expect(isValidForPeriod('none', 'daily')).toBe(true)
-      expect(isValidForPeriod('none', 'weekly')).toBe(true)
-      expect(isValidForPeriod('none', 'monthly')).toBe(true)
-      expect(isValidForPeriod('none', 'yearly')).toBe(true)
+      expect(isValidForPeriod('none', Duration.HOURLY)).toBe(true)
+      expect(isValidForPeriod('none', Duration.PER_RUN)).toBe(true)
+      expect(isValidForPeriod('none', Duration.DAILY)).toBe(true)
+      expect(isValidForPeriod('none', Duration.WEEKLY)).toBe(true)
+      expect(isValidForPeriod('none', Duration.MONTHLY)).toBe(true)
+      expect(isValidForPeriod('none', Duration.YEARLY)).toBe(true)
     })
 
     it('returns true for hourly values with hourly period', () => {
-      expect(isValidForPeriod('6h', 'hourly')).toBe(true)
-      expect(isValidForPeriod('12h', 'hourly')).toBe(true)
-      expect(isValidForPeriod('24h', 'hourly')).toBe(true)
+      expect(isValidForPeriod('6h', Duration.HOURLY)).toBe(true)
+      expect(isValidForPeriod('12h', Duration.HOURLY)).toBe(true)
+      expect(isValidForPeriod('24h', Duration.HOURLY)).toBe(true)
     })
 
     it('returns false for hourly values with non-hourly period', () => {
-      expect(isValidForPeriod('6h', 'daily')).toBe(false)
-      expect(isValidForPeriod('12h', 'weekly')).toBe(false)
+      expect(isValidForPeriod('6h', Duration.DAILY)).toBe(false)
+      expect(isValidForPeriod('12h', Duration.WEEKLY)).toBe(false)
     })
 
     it('returns true for run values with run period', () => {
-      expect(isValidForPeriod('3r', 'run')).toBe(true)
-      expect(isValidForPeriod('5r', 'run')).toBe(true)
-      expect(isValidForPeriod('10r', 'run')).toBe(true)
+      expect(isValidForPeriod('3r', Duration.PER_RUN)).toBe(true)
+      expect(isValidForPeriod('5r', Duration.PER_RUN)).toBe(true)
+      expect(isValidForPeriod('10r', Duration.PER_RUN)).toBe(true)
     })
 
     it('returns false for run values with non-run period', () => {
-      expect(isValidForPeriod('3r', 'daily')).toBe(false)
-      expect(isValidForPeriod('5r', 'hourly')).toBe(false)
+      expect(isValidForPeriod('3r', Duration.DAILY)).toBe(false)
+      expect(isValidForPeriod('5r', Duration.HOURLY)).toBe(false)
     })
 
     it('returns true for daily values with daily period', () => {
-      expect(isValidForPeriod('7d', 'daily')).toBe(true)
-      expect(isValidForPeriod('14d', 'daily')).toBe(true)
+      expect(isValidForPeriod('7d', Duration.DAILY)).toBe(true)
+      expect(isValidForPeriod('14d', Duration.DAILY)).toBe(true)
     })
 
     it('returns false for daily values with non-daily period', () => {
-      expect(isValidForPeriod('7d', 'weekly')).toBe(false)
-      expect(isValidForPeriod('14d', 'monthly')).toBe(false)
+      expect(isValidForPeriod('7d', Duration.WEEKLY)).toBe(false)
+      expect(isValidForPeriod('14d', Duration.MONTHLY)).toBe(false)
     })
 
     it('returns true for weekly values with weekly period', () => {
-      expect(isValidForPeriod('2w', 'weekly')).toBe(true)
-      expect(isValidForPeriod('4w', 'weekly')).toBe(true)
+      expect(isValidForPeriod('2w', Duration.WEEKLY)).toBe(true)
+      expect(isValidForPeriod('4w', Duration.WEEKLY)).toBe(true)
     })
 
     it('returns true for monthly values with monthly period', () => {
-      expect(isValidForPeriod('3m', 'monthly')).toBe(true)
-      expect(isValidForPeriod('4m', 'monthly')).toBe(true)
+      expect(isValidForPeriod('3m', Duration.MONTHLY)).toBe(true)
+      expect(isValidForPeriod('4m', Duration.MONTHLY)).toBe(true)
     })
 
     it('returns false for all non-none values with yearly period', () => {
       const values: TrendWindowValue[] = ['7d', '2w', '3m', '10r', '12h']
       values.forEach((value) => {
-        expect(isValidForPeriod(value, 'yearly')).toBe(false)
+        expect(isValidForPeriod(value, Duration.YEARLY)).toBe(false)
       })
     })
   })

--- a/src/features/analysis/time-series/moving-average/moving-average-types.ts
+++ b/src/features/analysis/time-series/moving-average/moving-average-types.ts
@@ -1,3 +1,4 @@
+import { Duration } from '@/shared/domain/filters/types'
 import type { TimePeriod } from '../chart-types'
 
 /**
@@ -44,18 +45,6 @@ const MONTHLY_OPTIONS = [
 const YEARLY_OPTIONS = [{ value: 'none', label: 'No Trend' }] as const
 
 /**
- * Maps time periods to their trend window options.
- */
-const OPTIONS_BY_PERIOD = {
-  hourly: HOURLY_OPTIONS,
-  run: RUN_OPTIONS,
-  daily: DAILY_OPTIONS,
-  weekly: WEEKLY_OPTIONS,
-  monthly: MONTHLY_OPTIONS,
-  yearly: YEARLY_OPTIONS,
-} as const
-
-/**
  * All valid trend window values derived from the option definitions.
  */
 type HourlyValue = (typeof HOURLY_OPTIONS)[number]['value']
@@ -74,6 +63,18 @@ export type TrendWindowValue =
 interface TrendWindowOption {
   readonly value: TrendWindowValue
   readonly label: string
+}
+
+/**
+ * Maps time periods to their trend window options.
+ */
+const OPTIONS_BY_PERIOD: Record<TimePeriod, readonly TrendWindowOption[]> = {
+  [Duration.HOURLY]: HOURLY_OPTIONS,
+  [Duration.PER_RUN]: RUN_OPTIONS,
+  [Duration.DAILY]: DAILY_OPTIONS,
+  [Duration.WEEKLY]: WEEKLY_OPTIONS,
+  [Duration.MONTHLY]: MONTHLY_OPTIONS,
+  [Duration.YEARLY]: YEARLY_OPTIONS,
 }
 
 /**

--- a/src/features/analysis/time-series/moving-average/use-moving-average.test.tsx
+++ b/src/features/analysis/time-series/moving-average/use-moving-average.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
+import { Duration } from '@/shared/domain/filters/types'
 import { useMovingAverage } from './use-moving-average'
 import type { TimePeriod } from '../chart-types'
 
@@ -10,7 +11,7 @@ describe('useMovingAverage', () => {
 
   describe('initial state', () => {
     it('returns "none" as default when no stored value exists', () => {
-      const { result } = renderHook(() => useMovingAverage('testMetric', 'daily'))
+      const { result } = renderHook(() => useMovingAverage('testMetric', Duration.DAILY))
 
       expect(result.current.trendWindow).toBe('none')
       expect(result.current.isEnabled).toBe(false)
@@ -25,7 +26,7 @@ describe('useMovingAverage', () => {
         })
       )
 
-      const { result } = renderHook(() => useMovingAverage('coinsEarned', 'daily'))
+      const { result } = renderHook(() => useMovingAverage('coinsEarned', Duration.DAILY))
 
       expect(result.current.trendWindow).toBe('7d')
       expect(result.current.isEnabled).toBe(true)
@@ -40,7 +41,7 @@ describe('useMovingAverage', () => {
         })
       )
 
-      const { result } = renderHook(() => useMovingAverage('totalDamage', 'daily'))
+      const { result } = renderHook(() => useMovingAverage('totalDamage', Duration.DAILY))
 
       expect(result.current.trendWindow).toBe('none')
       expect(result.current.isEnabled).toBe(false)
@@ -56,10 +57,10 @@ describe('useMovingAverage', () => {
       )
 
       const { result: dailyResult } = renderHook(() =>
-        useMovingAverage('coinsEarned', 'daily')
+        useMovingAverage('coinsEarned', Duration.DAILY)
       )
       const { result: weeklyResult } = renderHook(() =>
-        useMovingAverage('coinsEarned', 'weekly')
+        useMovingAverage('coinsEarned', Duration.WEEKLY)
       )
 
       expect(dailyResult.current.trendWindow).toBe('7d')
@@ -69,7 +70,7 @@ describe('useMovingAverage', () => {
 
   describe('setTrendWindow', () => {
     it('updates trendWindow state', () => {
-      const { result } = renderHook(() => useMovingAverage('testMetric', 'daily'))
+      const { result } = renderHook(() => useMovingAverage('testMetric', Duration.DAILY))
 
       act(() => {
         result.current.setTrendWindow('14d')
@@ -81,7 +82,7 @@ describe('useMovingAverage', () => {
     })
 
     it('persists value to localStorage with compound key', () => {
-      const { result } = renderHook(() => useMovingAverage('testMetric', 'daily'))
+      const { result } = renderHook(() => useMovingAverage('testMetric', Duration.DAILY))
 
       act(() => {
         result.current.setTrendWindow('3d')
@@ -93,7 +94,7 @@ describe('useMovingAverage', () => {
     })
 
     it('can set value back to "none"', () => {
-      const { result } = renderHook(() => useMovingAverage('testMetric', 'daily'))
+      const { result } = renderHook(() => useMovingAverage('testMetric', Duration.DAILY))
 
       act(() => {
         result.current.setTrendWindow('7d')
@@ -113,13 +114,13 @@ describe('useMovingAverage', () => {
 
   describe('windowSize', () => {
     it('returns null when trendWindow is "none"', () => {
-      const { result } = renderHook(() => useMovingAverage('testMetric', 'daily'))
+      const { result } = renderHook(() => useMovingAverage('testMetric', Duration.DAILY))
 
       expect(result.current.windowSize).toBeNull()
     })
 
     it('returns numeric value for daily options', () => {
-      const { result } = renderHook(() => useMovingAverage('testMetric', 'daily'))
+      const { result } = renderHook(() => useMovingAverage('testMetric', Duration.DAILY))
 
       act(() => {
         result.current.setTrendWindow('7d')
@@ -133,7 +134,7 @@ describe('useMovingAverage', () => {
     })
 
     it('returns numeric value for weekly options', () => {
-      const { result } = renderHook(() => useMovingAverage('testMetric', 'weekly'))
+      const { result } = renderHook(() => useMovingAverage('testMetric', Duration.WEEKLY))
 
       act(() => {
         result.current.setTrendWindow('2w')
@@ -149,13 +150,13 @@ describe('useMovingAverage', () => {
 
   describe('isEnabled', () => {
     it('is false when trendWindow is "none"', () => {
-      const { result } = renderHook(() => useMovingAverage('testMetric', 'daily'))
+      const { result } = renderHook(() => useMovingAverage('testMetric', Duration.DAILY))
 
       expect(result.current.isEnabled).toBe(false)
     })
 
     it('is true when trendWindow is not "none"', () => {
-      const { result } = renderHook(() => useMovingAverage('testMetric', 'daily'))
+      const { result } = renderHook(() => useMovingAverage('testMetric', Duration.DAILY))
 
       act(() => {
         result.current.setTrendWindow('3d')
@@ -178,12 +179,12 @@ describe('useMovingAverage', () => {
       const { result, rerender } = renderHook(
         ({ metricKey, period }: { metricKey: string; period: TimePeriod }) =>
           useMovingAverage(metricKey, period),
-        { initialProps: { metricKey: 'coinsEarned', period: 'daily' as TimePeriod } }
+        { initialProps: { metricKey: 'coinsEarned', period: Duration.DAILY as TimePeriod } }
       )
 
       expect(result.current.trendWindow).toBe('7d')
 
-      rerender({ metricKey: 'totalDamage', period: 'daily' as TimePeriod })
+      rerender({ metricKey: 'totalDamage', period: Duration.DAILY as TimePeriod })
 
       expect(result.current.trendWindow).toBe('14d')
     })
@@ -202,12 +203,12 @@ describe('useMovingAverage', () => {
       const { result, rerender } = renderHook(
         ({ metricKey, period }: { metricKey: string; period: TimePeriod }) =>
           useMovingAverage(metricKey, period),
-        { initialProps: { metricKey: 'coinsEarned', period: 'daily' as TimePeriod } }
+        { initialProps: { metricKey: 'coinsEarned', period: Duration.DAILY as TimePeriod } }
       )
 
       expect(result.current.trendWindow).toBe('7d')
 
-      rerender({ metricKey: 'coinsEarned', period: 'weekly' as TimePeriod })
+      rerender({ metricKey: 'coinsEarned', period: Duration.WEEKLY as TimePeriod })
 
       expect(result.current.trendWindow).toBe('2w')
     })
@@ -223,12 +224,12 @@ describe('useMovingAverage', () => {
       const { result, rerender } = renderHook(
         ({ metricKey, period }: { metricKey: string; period: TimePeriod }) =>
           useMovingAverage(metricKey, period),
-        { initialProps: { metricKey: 'coinsEarned', period: 'daily' as TimePeriod } }
+        { initialProps: { metricKey: 'coinsEarned', period: Duration.DAILY as TimePeriod } }
       )
 
       expect(result.current.trendWindow).toBe('7d')
 
-      rerender({ metricKey: 'coinsEarned', period: 'weekly' as TimePeriod })
+      rerender({ metricKey: 'coinsEarned', period: Duration.WEEKLY as TimePeriod })
 
       expect(result.current.trendWindow).toBe('none')
     })

--- a/src/features/analysis/time-series/time-series-chart-body.tsx
+++ b/src/features/analysis/time-series/time-series-chart-body.tsx
@@ -1,5 +1,6 @@
 import { Area, ComposedChart, Line, XAxis, YAxis, Tooltip } from 'recharts'
 import { ChartContainer } from '@/components/ui'
+import { Duration } from '@/shared/domain/filters/types'
 import type { ChartDataPoint, TimePeriodConfig } from './chart-types'
 import { TimeSeriesChartTooltip } from './time-series-tooltip'
 
@@ -66,7 +67,7 @@ export function TimeSeriesChartBody({
             content={
               <TimeSeriesChartTooltip
                 periodLabel={currentConfig.label} metricLabel={tooltipLabel}
-                formatter={formatter} isHourlyPeriod={selectedPeriod === 'hourly'}
+                formatter={formatter} isHourlyPeriod={selectedPeriod === Duration.HOURLY}
                 accentColor={color} showTrendLine={isAverageEnabled}
                 showPercentChange={percentChangeEnabled}
               />

--- a/src/features/analysis/time-series/time-series-chart.tsx
+++ b/src/features/analysis/time-series/time-series-chart.tsx
@@ -1,6 +1,8 @@
 import { useMemo } from 'react'
 import { FormControl } from '@/components/ui'
 import { useData } from '@/shared/domain/use-data'
+import { Duration, type PeriodCountFilter } from '@/shared/domain/filters/types'
+import { PeriodCountSelector } from '@/shared/domain/filters/period-count/period-count-selector'
 import type { TimePeriod, TimePeriodConfig } from './chart-types'
 import { formatLargeNumber } from '@/features/analysis/shared/formatting/chart-formatters'
 import { filterRunsByType, type RunTypeFilter } from '@/features/analysis/shared/filtering/run-type-filter'
@@ -33,10 +35,15 @@ interface FilterControlsProps {
   availablePeriodConfigs: TimePeriodConfig[]
   selectedPeriod: TimePeriod
   onSelectPeriod: (period: TimePeriod) => void
+  intervalCount: PeriodCountFilter
+  onIntervalCountChange: (count: PeriodCountFilter) => void
+  intervalCountOptions: number[]
+  intervalLabel: string
   showRunTypeSelector: boolean
   runTypeFilter: RunTypeFilter
   onRunTypeChange?: (runType: RunTypeFilter) => void
   dataPointCount: number
+  showTrendSelector: boolean
   trendWindow: TrendWindowValue
   onTrendWindowChange: (value: TrendWindowValue) => void
   percentChangeEnabled: boolean
@@ -47,36 +54,50 @@ function FilterControls({
   availablePeriodConfigs,
   selectedPeriod,
   onSelectPeriod,
+  intervalCount,
+  onIntervalCountChange,
+  intervalCountOptions,
+  intervalLabel,
   showRunTypeSelector,
   runTypeFilter,
   onRunTypeChange,
   dataPointCount,
+  showTrendSelector,
   trendWindow,
   onTrendWindowChange,
   percentChangeEnabled,
   onPercentChangeToggle,
 }: FilterControlsProps) {
-  // Hide trend selector for yearly view (not enough data points for meaningful trends)
-  const showTrendSelector = selectedPeriod !== 'yearly'
-
   return (
     <div className="flex flex-wrap items-end justify-between gap-4">
-      {/* Left side: Duration selector */}
-      <FormControl label="Duration" layout="vertical">
-        <div className="flex flex-wrap items-center gap-1.5 sm:gap-2">
-          {availablePeriodConfigs.map((config) => (
-            <PeriodSelectorButton
-              key={config.period}
-              config={config}
-              isSelected={selectedPeriod === config.period}
-              onSelect={onSelectPeriod}
-            />
-          ))}
-        </div>
-      </FormControl>
+      {/* Left side: Duration selector + Interval selector */}
+      <div className="flex flex-wrap items-end gap-4">
+        <FormControl label="Duration" layout="vertical">
+          <div className="flex flex-wrap items-center gap-1.5 sm:gap-2">
+            {availablePeriodConfigs.map((config) => (
+              <PeriodSelectorButton
+                key={config.period}
+                config={config}
+                isSelected={selectedPeriod === config.period}
+                onSelect={onSelectPeriod}
+              />
+            ))}
+          </div>
+        </FormControl>
+
+        <PeriodCountSelector
+          selectedCount={intervalCount}
+          onCountChange={onIntervalCountChange}
+          countOptions={intervalCountOptions}
+          label={intervalLabel}
+          showAllOption={true}
+          layout="vertical"
+          accentColor="orange"
+        />
+      </div>
 
       {/* Right side: Run type selector + SMA selector + % Change toggle + Data points count */}
-      <div className="flex items-end gap-4">
+      <div className="flex flex-wrap items-end gap-4">
         {showRunTypeSelector && onRunTypeChange && (
           <RunTypeSelector
             selectedType={runTypeFilter}
@@ -112,7 +133,7 @@ export function TimeSeriesChart({
   title,
   subtitle,
   tooltipLabel,
-  defaultPeriod = 'run',
+  defaultPeriod = Duration.PER_RUN,
   runTypeFilter = RunType.FARM,
   onRunTypeChange,
   valueFormatter
@@ -139,8 +160,13 @@ export function TimeSeriesChart({
     trendWindow,
     setTrendWindow,
     isAverageEnabled,
+    showTrendSelector,
     percentChangeEnabled,
     setPercentChangeEnabled,
+    intervalCount,
+    setIntervalCount,
+    intervalCountOptions,
+    intervalLabel,
   } = useTimeSeriesChartData(filteredRuns, metric, defaultPeriod)
 
   if (chartData.length === 0) {
@@ -170,10 +196,15 @@ export function TimeSeriesChart({
           availablePeriodConfigs={availablePeriodConfigs}
           selectedPeriod={selectedPeriod}
           onSelectPeriod={setSelectedPeriod}
+          intervalCount={intervalCount}
+          onIntervalCountChange={setIntervalCount}
+          intervalCountOptions={intervalCountOptions}
+          intervalLabel={intervalLabel}
           showRunTypeSelector={showRunTypeSelector}
           runTypeFilter={runTypeFilter}
           onRunTypeChange={onRunTypeChange}
           dataPointCount={chartData.length}
+          showTrendSelector={showTrendSelector}
           trendWindow={trendWindow}
           onTrendWindowChange={setTrendWindow}
           percentChangeEnabled={percentChangeEnabled}

--- a/src/features/analysis/time-series/use-time-series-chart-data.ts
+++ b/src/features/analysis/time-series/use-time-series-chart-data.ts
@@ -1,5 +1,6 @@
-import { useState, useMemo, useEffect } from 'react'
+import { useMemo } from 'react'
 import type { ParsedGameRun } from '@/shared/types/game-run.types'
+import { Duration, type PeriodCountFilter } from '@/shared/domain/filters/types'
 import { prepareTimeSeriesData, getAvailableTimePeriods } from './chart-data'
 import type { TimePeriod, ChartDataPoint, TimePeriodConfig } from './chart-types'
 import { generateYAxisTicks } from '@/features/analysis/shared/formatting/chart-formatters'
@@ -9,6 +10,11 @@ import {
   type TrendWindowValue,
 } from './moving-average'
 import { calculatePercentChange, usePercentChange } from './percent-change'
+import {
+  sliceToInterval,
+  useIntervalSelector,
+  useDurationSelector,
+} from './interval-selector'
 
 interface UseTimeSeriesChartDataResult {
   chartData: ChartDataPoint[]
@@ -20,39 +26,47 @@ interface UseTimeSeriesChartDataResult {
   trendWindow: TrendWindowValue
   setTrendWindow: (value: TrendWindowValue) => void
   isAverageEnabled: boolean
+  /** Whether trend selector should be shown (hidden for yearly -- insufficient data points) */
+  showTrendSelector: boolean
   percentChangeEnabled: boolean
   setPercentChangeEnabled: (enabled: boolean) => void
+  intervalCount: PeriodCountFilter
+  setIntervalCount: (count: PeriodCountFilter) => void
+  intervalCountOptions: number[]
+  intervalLabel: string
 }
 
 /**
  * Custom hook that encapsulates all chart data preparation logic.
- * Handles period selection, moving average, and percent change calculations.
+ * Handles period selection, interval slicing, moving average, and percent change calculations.
  */
 export function useTimeSeriesChartData(
   filteredRuns: ParsedGameRun[],
   metric: string,
   defaultPeriod: TimePeriod
 ): UseTimeSeriesChartDataResult {
-  const [selectedPeriod, setSelectedPeriod] = useState<TimePeriod>(defaultPeriod)
-
   // Get available periods based on data span
   const availablePeriodConfigs = useMemo(() => {
     return getAvailableTimePeriods(filteredRuns)
   }, [filteredRuns])
 
-  // Reset period if current selection is not available
-  useEffect(() => {
-    const isCurrentPeriodAvailable = availablePeriodConfigs.some(
-      (config) => config.period === selectedPeriod
-    )
-    if (!isCurrentPeriodAvailable && availablePeriodConfigs.length > 0) {
-      setSelectedPeriod(availablePeriodConfigs[0].period)
-    }
-  }, [availablePeriodConfigs, selectedPeriod])
+  // Duration selection with localStorage persistence and auto-reset
+  const { selectedPeriod, setSelectedPeriod } = useDurationSelector(
+    defaultPeriod,
+    availablePeriodConfigs
+  )
 
   const currentConfig =
     availablePeriodConfigs.find((config) => config.period === selectedPeriod) ||
     availablePeriodConfigs[0]
+
+  // Interval selector state with localStorage persistence
+  const {
+    intervalCount,
+    setIntervalCount,
+    countOptions: intervalCountOptions,
+    label: intervalLabel,
+  } = useIntervalSelector(selectedPeriod)
 
   // Moving average state with localStorage persistence (period-aware)
   const { trendWindow, setTrendWindow, windowSize, isEnabled: isAverageEnabled } =
@@ -66,9 +80,9 @@ export function useTimeSeriesChartData(
     return prepareTimeSeriesData(filteredRuns, selectedPeriod, metric)
   }, [filteredRuns, selectedPeriod, metric])
 
-  // Apply optional calculations: moving average and percent change
+  // Apply interval slicing, then moving average and percent change
   const chartData = useMemo(() => {
-    let data = baseChartData
+    let data = sliceToInterval(baseChartData, intervalCount)
 
     if (isAverageEnabled && windowSize !== null) {
       data = calculateMovingAverage(data, windowSize)
@@ -79,13 +93,16 @@ export function useTimeSeriesChartData(
     }
 
     return data
-  }, [baseChartData, windowSize, isAverageEnabled, percentChangeEnabled])
+  }, [baseChartData, intervalCount, windowSize, isAverageEnabled, percentChangeEnabled])
 
   const yAxisTicks = useMemo(() => {
     if (chartData.length === 0) return []
     const maxValue = Math.max(...chartData.map((d) => d.value))
     return generateYAxisTicks(maxValue)
   }, [chartData])
+
+  // Hide trend selector for yearly view (not enough data points for meaningful trends)
+  const showTrendSelector = selectedPeriod !== Duration.YEARLY
 
   return {
     chartData,
@@ -97,7 +114,12 @@ export function useTimeSeriesChartData(
     trendWindow,
     setTrendWindow,
     isAverageEnabled,
+    showTrendSelector,
     percentChangeEnabled,
     setPercentChangeEnabled,
+    intervalCount,
+    setIntervalCount,
+    intervalCountOptions,
+    intervalLabel,
   }
 }

--- a/src/routes/charts/cells.tsx
+++ b/src/routes/charts/cells.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 import { useState } from 'react'
 import { ChartPageLayout } from '@/shared/layouts'
 import { TimeSeriesChart } from '@/features/analysis/time-series/time-series-chart'
+import { Duration } from '@/shared/domain/filters/types'
 import { RunType } from '@/shared/domain/run-types/types'
 import type { RunTypeFilter } from '@/features/analysis/shared/filtering/run-type-filter'
 
@@ -21,7 +22,7 @@ function CellsChartPage() {
       <TimeSeriesChart
         metric="cellsEarned"
         tooltipLabel="Cells Earned"
-        defaultPeriod="hourly"
+        defaultPeriod={Duration.HOURLY}
         runTypeFilter={runTypeFilter}
         onRunTypeChange={setRunTypeFilter}
       />

--- a/src/routes/charts/coins.tsx
+++ b/src/routes/charts/coins.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 import { useState } from 'react'
 import { ChartPageLayout } from '@/shared/layouts'
 import { TimeSeriesChart } from '@/features/analysis/time-series/time-series-chart'
+import { Duration } from '@/shared/domain/filters/types'
 import { RunType } from '@/shared/domain/run-types/types'
 import type { RunTypeFilter } from '@/features/analysis/shared/filtering/run-type-filter'
 
@@ -21,7 +22,7 @@ function CoinsChartPage() {
       <TimeSeriesChart
         metric="coinsEarned"
         tooltipLabel="Coins Earned"
-        defaultPeriod="hourly"
+        defaultPeriod={Duration.HOURLY}
         runTypeFilter={runTypeFilter}
         onRunTypeChange={setRunTypeFilter}
       />

--- a/src/routes/charts/fields.tsx
+++ b/src/routes/charts/fields.tsx
@@ -7,6 +7,7 @@ import { useFieldSelector } from '@/features/analysis/field-analytics/use-field-
 import { useData } from '@/shared/domain/use-data'
 import { formatFieldDisplayName, getFieldFormatter } from '@/shared/domain/fields/field-formatters'
 import { getFieldDataType } from '@/shared/domain/fields/field-discovery'
+import { Duration } from '@/shared/domain/filters/types'
 import { RunType } from '@/shared/domain/run-types/types'
 import type { RunTypeFilter } from '@/features/analysis/shared/filtering/run-type-filter'
 
@@ -56,7 +57,7 @@ function FieldAnalyticsPage() {
         <TimeSeriesChart
           metric={selectedField}
           tooltipLabel={tooltipLabel}
-          defaultPeriod="hourly"
+          defaultPeriod={Duration.HOURLY}
           runTypeFilter={runTypeFilter}
           onRunTypeChange={setRunTypeFilter}
           valueFormatter={valueFormatter}

--- a/src/shared/domain/filters/period-count/period-count-logic.test.ts
+++ b/src/shared/domain/filters/period-count/period-count-logic.test.ts
@@ -9,6 +9,10 @@ import {
 } from './period-count-logic'
 
 describe('getPeriodCountOptions', () => {
+  it('should return hourly increments for HOURLY', () => {
+    expect(getPeriodCountOptions(Duration.HOURLY)).toEqual([6, 12, 18, 24, 30, 36])
+  })
+
   it('should return standard increments for PER_RUN', () => {
     expect(getPeriodCountOptions(Duration.PER_RUN)).toEqual([5, 10, 15, 20, 25, 30])
   })
@@ -31,6 +35,10 @@ describe('getPeriodCountOptions', () => {
 })
 
 describe('getDefaultPeriodCount', () => {
+  it('should return 12 for HOURLY', () => {
+    expect(getDefaultPeriodCount(Duration.HOURLY)).toBe(12)
+  })
+
   it('should return 10 for PER_RUN', () => {
     expect(getDefaultPeriodCount(Duration.PER_RUN)).toBe(10)
   })
@@ -54,6 +62,7 @@ describe('getDefaultPeriodCount', () => {
 
 describe('getPeriodCountLabel', () => {
   it('should return correct labels for each duration', () => {
+    expect(getPeriodCountLabel(Duration.HOURLY)).toBe('Last Hours')
     expect(getPeriodCountLabel(Duration.PER_RUN)).toBe('Last Runs')
     expect(getPeriodCountLabel(Duration.DAILY)).toBe('Last Days')
     expect(getPeriodCountLabel(Duration.WEEKLY)).toBe('Last Weeks')

--- a/src/shared/domain/filters/period-count/period-count-logic.ts
+++ b/src/shared/domain/filters/period-count/period-count-logic.ts
@@ -16,6 +16,7 @@ import { Duration, PERIOD_UNIT_LABELS } from '../types'
  * Yearly: Small increments (2, 3, 4, 5)
  */
 const PERIOD_COUNT_OPTIONS: Record<Duration, number[]> = {
+  [Duration.HOURLY]: [6, 12, 18, 24, 30, 36],
   [Duration.PER_RUN]: [5, 10, 15, 20, 25, 30],
   [Duration.DAILY]: [7, 14, 21, 28, 35, 42],
   [Duration.WEEKLY]: [5, 10, 15, 20, 25, 30],
@@ -27,6 +28,7 @@ const PERIOD_COUNT_OPTIONS: Record<Duration, number[]> = {
  * Default period counts per duration
  */
 const DEFAULT_PERIOD_COUNTS: Record<Duration, number> = {
+  [Duration.HOURLY]: 12,
   [Duration.PER_RUN]: 10,
   [Duration.DAILY]: 14,
   [Duration.WEEKLY]: 10,

--- a/src/shared/domain/filters/types.ts
+++ b/src/shared/domain/filters/types.ts
@@ -10,6 +10,7 @@
  * Replaces separate TrendsDuration and SourceDuration enums
  */
 export enum Duration {
+  HOURLY = 'hourly',
   PER_RUN = 'per-run',
   DAILY = 'daily',
   WEEKLY = 'weekly',
@@ -31,6 +32,7 @@ export type PeriodCountFilter = number | 'all'
  * Display labels for duration options
  */
 export const DURATION_LABELS: Record<Duration, string> = {
+  [Duration.HOURLY]: 'Per Hour',
   [Duration.PER_RUN]: 'Per Run',
   [Duration.DAILY]: 'Daily',
   [Duration.WEEKLY]: 'Weekly',
@@ -47,6 +49,7 @@ interface PeriodUnitLabels {
 }
 
 export const PERIOD_UNIT_LABELS: Record<Duration, PeriodUnitLabels> = {
+  [Duration.HOURLY]: { singular: 'Hour', plural: 'Hours' },
   [Duration.PER_RUN]: { singular: 'Run', plural: 'Runs' },
   [Duration.DAILY]: { singular: 'Day', plural: 'Days' },
   [Duration.WEEKLY]: { singular: 'Week', plural: 'Weeks' },


### PR DESCRIPTION
## Summary
- Add interval selector to all time series charts (Coins, Cells, Fields) allowing users to control visible data points (e.g., "Last 14 Days", "Last 10 Runs")
- Unify `TimePeriod` string union with shared `Duration` enum (`type TimePeriod = Duration`), adding `Duration.HOURLY`
- New `interval-selector/` module with data slicing logic, localStorage persistence, and React hooks following established `moving-average/` patterns
- Extract `useDurationSelector` hook for duration selection with persistence and auto-reset
- Integrate `PeriodCountSelector` UI component with responsive flex-wrap layout

<img width="1300" height="868" alt="image" src="https://github.com/user-attachments/assets/1cbc2f59-0742-4359-a0a6-412398fe4a58" />
