### PR TITLE
IMPROVE: Add data-aware period count pruning across analysis features

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -41,7 +41,8 @@
       "Bash(findstr:*)",
       "Bash(npx vitest run --reporter=verbose)",
       "Bash(npx vitest run --reporter=dot)",
-      "Bash(npx vitest run)"
+      "Bash(npx vitest run)",
+      "Bash(npx vitest run src/**)"      
     ],
     "defaultMode": "acceptEdits"
   },

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -193,11 +193,6 @@
       "count": 1
     }
   },
-  "src/shared/domain/filters/duration/duration-filter-logic.ts": {
-    "max-statements": {
-      "count": 1
-    }
-  },
   "src/shared/domain/run-types/run-type-detection.ts": {
     "complexity": {
       "count": 1

--- a/src/features/analysis/coverage-report/coverage-report.tsx
+++ b/src/features/analysis/coverage-report/coverage-report.tsx
@@ -214,6 +214,8 @@ export function CoverageReport() {
     yAxisMax,
     availableTiers,
     availableDurations,
+    periodCountOptions,
+    periodCountLabel,
   } = useCoverageReport({ runs })
 
   // Show empty state if no runs at all
@@ -228,6 +230,8 @@ export function CoverageReport() {
         filters={filters}
         availableTiers={availableTiers}
         availableDurations={availableDurations}
+        periodCountOptions={periodCountOptions}
+        periodCountLabel={periodCountLabel}
         onToggleMetric={toggleMetric}
         onRunTypeChange={setRunType}
         onTierChange={setTier}

--- a/src/features/analysis/coverage-report/filters/coverage-report-filters.tsx
+++ b/src/features/analysis/coverage-report/filters/coverage-report-filters.tsx
@@ -9,8 +9,6 @@ import {
   DurationSelector,
   PeriodCountSelector,
   Duration,
-  getPeriodCountOptions,
-  getPeriodCountLabel,
 } from '@/shared/domain/filters'
 import { RunTypeSelector } from '@/shared/domain/run-types/run-type-selector'
 import type { RunTypeFilter } from '@/features/analysis/shared/filtering/run-type-filter'
@@ -21,6 +19,8 @@ interface CoverageReportFiltersProps {
   filters: CoverageReportFilters
   availableTiers: number[]
   availableDurations: Duration[]
+  periodCountOptions: number[]
+  periodCountLabel: string
   onToggleMetric: (fieldName: CoverageFieldName) => void
   onRunTypeChange: (runType: RunTypeFilter) => void
   onTierChange: (tier: number | 'all') => void
@@ -32,14 +32,14 @@ export function CoverageReportFiltersComponent({
   filters,
   availableTiers,
   availableDurations,
+  periodCountOptions,
+  periodCountLabel,
   onToggleMetric,
   onRunTypeChange,
   onTierChange,
   onDurationChange,
   onPeriodCountChange,
 }: CoverageReportFiltersProps) {
-  const periodOptions = getPeriodCountOptions(filters.duration)
-  const periodLabel = getPeriodCountLabel(filters.duration)
 
   return (
     <div className="space-y-4">
@@ -80,8 +80,8 @@ export function CoverageReportFiltersComponent({
         <PeriodCountSelector
           selectedCount={filters.periodCount}
           onCountChange={onPeriodCountChange}
-          countOptions={periodOptions}
-          label={periodLabel}
+          countOptions={periodCountOptions}
+          label={periodCountLabel}
           accentColor="cyan"
           layout="vertical"
         />

--- a/src/features/analysis/coverage-report/use-coverage-report.test.tsx
+++ b/src/features/analysis/coverage-report/use-coverage-report.test.tsx
@@ -47,18 +47,15 @@ function createMockRun(
 }
 
 describe('useCoverageReport', () => {
-  const defaultMockRuns = [
-    createMockRun('1', new Date(2024, 2, 15, 12, 0, 0), {
+  // 30 runs spanning ~7 months to support default period counts across durations
+  const defaultMockRuns = Array.from({ length: 30 }, (_, i) => {
+    const date = new Date(2024, 0, 1 + i * 7, 12, 0, 0)
+    return createMockRun(String(i + 1), date, {
       totalEnemies: 1000,
-      taggedByDeathwave: 800,
-      destroyedInSpotlight: 300,
-    }),
-    createMockRun('2', new Date(2024, 2, 16, 12, 0, 0), {
-      totalEnemies: 1000,
-      taggedByDeathwave: 600,
-      destroyedInSpotlight: 400,
-    }),
-  ]
+      taggedByDeathwave: 800 - i * 10,
+      destroyedInSpotlight: 300 + i * 5,
+    })
+  })
 
   describe('initialization', () => {
     it('initializes with default filters', () => {
@@ -82,12 +79,12 @@ describe('useCoverageReport', () => {
       const { result } = renderHook(() =>
         useCoverageReport({
           runs: defaultMockRuns,
-          initialFilters: { tier: 11, periodCount: 10 },
+          initialFilters: { tier: 11, periodCount: 14 },
         })
       )
 
       expect(result.current.filters.tier).toBe(11)
-      expect(result.current.filters.periodCount).toBe(10)
+      expect(result.current.filters.periodCount).toBe(14)
       // Other values should be defaults
       expect(result.current.filters.runType).toBe('farm')
     })

--- a/src/features/analysis/coverage-report/use-coverage-report.ts
+++ b/src/features/analysis/coverage-report/use-coverage-report.ts
@@ -10,6 +10,8 @@ import type { ParsedGameRun } from '@/shared/types/game-run.types'
 import type { RunTypeFilter } from '@/features/analysis/shared/filtering/run-type-filter'
 import type { PeriodCountFilter } from '@/shared/domain/filters/types'
 import { clampPeriodCount } from '@/shared/domain/filters/period-count/period-count-logic'
+import { usePeriodCountOptions } from '@/shared/domain/filters/period-count/use-period-count-options'
+import { usePeriodCountFallback } from '@/shared/domain/filters/period-count/use-period-count-fallback'
 import type {
   CoverageReportFilters,
   CoverageAnalysisData,
@@ -56,6 +58,8 @@ interface UseCoverageReportReturn {
   // Available options for filters
   availableTiers: number[]
   availableDurations: Duration[]
+  periodCountOptions: number[]
+  periodCountLabel: string
 }
 
 /**
@@ -84,6 +88,17 @@ export function useCoverageReport({
   // Use unified hooks for available options
   const { tiers: availableTiers } = useAvailableTiers(runs, filters.runType)
   const { durations: availableDurations } = useAvailableDurations(runs)
+
+  // Data-aware period count options
+  const { options: periodCountOptions, label: periodCountLabel } =
+    usePeriodCountOptions(filters.duration, undefined, runs)
+
+  // Auto-fallback when options change and current selection is no longer available
+  usePeriodCountFallback(
+    filters.periodCount,
+    periodCountOptions,
+    (periodCount) => setFilters(prev => ({ ...prev, periodCount }))
+  )
 
   // Auto-reset tier to 'all' when the selected tier is no longer available
   useEffect(() => {
@@ -174,5 +189,7 @@ export function useCoverageReport({
     // Available options
     availableTiers,
     availableDurations,
+    periodCountOptions,
+    periodCountLabel,
   }
 }

--- a/src/features/analysis/source-analysis/filters/source-analysis-filters.tsx
+++ b/src/features/analysis/source-analysis/filters/source-analysis-filters.tsx
@@ -11,8 +11,6 @@ import {
   DurationSelector,
   PeriodCountSelector,
   Duration,
-  getPeriodCountOptions,
-  getPeriodCountLabel,
 } from '@/shared/domain/filters'
 import { RunTypeSelector } from '@/shared/domain/run-types/run-type-selector'
 import type { RunTypeFilter } from '@/features/analysis/shared/filtering/run-type-filter'
@@ -27,6 +25,8 @@ interface SourceAnalysisFiltersProps {
   filters: SourceAnalysisFilters
   availableTiers: number[]
   availableDurations: Duration[]
+  periodCountOptions: number[]
+  periodCountLabel: string
   onCategoryChange: (category: SourceCategory) => void
   onRunTypeChange: (runType: RunTypeFilter) => void
   onTierChange: (tier: number | 'all') => void
@@ -38,6 +38,8 @@ export function SourceAnalysisFiltersComponent({
   filters,
   availableTiers,
   availableDurations,
+  periodCountOptions,
+  periodCountLabel,
   onCategoryChange,
   onRunTypeChange,
   onTierChange,
@@ -45,8 +47,6 @@ export function SourceAnalysisFiltersComponent({
   onQuantityChange,
 }: SourceAnalysisFiltersProps) {
   const categories = getAvailableCategories()
-  const periodOptions = getPeriodCountOptions(filters.duration)
-  const periodLabel = getPeriodCountLabel(filters.duration)
 
   return (
     <div className="space-y-4">
@@ -95,8 +95,8 @@ export function SourceAnalysisFiltersComponent({
         <PeriodCountSelector
           selectedCount={filters.quantity}
           onCountChange={onQuantityChange}
-          countOptions={periodOptions}
-          label={periodLabel}
+          countOptions={periodCountOptions}
+          label={periodCountLabel}
           accentColor="purple"
           layout="vertical"
         />

--- a/src/features/analysis/source-analysis/source-analysis.tsx
+++ b/src/features/analysis/source-analysis/source-analysis.tsx
@@ -172,6 +172,62 @@ function ChartCard({ title, children }: ChartCardProps) {
   )
 }
 
+function SourceAnalysisCharts({
+  analysisData,
+  highlightedSource,
+  onSourceHover,
+}: {
+  analysisData: NonNullable<ReturnType<typeof useSourceAnalysis>['analysisData']>
+  highlightedSource: string | null
+  onSourceHover: (fieldName: string | null) => void
+}) {
+  return (
+    <div className="space-y-6">
+      <ChartCard title="Source Proportions Over Time">
+        <SourceTimelineChart
+          periods={analysisData.periods}
+          sortedSources={analysisData.summary.sources}
+          highlightedSource={highlightedSource}
+          onSourceHover={onSourceHover}
+        />
+      </ChartCard>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <ChartCard title="Overall Breakdown">
+          <div className="flex items-center justify-center" style={{ height: Math.max(224, analysisData.summary.sources.length * 32 + 40) }}>
+            <SourcePieChart
+              sources={analysisData.summary.sources}
+              highlightedSource={highlightedSource}
+              onSourceHover={onSourceHover}
+            />
+          </div>
+        </ChartCard>
+
+        <div className="lg:col-span-2">
+          <ChartCard title="Source Ranking">
+            <SourceBarChart
+              sources={analysisData.summary.sources}
+              highlightedSource={highlightedSource}
+              onSourceHover={onSourceHover}
+            />
+          </ChartCard>
+        </div>
+      </div>
+
+      {analysisData.periods.length <= 2 && (
+        <div className="text-center text-sm text-slate-400 py-2">
+          <span className="inline-flex items-center gap-2">
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            Add more runs for detailed trend analysis.
+          </span>
+        </div>
+      )}
+    </div>
+  )
+}
+
 export function SourceAnalysis() {
   const { runs } = useData()
 
@@ -188,20 +244,22 @@ export function SourceAnalysis() {
     setHighlightedSource,
     availableTiers,
     availableDurations,
+    periodCountOptions,
+    periodCountLabel,
   } = useSourceAnalysis({ runs })
 
-  // Show empty state if no runs at all
   if (runs.length === 0) {
     return <EmptyState />
   }
 
   return (
     <div className="space-y-6">
-      {/* Filter Controls */}
       <SourceAnalysisFiltersComponent
         filters={filters}
         availableTiers={availableTiers}
         availableDurations={availableDurations}
+        periodCountOptions={periodCountOptions}
+        periodCountLabel={periodCountLabel}
         onCategoryChange={setCategory}
         onRunTypeChange={setRunType}
         onTierChange={setTier}
@@ -209,7 +267,6 @@ export function SourceAnalysis() {
         onQuantityChange={setQuantity}
       />
 
-      {/* Filter Summary */}
       {analysisData && (
         <FilterSummary
           categoryName={analysisData.category.name}
@@ -222,62 +279,18 @@ export function SourceAnalysis() {
         />
       )}
 
-      {/* No filtered data state */}
       {!hasData && (
         <NoFilteredDataState
           message="Try expanding the time period or adjusting tier/run type filters."
         />
       )}
 
-      {/* Charts */}
       {hasData && analysisData && (
-        <div className="space-y-6">
-          {/* Timeline Chart */}
-          <ChartCard title="Source Proportions Over Time">
-            <SourceTimelineChart
-              periods={analysisData.periods}
-              sortedSources={analysisData.summary.sources}
-              highlightedSource={highlightedSource}
-              onSourceHover={setHighlightedSource}
-            />
-          </ChartCard>
-
-          {/* Summary Charts Row - 1/3 pie chart, 2/3 bar chart */}
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-            <ChartCard title="Overall Breakdown">
-              <div className="flex items-center justify-center" style={{ height: Math.max(224, analysisData.summary.sources.length * 32 + 40) }}>
-                <SourcePieChart
-                  sources={analysisData.summary.sources}
-                  highlightedSource={highlightedSource}
-                  onSourceHover={setHighlightedSource}
-                />
-              </div>
-            </ChartCard>
-
-            {/* Bar Chart - takes 2/3 width */}
-            <div className="lg:col-span-2">
-              <ChartCard title="Source Ranking">
-                <SourceBarChart
-                  sources={analysisData.summary.sources}
-                  highlightedSource={highlightedSource}
-                  onSourceHover={setHighlightedSource}
-                />
-              </ChartCard>
-            </div>
-          </div>
-
-          {/* Limited Data Notice */}
-          {analysisData.periods.length <= 2 && (
-            <div className="text-center text-sm text-slate-400 py-2">
-              <span className="inline-flex items-center gap-2">
-                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                </svg>
-                Add more runs for detailed trend analysis.
-              </span>
-            </div>
-          )}
-        </div>
+        <SourceAnalysisCharts
+          analysisData={analysisData}
+          highlightedSource={highlightedSource}
+          onSourceHover={setHighlightedSource}
+        />
       )}
     </div>
   )

--- a/src/features/analysis/source-analysis/use-source-analysis.test.tsx
+++ b/src/features/analysis/source-analysis/use-source-analysis.test.tsx
@@ -41,11 +41,18 @@ function createMockRun(
   };
 }
 
-const mockRuns: ParsedGameRun[] = [
-  createMockRun('1', new Date('2024-03-15'), { orbDamage: 600, thornDamage: 400 }, 11, 'farm'),
-  createMockRun('2', new Date('2024-03-16'), { orbDamage: 700, thornDamage: 300 }, 11, 'tournament'),
-  createMockRun('3', new Date('2024-03-17'), { orbDamage: 500, thornDamage: 500 }, 12, 'farm'),
-];
+// 60 runs spanning ~7 months to support all default period counts across durations
+const mockRuns: ParsedGameRun[] = Array.from({ length: 60 }, (_, i) => {
+  const date = new Date('2024-01-01')
+  date.setDate(date.getDate() + i * 3.5)
+  return createMockRun(
+    String(i + 1),
+    date,
+    { orbDamage: 500 + i * 20, thornDamage: 500 - i * 10 },
+    i < 40 ? 11 : 12,
+    i % 3 === 0 ? 'tournament' : 'farm'
+  )
+});
 
 describe('useSourceAnalysis', () => {
   describe('initialization', () => {
@@ -261,13 +268,20 @@ describe('useSourceAnalysis', () => {
   });
 
   describe('available tiers', () => {
+    // Use minimal data for tier-specific tests
+    const tierTestRuns: ParsedGameRun[] = [
+      createMockRun('t1', new Date('2024-03-15'), { orbDamage: 600, thornDamage: 400 }, 11, 'farm'),
+      createMockRun('t2', new Date('2024-03-16'), { orbDamage: 700, thornDamage: 300 }, 11, 'tournament'),
+      createMockRun('t3', new Date('2024-03-17'), { orbDamage: 500, thornDamage: 500 }, 12, 'farm'),
+    ];
+
     it('filters tiers by current run type', () => {
       const { result } = renderHook(() =>
-        useSourceAnalysis({ runs: mockRuns })
+        useSourceAnalysis({ runs: tierTestRuns })
       );
 
       // Default category is damageDealt with tournament run type
-      // Only run 2 is tournament (T11), so only T11 should be available
+      // Only run t2 is tournament (T11), so only T11 should be available
       expect(result.current.availableTiers).toEqual([11]);
 
       // Switch to farm runs to see different tiers
@@ -275,7 +289,7 @@ describe('useSourceAnalysis', () => {
         result.current.setRunType('farm');
       });
 
-      // Farm runs include T11 (run 1) and T12 (run 3)
+      // Farm runs include T11 (run t1) and T12 (run t3)
       expect(result.current.availableTiers).toEqual([12, 11]);
     });
 
@@ -289,7 +303,7 @@ describe('useSourceAnalysis', () => {
 
     it('resets tier to all when selected tier becomes unavailable', () => {
       const { result } = renderHook(() =>
-        useSourceAnalysis({ runs: mockRuns })
+        useSourceAnalysis({ runs: tierTestRuns })
       );
 
       // Switch to farm to get T12 available

--- a/src/features/analysis/source-analysis/use-source-analysis.ts
+++ b/src/features/analysis/source-analysis/use-source-analysis.ts
@@ -17,6 +17,8 @@ import { DEFAULT_FILTERS, getDefaultRunTypeForCategory } from './types';
 import { getCategoryDefinition } from './category-config';
 import { calculateSourceAnalysis } from './calculations/period-grouping';
 import { clampPeriodCount } from '@/shared/domain/filters/period-count/period-count-logic';
+import { usePeriodCountOptions } from '@/shared/domain/filters/period-count/use-period-count-options';
+import { usePeriodCountFallback } from '@/shared/domain/filters/period-count/use-period-count-fallback';
 import {
   useAvailableTiers,
   useAvailableDurations,
@@ -50,6 +52,8 @@ interface UseSourceAnalysisReturn {
   // Available options for filters
   availableTiers: number[];
   availableDurations: Duration[];
+  periodCountOptions: number[];
+  periodCountLabel: string;
 }
 
 /**
@@ -72,6 +76,17 @@ export function useSourceAnalysis({
   // Filter tiers by current run type to only show tiers with data for that run type
   const { tiers: availableTiers } = useAvailableTiers(runs, filters.runType);
   const { durations: availableDurations } = useAvailableDurations(runs);
+
+  // Data-aware period count options
+  const { options: periodCountOptions, label: periodCountLabel } =
+    usePeriodCountOptions(filters.duration, undefined, runs);
+
+  // Auto-fallback when options change and current selection is no longer available
+  usePeriodCountFallback(
+    filters.quantity,
+    periodCountOptions,
+    (quantity) => setFilters(prev => ({ ...prev, quantity }))
+  );
 
   // Auto-reset tier to 'all' when the selected tier is no longer available
   useEffect(() => {
@@ -143,5 +158,7 @@ export function useSourceAnalysis({
     // Available options
     availableTiers,
     availableDurations,
+    periodCountOptions,
+    periodCountLabel,
   };
 }

--- a/src/features/analysis/tier-trends/filters/tier-trends-controls.test.tsx
+++ b/src/features/analysis/tier-trends/filters/tier-trends-controls.test.tsx
@@ -16,6 +16,8 @@ describe('TierTrendsControls', () => {
 
   const availableTiers = [1, 2, 3, 4, 5]
   const availableDurations = [Duration.PER_RUN, Duration.DAILY, Duration.WEEKLY, Duration.MONTHLY, Duration.YEARLY]
+  const periodCountOptions = [2, 3, 4, 5, 6, 7]
+  const periodCountLabel = 'Last Runs'
 
   it('renders all control groups', () => {
     const onRunTypeChange = vi.fn()
@@ -29,6 +31,8 @@ describe('TierTrendsControls', () => {
         onFiltersChange={onFiltersChange}
         availableTiers={availableTiers}
         availableDurations={availableDurations}
+        periodCountOptions={periodCountOptions}
+        periodCountLabel={periodCountLabel}
       />
     )
 
@@ -49,6 +53,8 @@ describe('TierTrendsControls', () => {
         onFiltersChange={onFiltersChange}
         availableTiers={availableTiers}
         availableDurations={availableDurations}
+        periodCountOptions={periodCountOptions}
+        periodCountLabel={periodCountLabel}
       />
     )
 
@@ -77,6 +83,8 @@ describe('TierTrendsControls', () => {
         onFiltersChange={onFiltersChange}
         availableTiers={availableTiers}
         availableDurations={availableDurations}
+        periodCountOptions={periodCountOptions}
+        periodCountLabel={periodCountLabel}
       />
     )
 
@@ -103,6 +111,8 @@ describe('TierTrendsControls', () => {
         onFiltersChange={onFiltersChange}
         availableTiers={availableTiers}
         availableDurations={availableDurations}
+        periodCountOptions={periodCountOptions}
+        periodCountLabel={periodCountLabel}
       />
     )
 
@@ -130,6 +140,8 @@ describe('TierTrendsControls', () => {
         onFiltersChange={onFiltersChange}
         availableTiers={availableTiers}
         availableDurations={availableDurations}
+        periodCountOptions={periodCountOptions}
+        periodCountLabel={periodCountLabel}
       />
     )
 
@@ -156,6 +168,8 @@ describe('TierTrendsControls', () => {
         onFiltersChange={onFiltersChange}
         availableTiers={availableTiers}
         availableDurations={availableDurations}
+        periodCountOptions={periodCountOptions}
+        periodCountLabel={periodCountLabel}
       />
     )
 
@@ -188,6 +202,8 @@ describe('TierTrendsControls', () => {
         onFiltersChange={onFiltersChange}
         availableTiers={availableTiers}
         availableDurations={availableDurations}
+        periodCountOptions={periodCountOptions}
+        periodCountLabel={periodCountLabel}
       />
     )
 
@@ -221,6 +237,8 @@ describe('TierTrendsControls', () => {
         onFiltersChange={onFiltersChange}
         availableTiers={availableTiers}
         availableDurations={availableDurations}
+        periodCountOptions={periodCountOptions}
+        periodCountLabel={periodCountLabel}
       />
     )
 

--- a/src/features/analysis/tier-trends/filters/tier-trends-controls.tsx
+++ b/src/features/analysis/tier-trends/filters/tier-trends-controls.tsx
@@ -7,7 +7,6 @@ import {
   zeroToAllTierAdapter,
   allToZeroTierAdapter
 } from '@/shared/domain/filters'
-import { usePeriodCountOptions } from '@/shared/domain/filters/period-count/use-period-count-options'
 import { adjustPeriodCountForDuration, asNumericPeriodCount } from '@/shared/domain/filters/period-count/period-count-logic'
 import type { RunTypeFilter } from '@/features/analysis/shared/filtering/run-type-filter'
 import type { TierTrendsFilters } from '../types'
@@ -23,6 +22,8 @@ interface TierTrendsControlsProps {
   onFiltersChange: (filters: TierTrendsFilters) => void
   availableTiers: number[]
   availableDurations: Duration[]
+  periodCountOptions: number[]
+  periodCountLabel: string
   tierCounts?: Map<number, number>
 }
 
@@ -33,11 +34,10 @@ export function TierTrendsControls({
   onFiltersChange,
   availableTiers,
   availableDurations,
-  tierCounts
+  periodCountOptions,
+  periodCountLabel,
+  tierCounts,
 }: TierTrendsControlsProps) {
-  const { options: periodCountOptions, label: periodCountLabel } =
-    usePeriodCountOptions(filters.duration, TIER_TRENDS_PERIOD_COUNTS)
-
   return (
     <div className="space-y-4">
       {/* Row 1: Run Type & Tier */}

--- a/src/features/analysis/tier-trends/tier-trends-analysis.tsx
+++ b/src/features/analysis/tier-trends/tier-trends-analysis.tsx
@@ -4,6 +4,9 @@ import { getAvailableTiersForTrends } from './calculations/tier-trends-calculati
 import { RunType } from '@/shared/domain/run-types/types'
 import { Duration, TrendsAggregation } from './types'
 import { useAvailableDurations } from '@/shared/domain/filters'
+import { usePeriodCountOptions } from '@/shared/domain/filters/period-count/use-period-count-options'
+import { usePeriodCountFallback } from '@/shared/domain/filters/period-count/use-period-count-fallback'
+import { TIER_TRENDS_PERIOD_COUNTS } from './filters/tier-trends-period-counts'
 import { RunTypeFilter } from '@/features/analysis/shared/filtering/run-type-filter'
 import { TierTrendsFilters as TierTrendsFiltersComponent } from './filters/tier-trends-filters'
 import { TierTrendsTable } from './table/tier-trends-table'
@@ -35,7 +38,19 @@ export function TierTrendsAnalysis() {
     quantity: 4, // Default to 4 periods for better trending visibility
     aggregationType: TrendsAggregation.AVERAGE
   })
-  
+
+  // Data-aware period count options
+  const { options: periodCountOptions, label: periodCountLabel } =
+    usePeriodCountOptions(filters.duration, TIER_TRENDS_PERIOD_COUNTS, runs)
+
+  // Auto-fallback when options change and current selection is no longer available
+  usePeriodCountFallback(
+    filters.quantity,
+    periodCountOptions,
+    (count) => { if (typeof count === 'number') setFilters(prev => ({ ...prev, quantity: count })) },
+    'last-available'
+  )
+
   // Auto-select first available tier when run type changes
   useEffect(() => {
     if (availableTiers.length > 0 && filters.tier !== 0 && !availableTiers.includes(filters.tier)) {
@@ -107,6 +122,8 @@ export function TierTrendsAnalysis() {
         onFiltersChange={setFilters}
         availableTiers={availableTiers}
         availableDurations={availableDurations}
+        periodCountOptions={periodCountOptions}
+        periodCountLabel={periodCountLabel}
       />
 
       {/* Conditional Results Area */}

--- a/src/features/analysis/time-series/chart-data.test.ts
+++ b/src/features/analysis/time-series/chart-data.test.ts
@@ -5,7 +5,7 @@ import { Duration } from '@/shared/domain/filters/types'
 
 describe('Chart Data Utils', () => {
   describe('getAvailableTimePeriods', () => {
-    it('should show daily, weekly, and monthly views even with single day of data', () => {
+    it('should show only hourly, per-run, and daily for same-day data', () => {
       const runs: ParsedGameRun[] = [
         {
           id: '1',
@@ -37,9 +37,9 @@ describe('Chart Data Utils', () => {
       expect(periodTypes).toContain(Duration.HOURLY)
       expect(periodTypes).toContain(Duration.PER_RUN)
       expect(periodTypes).toContain(Duration.DAILY)
-      expect(periodTypes).toContain(Duration.WEEKLY)
-      expect(periodTypes).toContain(Duration.MONTHLY)
-      expect(periodTypes).not.toContain(Duration.YEARLY) // Only one year of data
+      expect(periodTypes).not.toContain(Duration.WEEKLY)
+      expect(periodTypes).not.toContain(Duration.MONTHLY)
+      expect(periodTypes).not.toContain(Duration.YEARLY)
     })
 
     it('should show yearly view only when data spans multiple years', () => {
@@ -74,13 +74,13 @@ describe('Chart Data Utils', () => {
       expect(periodTypes).toContain(Duration.YEARLY)
     })
 
-    it('should only show hourly and run views when no data', () => {
+    it('should return empty when no data', () => {
       const runs: ParsedGameRun[] = []
 
       const periods = getAvailableTimePeriods(runs)
       const periodTypes = periods.map(p => p.period)
 
-      expect(periodTypes).toEqual([Duration.HOURLY, Duration.PER_RUN])
+      expect(periodTypes).toEqual([])
     })
   })
 

--- a/src/features/analysis/time-series/chart-data.ts
+++ b/src/features/analysis/time-series/chart-data.ts
@@ -1,4 +1,3 @@
-import { format, startOfDay, startOfWeek, startOfMonth, startOfYear } from 'date-fns'
 import { ParsedGameRun } from '@/shared/types/game-run.types'
 import {
   ChartDataPoint,
@@ -6,6 +5,7 @@ import {
   TIME_PERIOD_CONFIGS
 } from './chart-types'
 import { Duration } from '@/shared/domain/filters/types'
+import { getAvailableDurations } from '@/shared/domain/filters/duration/duration-filter-logic'
 import {
   prepareFieldPerRunData,
   prepareFieldPerHourData,
@@ -43,56 +43,10 @@ export function prepareTimeSeriesData(
 }
 
 /**
- * Function to determine which time periods should be available based on data span
- * Optimized to use single pass through data for all period calculations
+ * Determine which time periods should be available based on data span.
+ * Delegates to shared getAvailableDurations() for consistent logic.
  */
 export function getAvailableTimePeriods(runs: ParsedGameRun[]): TimePeriodConfig[] {
-  if (runs.length === 0) {
-    // Always show hourly and per run when no data
-    return TIME_PERIOD_CONFIGS.filter(config =>
-      config.period === Duration.HOURLY || config.period === Duration.PER_RUN
-    )
-  }
-
-  // Single pass to collect all unique periods
-  const uniqueDays = new Set<string>()
-  const uniqueWeeks = new Set<string>()
-  const uniqueMonths = new Set<string>()
-  const uniqueYears = new Set<string>()
-
-  runs.forEach(run => {
-    const timestamp = run.timestamp
-    uniqueDays.add(format(startOfDay(timestamp), 'yyyy-MM-dd'))
-    uniqueWeeks.add(format(startOfWeek(timestamp, { weekStartsOn: 0 }), 'yyyy-MM-dd'))
-    uniqueMonths.add(format(startOfMonth(timestamp), 'yyyy-MM'))
-    uniqueYears.add(format(startOfYear(timestamp), 'yyyy'))
-  })
-
-  // Always include hourly and per run
-  const availablePeriods: Duration[] = [Duration.HOURLY, Duration.PER_RUN]
-
-  // Always show daily view if we have any data
-  if (uniqueDays.size >= 1) {
-    availablePeriods.push(Duration.DAILY)
-  }
-
-  // Always show weekly view if we have any data
-  if (uniqueWeeks.size >= 1) {
-    availablePeriods.push(Duration.WEEKLY)
-  }
-
-  // Always show monthly view if we have any data
-  if (uniqueMonths.size >= 1) {
-    availablePeriods.push(Duration.MONTHLY)
-  }
-
-  // Only show yearly view if we have data spanning multiple years
-  if (uniqueYears.size > 1) {
-    availablePeriods.push(Duration.YEARLY)
-  }
-
-  // Return configurations for available periods in original order
-  return TIME_PERIOD_CONFIGS.filter(config =>
-    availablePeriods.includes(config.period)
-  )
+  const availableDurations = getAvailableDurations(runs)
+  return TIME_PERIOD_CONFIGS.filter(config => availableDurations.includes(config.period))
 }

--- a/src/features/analysis/time-series/interval-selector/use-interval-selector.ts
+++ b/src/features/analysis/time-series/interval-selector/use-interval-selector.ts
@@ -1,6 +1,12 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useMemo } from 'react'
+import type { ParsedGameRun } from '@/shared/types/game-run.types'
 import { Duration, type PeriodCountFilter } from '@/shared/domain/filters/types'
-import { getPeriodCountOptions, getPeriodCountLabel } from '@/shared/domain/filters/period-count/period-count-logic'
+import {
+  getDataAwarePeriodCountOptions,
+  getPeriodCountLabel,
+  fallbackToValidOption,
+} from '@/shared/domain/filters/period-count/period-count-logic'
+import { countDataPeriods } from '@/shared/domain/filters/period-count/count-data-periods'
 import {
   loadPersistedIntervalCount,
   savePersistedIntervalCount,
@@ -15,16 +21,34 @@ interface UseIntervalSelectorResult {
 
 /**
  * Hook to manage interval count state with localStorage persistence.
- * Loads persisted value on duration change, falls back to 'all'.
+ * Prunes options based on actual data coverage using N+1 bucket rule.
  */
-export function useIntervalSelector(duration: Duration): UseIntervalSelectorResult {
+export function useIntervalSelector(
+  duration: Duration,
+  runs?: ParsedGameRun[]
+): UseIntervalSelectorResult {
   const [intervalCount, setIntervalCountState] = useState<PeriodCountFilter>('all')
 
-  // Load persisted interval when duration changes
+  const dataPeriodCount = useMemo(
+    () => (runs ? countDataPeriods(runs, duration) : null),
+    [runs, duration]
+  )
+
+  const countOptions = useMemo(
+    () => getDataAwarePeriodCountOptions(duration, dataPeriodCount ?? Infinity),
+    [duration, dataPeriodCount]
+  )
+
+  // Load persisted interval when duration or options change, with fallback
   useEffect(() => {
     const persisted = loadPersistedIntervalCount(duration)
-    setIntervalCountState(persisted ?? 'all')
-  }, [duration])
+    const value = persisted ?? 'all'
+    const valid = fallbackToValidOption(value, countOptions)
+    setIntervalCountState(valid)
+    if (valid !== value) {
+      savePersistedIntervalCount(duration, valid)
+    }
+  }, [duration, countOptions])
 
   const setIntervalCount = useCallback(
     (count: PeriodCountFilter) => {
@@ -37,7 +61,7 @@ export function useIntervalSelector(duration: Duration): UseIntervalSelectorResu
   return {
     intervalCount,
     setIntervalCount,
-    countOptions: getPeriodCountOptions(duration),
+    countOptions,
     label: getPeriodCountLabel(duration),
   }
 }

--- a/src/features/analysis/time-series/use-time-series-chart-data.ts
+++ b/src/features/analysis/time-series/use-time-series-chart-data.ts
@@ -66,7 +66,7 @@ export function useTimeSeriesChartData(
     setIntervalCount,
     countOptions: intervalCountOptions,
     label: intervalLabel,
-  } = useIntervalSelector(selectedPeriod)
+  } = useIntervalSelector(selectedPeriod, filteredRuns)
 
   // Moving average state with localStorage persistence (period-aware)
   const { trendWindow, setTrendWindow, windowSize, isEnabled: isAverageEnabled } =

--- a/src/shared/domain/filters/data-span.test.ts
+++ b/src/shared/domain/filters/data-span.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest'
+import type { ParsedGameRun } from '@/shared/types/game-run.types'
+import { calculateDataSpan } from './data-span'
+
+function mockRun(date: Date): ParsedGameRun {
+  return {
+    id: `run-${date.getTime()}`,
+    timestamp: date,
+    tier: 14,
+    wave: 100,
+    coinsEarned: 1000,
+    cellsEarned: 100,
+    realTime: 3600,
+    runType: 'farm',
+    fields: {}
+  } as ParsedGameRun
+}
+
+describe('calculateDataSpan', () => {
+  it('should return null for empty array', () => {
+    expect(calculateDataSpan([])).toBeNull()
+  })
+
+  it('should return null for single run', () => {
+    expect(calculateDataSpan([mockRun(new Date('2024-06-15'))])).toBeNull()
+  })
+
+  it('should return null when fewer than 2 valid timestamps', () => {
+    const runs = [
+      mockRun(new Date('2024-06-15')),
+      { ...mockRun(new Date('2024-06-16')), timestamp: undefined } as unknown as ParsedGameRun,
+    ]
+    expect(calculateDataSpan(runs)).toBeNull()
+  })
+
+  it('should compute day span correctly', () => {
+    const result = calculateDataSpan([
+      mockRun(new Date('2024-01-01')),
+      mockRun(new Date('2024-01-15')),
+    ])
+    expect(result).not.toBeNull()
+    expect(result!.daySpan).toBe(14)
+  })
+
+  it('should find earliest and latest dates regardless of order', () => {
+    const result = calculateDataSpan([
+      mockRun(new Date('2024-03-15')),
+      mockRun(new Date('2024-01-01')),
+      mockRun(new Date('2024-06-30')),
+    ])
+    expect(result!.earliest.toISOString()).toContain('2024-01-01')
+    expect(result!.latest.toISOString()).toContain('2024-06-30')
+  })
+
+  it('should detect different months', () => {
+    const sameMonth = calculateDataSpan([
+      mockRun(new Date('2024-03-01')),
+      mockRun(new Date('2024-03-28')),
+    ])
+    expect(sameMonth!.spansDifferentMonths).toBe(false)
+
+    const diffMonth = calculateDataSpan([
+      mockRun(new Date('2024-03-31')),
+      mockRun(new Date('2024-04-01')),
+    ])
+    expect(diffMonth!.spansDifferentMonths).toBe(true)
+  })
+
+  it('should detect different years', () => {
+    const sameYear = calculateDataSpan([
+      mockRun(new Date('2024-01-01')),
+      mockRun(new Date('2024-12-31')),
+    ])
+    expect(sameYear!.spansDifferentYears).toBe(false)
+
+    const diffYear = calculateDataSpan([
+      mockRun(new Date('2023-12-31')),
+      mockRun(new Date('2024-01-01')),
+    ])
+    expect(diffYear!.spansDifferentYears).toBe(true)
+  })
+
+  it('should handle runs with same timestamp', () => {
+    const result = calculateDataSpan([
+      mockRun(new Date('2024-06-15T10:00:00')),
+      mockRun(new Date('2024-06-15T10:00:00')),
+    ])
+    expect(result!.daySpan).toBe(0)
+    expect(result!.spansDifferentMonths).toBe(false)
+    expect(result!.spansDifferentYears).toBe(false)
+  })
+})

--- a/src/shared/domain/filters/data-span.ts
+++ b/src/shared/domain/filters/data-span.ts
@@ -1,0 +1,52 @@
+/**
+ * Data Span Calculation
+ *
+ * Pure functions for calculating the temporal span of game run data.
+ * Used by duration filtering and period count pruning to determine
+ * which options are meaningful for the user's actual data.
+ */
+
+import type { ParsedGameRun } from '@/shared/types/game-run.types'
+
+const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000
+
+interface DataSpan {
+  earliest: Date
+  latest: Date
+  daySpan: number
+  spansDifferentMonths: boolean
+  spansDifferentYears: boolean
+}
+
+/**
+ * Calculate the temporal span of a set of game runs.
+ * Returns null for empty arrays or arrays with fewer than 2 valid timestamps.
+ */
+export function calculateDataSpan(runs: ParsedGameRun[]): DataSpan | null {
+  const dates = runs
+    .map(run => run.timestamp)
+    .filter((date): date is Date => date instanceof Date && !isNaN(date.getTime()))
+
+  if (dates.length < 2) {
+    return null
+  }
+
+  let earliest = dates[0]
+  let latest = dates[0]
+
+  for (const date of dates) {
+    if (date.getTime() < earliest.getTime()) earliest = date
+    if (date.getTime() > latest.getTime()) latest = date
+  }
+
+  const daySpan = Math.floor((latest.getTime() - earliest.getTime()) / MILLISECONDS_PER_DAY)
+
+  const spansDifferentMonths =
+    earliest.getUTCFullYear() !== latest.getUTCFullYear() ||
+    earliest.getUTCMonth() !== latest.getUTCMonth()
+
+  const spansDifferentYears =
+    earliest.getUTCFullYear() !== latest.getUTCFullYear()
+
+  return { earliest, latest, daySpan, spansDifferentMonths, spansDifferentYears }
+}

--- a/src/shared/domain/filters/duration/duration-filter-logic.test.ts
+++ b/src/shared/domain/filters/duration/duration-filter-logic.test.ts
@@ -27,41 +27,56 @@ describe('getAvailableDurations', () => {
     expect(getAvailableDurations([])).toEqual([])
   })
 
-  it('should return HOURLY and PER_RUN for single run', () => {
+  it('should return HOURLY, PER_RUN, and DAILY for single run', () => {
     const runs = [createMockRunWithDate(new Date('2024-01-15'))]
-    expect(getAvailableDurations(runs)).toEqual([Duration.HOURLY, Duration.PER_RUN])
+    expect(getAvailableDurations(runs)).toEqual([Duration.HOURLY, Duration.PER_RUN, Duration.DAILY])
   })
 
-  it('should include DAILY for runs spanning 2+ days', () => {
+  it('should always include DAILY when runs exist', () => {
     const runs = [
       createMockRunWithDate(new Date('2024-01-15')),
-      createMockRunWithDate(new Date('2024-01-16'))
+      createMockRunWithDate(new Date('2024-01-15'))
     ]
     const available = getAvailableDurations(runs)
-    expect(available).toContain(Duration.HOURLY)
-    expect(available).toContain(Duration.PER_RUN)
     expect(available).toContain(Duration.DAILY)
+  })
+
+  it('should not include WEEKLY for 7 days or fewer', () => {
+    const runs = [
+      createMockRunWithDate(new Date('2024-01-01')),
+      createMockRunWithDate(new Date('2024-01-08'))
+    ]
+    const available = getAvailableDurations(runs)
     expect(available).not.toContain(Duration.WEEKLY)
   })
 
-  it('should include WEEKLY for runs spanning 14+ days', () => {
+  it('should include WEEKLY for data spanning more than 7 days', () => {
     const runs = [
       createMockRunWithDate(new Date('2024-01-01')),
-      createMockRunWithDate(new Date('2024-01-15'))
+      createMockRunWithDate(new Date('2024-01-09'))
     ]
     const available = getAvailableDurations(runs)
     expect(available).toContain(Duration.WEEKLY)
     expect(available).not.toContain(Duration.MONTHLY)
   })
 
-  it('should include MONTHLY for runs spanning 60+ days', () => {
+  it('should include MONTHLY for runs in different calendar months', () => {
     const runs = [
-      createMockRunWithDate(new Date('2024-01-01')),
-      createMockRunWithDate(new Date('2024-03-02'))
+      createMockRunWithDate(new Date('2024-01-31')),
+      createMockRunWithDate(new Date('2024-02-01'))
     ]
     const available = getAvailableDurations(runs)
     expect(available).toContain(Duration.MONTHLY)
     expect(available).not.toContain(Duration.YEARLY)
+  })
+
+  it('should not include MONTHLY for runs in same calendar month', () => {
+    const runs = [
+      createMockRunWithDate(new Date('2024-01-01')),
+      createMockRunWithDate(new Date('2024-01-31'))
+    ]
+    const available = getAvailableDurations(runs)
+    expect(available).not.toContain(Duration.MONTHLY)
   })
 
   it('should include YEARLY for runs spanning multiple calendar years', () => {
@@ -87,9 +102,9 @@ describe('getAvailableDurations', () => {
       { ...createMockRunWithDate(new Date('2024-01-01')), timestamp: undefined } as unknown as ParsedGameRun,
       createMockRunWithDate(new Date('2024-01-02'))
     ]
-    // With only one valid date, can't determine span
+    // With only one valid date, can't determine span beyond daily
     const available = getAvailableDurations(runs)
-    expect(available).toEqual([Duration.HOURLY, Duration.PER_RUN])
+    expect(available).toEqual([Duration.HOURLY, Duration.PER_RUN, Duration.DAILY])
   })
 })
 
@@ -135,4 +150,3 @@ describe('getClosestAvailableDuration', () => {
     expect(getClosestAvailableDuration(Duration.WEEKLY, [])).toBe(Duration.PER_RUN)
   })
 })
-

--- a/src/shared/domain/filters/duration/duration-filter-logic.ts
+++ b/src/shared/domain/filters/duration/duration-filter-logic.ts
@@ -8,63 +8,46 @@
 
 import type { ParsedGameRun } from '@/shared/types/game-run.types'
 import { Duration, DURATION_LABELS } from '../types'
-
-const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000
+import { calculateDataSpan } from '../data-span'
 
 /**
  * Determine which duration options should be available based on the data span
  *
- * Rules:
- * - Per Run: Always available if runs exist
- * - Daily: Available if data spans at least 2 days
- * - Weekly: Available if data spans at least 2 weeks
- * - Monthly: Available if data spans at least 2 months
- * - Yearly: Available if data spans multiple years
+ * Rules (aligned with PRD):
+ * - Hourly & Per Run: Always available if runs exist
+ * - Daily: Always available if runs exist (any amount of data supports daily)
+ * - Weekly: Available if data spans more than 7 days
+ * - Monthly: Available if data spans different calendar months
+ * - Yearly: Available if data spans different calendar years
  */
 export function getAvailableDurations(runs: ParsedGameRun[]): Duration[] {
   if (runs.length === 0) {
     return []
   }
 
+  const available: Duration[] = [Duration.HOURLY, Duration.PER_RUN, Duration.DAILY]
+
   if (runs.length === 1) {
-    return [Duration.HOURLY, Duration.PER_RUN]
-  }
-
-  const available: Duration[] = [Duration.HOURLY, Duration.PER_RUN]
-
-  // Find date range from runs
-  const dates = runs
-    .map(run => run.timestamp)
-    .filter((date): date is Date => date instanceof Date && !isNaN(date.getTime()))
-
-  if (dates.length < 2) {
     return available
   }
 
-  const sortedDates = dates.sort((a, b) => a.getTime() - b.getTime())
-  const earliest = sortedDates[0]
-  const latest = sortedDates[sortedDates.length - 1]
-
-  const daySpan = Math.floor((latest.getTime() - earliest.getTime()) / MILLISECONDS_PER_DAY)
-
-  // Daily requires at least 2 different days
-  if (daySpan >= 1) {
-    available.push(Duration.DAILY)
+  const span = calculateDataSpan(runs)
+  if (!span) {
+    return available
   }
 
-  // Weekly requires at least 2 weeks of data (14 days)
-  if (daySpan >= 14) {
+  // Weekly: data spans more than 7 days
+  if (span.daySpan > 7) {
     available.push(Duration.WEEKLY)
   }
 
-  // Monthly requires at least 2 months of data (60 days as approximation)
-  if (daySpan >= 60) {
+  // Monthly: earliest and latest are in different calendar months
+  if (span.spansDifferentMonths) {
     available.push(Duration.MONTHLY)
   }
 
-  // Yearly requires data spanning multiple calendar years
-  // Use UTC year to avoid timezone issues
-  if (earliest.getUTCFullYear() !== latest.getUTCFullYear()) {
+  // Yearly: 2+ distinct calendar years
+  if (span.spansDifferentYears) {
     available.push(Duration.YEARLY)
   }
 
@@ -118,4 +101,3 @@ export function getClosestAvailableDuration(
 
   return Duration.PER_RUN
 }
-

--- a/src/shared/domain/filters/duration/use-available-durations.test.tsx
+++ b/src/shared/domain/filters/duration/use-available-durations.test.tsx
@@ -25,11 +25,11 @@ describe('useAvailableDurations', () => {
     expect(result.current.durations).toEqual([])
   })
 
-  it('should return HOURLY and PER_RUN for single run', () => {
+  it('should return HOURLY, PER_RUN, and DAILY for single run', () => {
     const runs = [createMockRunWithDate(new Date('2024-01-15'))]
     const { result } = renderHook(() => useAvailableDurations(runs))
 
-    expect(result.current.durations).toEqual([Duration.HOURLY, Duration.PER_RUN])
+    expect(result.current.durations).toEqual([Duration.HOURLY, Duration.PER_RUN, Duration.DAILY])
   })
 
   it('should include appropriate durations based on data span', () => {

--- a/src/shared/domain/filters/index.ts
+++ b/src/shared/domain/filters/index.ts
@@ -5,7 +5,7 @@
  */
 
 // Types
-export { Duration, PERIOD_UNIT_LABELS } from './types'
+export { Duration, PERIOD_UNIT_LABELS } from './types'
 
 // Tier filter - pure logic functions, hooks, and components
 export {
@@ -22,11 +22,6 @@ export { TierSelector,  } from './tier/tier-selector'
 export { useAvailableDurations,  } from './duration/use-available-durations'
 export { DurationSelector,  } from './duration/duration-selector'
 
-// Period count filter - pure logic functions, hooks, and components
-export {
-  getPeriodCountOptions,
-  getDefaultPeriodCount,
-  getPeriodCountLabel
-} from './period-count/period-count-logic'
-
+// Period count filter - pure logic functions, hooks, and components
+export { getDefaultPeriodCount } from './period-count/period-count-logic'
 export { PeriodCountSelector,  } from './period-count/period-count-selector'

--- a/src/shared/domain/filters/period-count/count-data-periods.test.ts
+++ b/src/shared/domain/filters/period-count/count-data-periods.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest'
+import type { ParsedGameRun } from '@/shared/types/game-run.types'
+import { Duration } from '../types'
+import { countDataPeriods } from './count-data-periods'
+
+function mockRun(date: Date): ParsedGameRun {
+  return {
+    id: `run-${date.getTime()}`,
+    timestamp: date,
+    tier: 14,
+    wave: 100,
+    coinsEarned: 1000,
+    cellsEarned: 100,
+    realTime: 3600,
+    runType: 'farm',
+    fields: {}
+  } as ParsedGameRun
+}
+
+describe('countDataPeriods', () => {
+  it('should return 0 for empty runs', () => {
+    expect(countDataPeriods([], Duration.DAILY)).toBe(0)
+  })
+
+  it('should return 1 for single run', () => {
+    expect(countDataPeriods([mockRun(new Date('2024-06-15'))], Duration.DAILY)).toBe(1)
+  })
+
+  it('should count distinct days', () => {
+    const runs = [
+      mockRun(new Date('2024-06-15T10:00:00')),
+      mockRun(new Date('2024-06-15T14:00:00')),
+      mockRun(new Date('2024-06-16T10:00:00')),
+      mockRun(new Date('2024-06-17T10:00:00')),
+    ]
+    expect(countDataPeriods(runs, Duration.DAILY)).toBe(3)
+  })
+
+  it('should count distinct weeks', () => {
+    const runs = [
+      // Week 1 (Sun Jun 9 - Sat Jun 15, 2024)
+      mockRun(new Date('2024-06-10T10:00:00')),
+      mockRun(new Date('2024-06-12T10:00:00')),
+      // Week 2 (Sun Jun 16 - Sat Jun 22)
+      mockRun(new Date('2024-06-17T10:00:00')),
+      // Week 3 (Sun Jun 23 - Sat Jun 29)
+      mockRun(new Date('2024-06-25T10:00:00')),
+    ]
+    expect(countDataPeriods(runs, Duration.WEEKLY)).toBe(3)
+  })
+
+  it('should count distinct months', () => {
+    const runs = [
+      mockRun(new Date('2024-01-15')),
+      mockRun(new Date('2024-01-20')),
+      mockRun(new Date('2024-03-10')),
+      mockRun(new Date('2024-05-01')),
+    ]
+    expect(countDataPeriods(runs, Duration.MONTHLY)).toBe(3)
+  })
+
+  it('should count distinct years', () => {
+    const runs = [
+      mockRun(new Date('2023-06-15')),
+      mockRun(new Date('2024-01-01')),
+      mockRun(new Date('2024-12-31')),
+    ]
+    expect(countDataPeriods(runs, Duration.YEARLY)).toBe(2)
+  })
+
+  it('should count per-run periods (each run is unique)', () => {
+    const runs = [
+      mockRun(new Date('2024-06-15T10:00:00')),
+      mockRun(new Date('2024-06-15T10:00:01')),
+    ]
+    expect(countDataPeriods(runs, Duration.PER_RUN)).toBe(2)
+  })
+
+  it('should skip invalid timestamps', () => {
+    const runs = [
+      mockRun(new Date('2024-06-15')),
+      { ...mockRun(new Date('2024-06-16')), timestamp: undefined } as unknown as ParsedGameRun,
+      mockRun(new Date('2024-06-17')),
+    ]
+    expect(countDataPeriods(runs, Duration.DAILY)).toBe(2)
+  })
+})

--- a/src/shared/domain/filters/period-count/count-data-periods.ts
+++ b/src/shared/domain/filters/period-count/count-data-periods.ts
@@ -1,0 +1,65 @@
+/**
+ * Count Data Periods
+ *
+ * Pure function for counting how many distinct periods of a given
+ * duration type the user's data covers. Used by data-aware pruning
+ * to determine which interval count options are meaningful.
+ */
+
+import type { ParsedGameRun } from '@/shared/types/game-run.types'
+import { Duration } from '../types'
+
+/**
+ * Get a period key for grouping purposes.
+ * Simplified version focused on counting unique periods.
+ */
+function getPeriodKeyForCounting(timestamp: Date, duration: Duration): string {
+  const d = new Date(timestamp)
+  const year = d.getFullYear()
+  const month = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+
+  switch (duration) {
+    case Duration.HOURLY:
+      return `${year}-${month}-${day}T${String(d.getHours()).padStart(2, '0')}`
+    case Duration.PER_RUN:
+      return d.toISOString()
+    case Duration.DAILY:
+      return `${year}-${month}-${day}`
+    case Duration.WEEKLY: {
+      // Get Sunday of this week
+      const dayOfWeek = d.getDay()
+      const sunday = new Date(d)
+      sunday.setDate(d.getDate() - dayOfWeek)
+      const sy = sunday.getFullYear()
+      const sm = String(sunday.getMonth() + 1).padStart(2, '0')
+      const sd = String(sunday.getDate()).padStart(2, '0')
+      return `${sy}-${sm}-${sd}`
+    }
+    case Duration.MONTHLY:
+      return `${year}-${month}`
+    case Duration.YEARLY:
+      return `${year}`
+    default:
+      return d.toISOString()
+  }
+}
+
+/**
+ * Count the number of distinct periods in the data for a given duration.
+ */
+export function countDataPeriods(runs: ParsedGameRun[], duration: Duration): number {
+  if (runs.length === 0) {
+    return 0
+  }
+
+  const uniquePeriods = new Set<string>()
+
+  for (const run of runs) {
+    if (run.timestamp instanceof Date && !isNaN(run.timestamp.getTime())) {
+      uniquePeriods.add(getPeriodKeyForCounting(run.timestamp, duration))
+    }
+  }
+
+  return uniquePeriods.size
+}

--- a/src/shared/domain/filters/period-count/period-count-logic.test.ts
+++ b/src/shared/domain/filters/period-count/period-count-logic.test.ts
@@ -7,7 +7,9 @@ import {
   getDefaultPeriodCount,
   getPeriodCountLabel,
   formatPeriodCountValue,
-  adjustPeriodCountForDuration
+  adjustPeriodCountForDuration,
+  getDataAwarePeriodCountOptions,
+  fallbackToValidOption
 } from './period-count-logic'
 
 describe('getPeriodCountOptions', () => {
@@ -192,5 +194,67 @@ describe('asNumericPeriodCount', () => {
       [Duration.DAILY]: [2, 3, 4, 5, 6, 7],
     }
     expect(asNumericPeriodCount('all', Duration.WEEKLY, overrides)).toBe(10)
+  })
+})
+
+describe('getDataAwarePeriodCountOptions', () => {
+  it('should prune weekly options with N+1 rule', () => {
+    // 9 weeks of data, weekly options [5,10,15,20,25,30] -> [5, 10]
+    expect(getDataAwarePeriodCountOptions(Duration.WEEKLY, 9)).toEqual([5, 10])
+  })
+
+  it('should prune monthly options with N+1 rule', () => {
+    // 4 months, monthly options [3,6,9,12] -> [3, 6]
+    expect(getDataAwarePeriodCountOptions(Duration.MONTHLY, 4)).toEqual([3, 6])
+  })
+
+  it('should return all options when data exceeds all', () => {
+    expect(getDataAwarePeriodCountOptions(Duration.WEEKLY, 35)).toEqual([5, 10, 15, 20, 25, 30])
+  })
+
+  it('should return empty when dataPeriodCount is 0', () => {
+    expect(getDataAwarePeriodCountOptions(Duration.WEEKLY, 0)).toEqual([])
+  })
+
+  it('should respect overrides', () => {
+    const overrides: PeriodCountOverrides = {
+      [Duration.DAILY]: [2, 3, 4, 5, 6, 7],
+    }
+    // 3 days of data, overrides [2,3,4,5,6,7] -> [2, 3, 4]
+    expect(getDataAwarePeriodCountOptions(Duration.DAILY, 3, overrides)).toEqual([2, 3, 4])
+  })
+})
+
+describe('fallbackToValidOption', () => {
+  it('should pass through "all" unchanged', () => {
+    expect(fallbackToValidOption('all', [5, 10, 15])).toBe('all')
+  })
+
+  it('should keep valid numeric option', () => {
+    expect(fallbackToValidOption(10, [5, 10, 15])).toBe(10)
+  })
+
+  it('should fall back to "all" when option is not available', () => {
+    expect(fallbackToValidOption(20, [5, 10, 15])).toBe('all')
+  })
+
+  it('should fall back to "all" for empty options', () => {
+    expect(fallbackToValidOption(5, [])).toBe('all')
+  })
+
+  it('should fall back to last available option with last-available strategy', () => {
+    expect(fallbackToValidOption(20, [5, 10, 15], 'last-available')).toBe(15)
+  })
+
+  it('should fall back to "all" with last-available strategy when options are empty', () => {
+    expect(fallbackToValidOption(5, [], 'last-available')).toBe('all')
+  })
+
+  it('should keep valid option with last-available strategy', () => {
+    expect(fallbackToValidOption(10, [5, 10, 15], 'last-available')).toBe(10)
+  })
+
+  it('should pass through "all" with last-available strategy', () => {
+    expect(fallbackToValidOption('all', [5, 10, 15], 'last-available')).toBe('all')
   })
 })

--- a/src/shared/domain/filters/period-count/period-count-logic.ts
+++ b/src/shared/domain/filters/period-count/period-count-logic.ts
@@ -7,6 +7,7 @@
  */
 
 import { Duration, PERIOD_UNIT_LABELS } from '../types'
+import { pruneCountOptions } from './prune-period-options'
 
 /**
  * Custom period count overrides for consumers with layout-specific needs.
@@ -157,4 +158,47 @@ export function adjustPeriodCountForDuration(
   }
 
   return closest
+}
+
+/**
+ * Get period count options pruned by actual data coverage.
+ * Uses N+1 bucket rule: includes one option beyond the data's period count.
+ */
+export function getDataAwarePeriodCountOptions(
+  duration: Duration,
+  dataPeriodCount: number,
+  overrides?: PeriodCountOverrides
+): number[] {
+  const allOptions = getPeriodCountOptions(duration, overrides)
+  return pruneCountOptions(allOptions, dataPeriodCount)
+}
+
+/**
+ * Fallback strategy when the current selection is not in the available options.
+ * - 'all': fall back to 'all' (for chart-based views that support unlimited)
+ * - 'last-available': fall back to the last numeric option (for table-based views)
+ */
+export type FallbackStrategy = 'all' | 'last-available'
+
+/**
+ * Fall back to a valid option when the current selection is pruned away.
+ *
+ * With 'last-available' strategy, falls back to the highest available numeric
+ * option instead of 'all'. Use this for consumers whose state is number-only.
+ */
+export function fallbackToValidOption(
+  currentCount: number | 'all',
+  availableOptions: number[],
+  fallbackTo: FallbackStrategy = 'all'
+): number | 'all' {
+  if (currentCount === 'all') {
+    return 'all'
+  }
+  if (availableOptions.includes(currentCount)) {
+    return currentCount
+  }
+  if (fallbackTo === 'last-available' && availableOptions.length > 0) {
+    return availableOptions[availableOptions.length - 1]
+  }
+  return 'all'
 }

--- a/src/shared/domain/filters/period-count/prune-period-options.test.ts
+++ b/src/shared/domain/filters/period-count/prune-period-options.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { pruneCountOptions } from './prune-period-options'
+
+describe('pruneCountOptions', () => {
+  it('should return empty array when dataPeriodCount is 0', () => {
+    expect(pruneCountOptions([3, 6, 9, 12], 0)).toEqual([])
+  })
+
+  it('should include options up to count plus N+1 bucket', () => {
+    // PRD example: 4 months, monthly options [3,6,9,12] -> [3, 6]
+    expect(pruneCountOptions([3, 6, 9, 12], 4)).toEqual([3, 6])
+  })
+
+  it('should handle weekly options with 9 periods', () => {
+    // PRD example: 9 weeks -> [5, 10]
+    expect(pruneCountOptions([5, 10, 15, 20, 25, 30], 9)).toEqual([5, 10])
+  })
+
+  it('should handle weekly options with 11 periods', () => {
+    // PRD example: 11 weeks -> [5, 10, 15]
+    expect(pruneCountOptions([5, 10, 15, 20, 25, 30], 11)).toEqual([5, 10, 15])
+  })
+
+  it('should include N+1 bucket when exactly on boundary', () => {
+    // PRD example: exactly 10 -> [5, 10, 15]
+    expect(pruneCountOptions([5, 10, 15, 20, 25, 30], 10)).toEqual([5, 10, 15])
+  })
+
+  it('should include all options when data exceeds all', () => {
+    // PRD example: 26 weeks -> [5, 10, 15, 20, 25, 30]
+    expect(pruneCountOptions([5, 10, 15, 20, 25, 30], 26)).toEqual([5, 10, 15, 20, 25, 30])
+  })
+
+  it('should return smallest option when count is less than all options', () => {
+    // dataPeriodCount=1, options start at 3 -> [3] (N+1 bucket)
+    expect(pruneCountOptions([3, 6, 9, 12], 1)).toEqual([3])
+  })
+
+  it('should return smallest option when count is very small', () => {
+    expect(pruneCountOptions([5, 10, 15, 20, 25, 30], 2)).toEqual([5])
+  })
+
+  it('should handle empty options array', () => {
+    expect(pruneCountOptions([], 5)).toEqual([])
+  })
+
+  it('should handle single option', () => {
+    expect(pruneCountOptions([10], 5)).toEqual([10])
+    expect(pruneCountOptions([10], 15)).toEqual([10])
+  })
+
+  it('should include all options when count equals last option', () => {
+    expect(pruneCountOptions([3, 6, 9, 12], 12)).toEqual([3, 6, 9, 12])
+  })
+
+  it('should include all options when count exceeds last option', () => {
+    expect(pruneCountOptions([3, 6, 9, 12], 100)).toEqual([3, 6, 9, 12])
+  })
+})

--- a/src/shared/domain/filters/period-count/prune-period-options.ts
+++ b/src/shared/domain/filters/period-count/prune-period-options.ts
@@ -1,0 +1,41 @@
+/**
+ * Prune Period Options
+ *
+ * Pure function implementing the N+1 bucket rule for data-aware
+ * interval count pruning. Removes options that would produce
+ * empty or meaningless visualizations.
+ */
+
+/**
+ * Prune period count options based on how many data periods exist.
+ *
+ * Algorithm:
+ * 1. Include all options where option <= dataPeriodCount
+ * 2. Include the first option where option > dataPeriodCount (N+1 bucket)
+ * 3. If no options qualify and dataPeriodCount > 0, return [allOptions[0]]
+ * 4. If dataPeriodCount is 0, return empty array
+ */
+export function pruneCountOptions(allOptions: number[], dataPeriodCount: number): number[] {
+  if (dataPeriodCount === 0) {
+    return []
+  }
+
+  const result: number[] = []
+  let addedN1Bucket = false
+
+  for (const option of allOptions) {
+    if (option <= dataPeriodCount) {
+      result.push(option)
+    } else if (!addedN1Bucket) {
+      result.push(option)
+      addedN1Bucket = true
+    }
+  }
+
+  // If no options qualified but we have data, include the smallest option
+  if (result.length === 0 && allOptions.length > 0) {
+    result.push(allOptions[0])
+  }
+
+  return result
+}

--- a/src/shared/domain/filters/period-count/use-period-count-fallback.test.tsx
+++ b/src/shared/domain/filters/period-count/use-period-count-fallback.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { usePeriodCountFallback } from './use-period-count-fallback'
+
+describe('usePeriodCountFallback', () => {
+  describe('default (all) strategy', () => {
+    it('does not call onFallback when current count is valid', () => {
+      const onFallback = vi.fn()
+      renderHook(() => usePeriodCountFallback(10, [5, 10, 15], onFallback))
+      expect(onFallback).not.toHaveBeenCalled()
+    })
+
+    it('does not call onFallback when current count is all', () => {
+      const onFallback = vi.fn()
+      renderHook(() => usePeriodCountFallback('all', [5, 10, 15], onFallback))
+      expect(onFallback).not.toHaveBeenCalled()
+    })
+
+    it('calls onFallback with all when current count is pruned', () => {
+      const onFallback = vi.fn()
+      renderHook(() => usePeriodCountFallback(20, [5, 10, 15], onFallback))
+      expect(onFallback).toHaveBeenCalledWith('all')
+    })
+
+    it('calls onFallback when options change and current becomes invalid', () => {
+      const onFallback = vi.fn()
+      const { rerender } = renderHook(
+        ({ options }) => usePeriodCountFallback(10, options, onFallback),
+        { initialProps: { options: [5, 10, 15] } }
+      )
+
+      expect(onFallback).not.toHaveBeenCalled()
+
+      rerender({ options: [5, 15] })
+      expect(onFallback).toHaveBeenCalledWith('all')
+    })
+  })
+
+  describe('last-available strategy', () => {
+    it('does not call onFallback when current count is valid', () => {
+      const onFallback = vi.fn()
+      renderHook(() => usePeriodCountFallback(10, [5, 10, 15], onFallback, 'last-available'))
+      expect(onFallback).not.toHaveBeenCalled()
+    })
+
+    it('calls onFallback with last option when current count is pruned', () => {
+      const onFallback = vi.fn()
+      renderHook(() => usePeriodCountFallback(20, [5, 10, 15], onFallback, 'last-available'))
+      expect(onFallback).toHaveBeenCalledWith(15)
+    })
+
+    it('calls onFallback when options change and current becomes invalid', () => {
+      const onFallback = vi.fn()
+      const { rerender } = renderHook(
+        ({ options }) => usePeriodCountFallback(10, options, onFallback, 'last-available'),
+        { initialProps: { options: [5, 10, 15] } }
+      )
+
+      expect(onFallback).not.toHaveBeenCalled()
+
+      rerender({ options: [5, 7] })
+      expect(onFallback).toHaveBeenCalledWith(7)
+    })
+  })
+})

--- a/src/shared/domain/filters/period-count/use-period-count-fallback.ts
+++ b/src/shared/domain/filters/period-count/use-period-count-fallback.ts
@@ -1,0 +1,36 @@
+/**
+ * Period Count Fallback Hook
+ *
+ * Auto-corrects the selected period count when data-aware pruning
+ * removes the currently selected option from the available list.
+ *
+ * Encapsulates the repeated pattern of "watch options, fall back if invalid"
+ * used across source-analysis, coverage-report, and tier-trends.
+ */
+
+import { useEffect } from 'react'
+import type { PeriodCountFilter } from '../types'
+import { fallbackToValidOption, type FallbackStrategy } from './period-count-logic'
+
+/**
+ * Auto-fallback hook for period count selection.
+ *
+ * When available options change and the current selection is no longer valid,
+ * calls onFallback with a valid replacement.
+ *
+ * @param strategy - 'all' (default) falls back to 'all'; 'last-available' falls
+ *   back to the highest numeric option (for number-only consumers like tier-trends).
+ */
+export function usePeriodCountFallback(
+  currentCount: PeriodCountFilter,
+  availableOptions: number[],
+  onFallback: (count: PeriodCountFilter) => void,
+  strategy: FallbackStrategy = 'all'
+): void {
+  useEffect(() => {
+    const validCount = fallbackToValidOption(currentCount, availableOptions, strategy)
+    if (validCount !== currentCount) {
+      onFallback(validCount)
+    }
+  }, [availableOptions]) // intentionally omit currentCount to avoid re-triggering on every change
+}

--- a/src/shared/domain/filters/period-count/use-period-count-options.test.tsx
+++ b/src/shared/domain/filters/period-count/use-period-count-options.test.tsx
@@ -1,8 +1,23 @@
 import { describe, it, expect } from 'vitest'
 import { renderHook } from '@testing-library/react'
+import type { ParsedGameRun } from '@/shared/types/game-run.types'
 import { Duration } from '../types'
 import type { PeriodCountOverrides } from './period-count-logic'
 import { usePeriodCountOptions } from './use-period-count-options'
+
+function mockRun(date: Date): ParsedGameRun {
+  return {
+    id: `run-${date.getTime()}`,
+    timestamp: date,
+    tier: 14,
+    wave: 100,
+    coinsEarned: 1000,
+    cellsEarned: 100,
+    realTime: 3600,
+    runType: 'farm',
+    fields: {}
+  } as ParsedGameRun
+}
 
 describe('usePeriodCountOptions', () => {
   it('should return correct options for PER_RUN', () => {
@@ -119,6 +134,57 @@ describe('usePeriodCountOptions', () => {
       expect(result.current.adjustForDuration(14)).toBe(7)
       // 5 is valid
       expect(result.current.adjustForDuration(5)).toBe(5)
+    })
+  })
+
+  describe('with runs (data-aware pruning)', () => {
+    it('should prune options based on data coverage', () => {
+      // 9 distinct weeks of data
+      const runs: ParsedGameRun[] = []
+      for (let i = 0; i < 9; i++) {
+        const date = new Date('2024-01-01')
+        date.setDate(date.getDate() + i * 7)
+        runs.push(mockRun(date))
+      }
+
+      const { result } = renderHook(() =>
+        usePeriodCountOptions(Duration.WEEKLY, undefined, runs)
+      )
+
+      // Weekly options [5,10,15,20,25,30], 9 weeks -> [5, 10]
+      expect(result.current.options).toEqual([5, 10])
+    })
+
+    it('should return full options when runs not provided', () => {
+      const { result } = renderHook(() =>
+        usePeriodCountOptions(Duration.WEEKLY)
+      )
+
+      expect(result.current.options).toEqual([5, 10, 15, 20, 25, 30])
+    })
+
+    it('should provide ensureValidOption helper', () => {
+      // 4 months of data
+      const runs = [
+        mockRun(new Date('2024-01-15')),
+        mockRun(new Date('2024-02-15')),
+        mockRun(new Date('2024-03-15')),
+        mockRun(new Date('2024-04-15')),
+      ]
+
+      const { result } = renderHook(() =>
+        usePeriodCountOptions(Duration.MONTHLY, undefined, runs)
+      )
+
+      // Monthly options [3,6,9,12], 4 months -> [3, 6]
+      expect(result.current.options).toEqual([3, 6])
+
+      // 3 is valid
+      expect(result.current.ensureValidOption(3)).toBe(3)
+      // 9 is pruned, falls back to 'all'
+      expect(result.current.ensureValidOption(9)).toBe('all')
+      // 'all' stays 'all'
+      expect(result.current.ensureValidOption('all')).toBe('all')
     })
   })
 })

--- a/src/shared/domain/filters/period-count/use-period-count-options.ts
+++ b/src/shared/domain/filters/period-count/use-period-count-options.ts
@@ -2,19 +2,24 @@
  * usePeriodCountOptions Hook
  *
  * React hook for generating period count options based on duration.
+ * Supports optional data-aware pruning when runs are provided.
  *
  * Architecture decisions for this module: see DECISIONS.md in this directory
  */
 
 import { useMemo } from 'react'
+import type { ParsedGameRun } from '@/shared/types/game-run.types'
 import { Duration } from '../types'
 import type { PeriodCountOverrides } from './period-count-logic'
 import {
   getPeriodCountOptions,
+  getDataAwarePeriodCountOptions,
   getDefaultPeriodCount,
   getPeriodCountLabel,
-  adjustPeriodCountForDuration
+  adjustPeriodCountForDuration,
+  fallbackToValidOption
 } from './period-count-logic'
+import { countDataPeriods } from './count-data-periods'
 
 interface UsePeriodCountOptionsResult {
   /** Available period count options for current duration */
@@ -25,19 +30,30 @@ interface UsePeriodCountOptionsResult {
   label: string
   /** Adjust a period count when duration changes */
   adjustForDuration: (count: number | 'all') => number | 'all'
+  /** Fall back to valid option if current selection was pruned */
+  ensureValidOption: (count: number | 'all') => number | 'all'
 }
 
 /**
- * Hook to get period count options for a given duration
- *
- * @param duration - Current duration selection
- * @returns Object containing options, default, label, and adjustment function
+ * Hook to get period count options for a given duration.
+ * When runs are provided, options are pruned using the N+1 bucket rule.
  */
 export function usePeriodCountOptions(
   duration: Duration,
-  overrides?: PeriodCountOverrides
+  overrides?: PeriodCountOverrides,
+  runs?: ParsedGameRun[]
 ): UsePeriodCountOptionsResult {
-  const options = useMemo(() => getPeriodCountOptions(duration, overrides), [duration, overrides])
+  const dataPeriodCount = useMemo(
+    () => (runs ? countDataPeriods(runs, duration) : null),
+    [runs, duration]
+  )
+
+  const options = useMemo(() => {
+    if (dataPeriodCount !== null) {
+      return getDataAwarePeriodCountOptions(duration, dataPeriodCount, overrides)
+    }
+    return getPeriodCountOptions(duration, overrides)
+  }, [duration, overrides, dataPeriodCount])
 
   const defaultCount = useMemo(() => getDefaultPeriodCount(duration, overrides), [duration, overrides])
 
@@ -48,5 +64,10 @@ export function usePeriodCountOptions(
     [duration, overrides]
   )
 
-  return { options, defaultCount, label, adjustForDuration }
+  const ensureValidOption = useMemo(
+    () => (count: number | 'all') => fallbackToValidOption(count, options),
+    [options]
+  )
+
+  return { options, defaultCount, label, adjustForDuration, ensureValidOption }
 }


### PR DESCRIPTION
Period count selectors now prune their options based on actual data coverage using an N+1 bucket rule—options that would produce empty visualizations are hidden. Duration availability is also tightened to require meaningful data spans (e.g., weekly needs >7 days, monthly needs different calendar months).

## Summary

- **Data-aware filter pruning**: Period count selectors now hide options that exceed the user's actual data coverage using an N+1 bucket rule (e.g., if you have 9 weeks of data, weekly options show [5, 10] instead of [5, 10, 15, 20, 25, 30])
- **Tighter duration availability**: Duration options now require meaningful data spans — weekly requires >7 days, monthly requires different calendar months, yearly requires different calendar years. Daily is always shown when runs exist.
- **Auto-fallback on pruning**: When data-aware pruning removes the currently selected period count, a new `usePeriodCountFallback` hook automatically corrects the selection (to "all" or "last-available" depending on the consumer)
- **Shared data-span utilities**: Extracted `calculateDataSpan()` and `countDataPeriods()` as reusable pure functions, eliminating duplicated date-range logic across duration filtering and time-series availability
- **Consolidated time-series logic**: `getAvailableTimePeriods()` now delegates to the shared `getAvailableDurations()` instead of maintaining its own duplicate implementation

### New shared modules
| Module | Purpose |
|--------|---------|
| `data-span.ts` | Calculate temporal span (earliest/latest, day span, cross-month/year flags) |
| `count-data-periods.ts` | Count distinct periods for a given duration type |
| `prune-period-options.ts` | N+1 bucket pruning algorithm |
| `use-period-count-fallback.ts` | Auto-correct hook for stale period selections |

### Features updated
- Time Series (interval selector)
- Tier Trends
- Coverage Report
- Source Analysis